### PR TITLE
fix: Harden tenant schema init and seed welcome onboarding cards

### DIFF
--- a/k8s/deploy-pg.sh
+++ b/k8s/deploy-pg.sh
@@ -453,10 +453,12 @@ generate_manifests() {
     # Prefer local configmap-pg.yaml (gitignored secrets); fall back to example template
     # NOTE: INSTANCE_TOKEN_PLACEHOLDER will be replaced later after checking existing ConfigMap
     CONFIGMAP_SRC="$(resolve_manifest configmap-pg.yaml)"
+    # Leave STARTUP_TENANT_ID empty in the generated ConfigMap. Pre-init of one
+    # tenant on a shared multi-tenant Deployment races across replicas and can
+    # pollute public after DROP SCHEMA. Tenants are created on first request.
     sed -e "s/easy-kanban-pg/${NAMESPACE}/g" \
         -e "s/JWT_SECRET_PLACEHOLDER/${JWT_SECRET}/g" \
         -e "s/APP_VERSION_PLACEHOLDER//g" \
-        -e "s/STARTUP_TENANT_ID: \"\"/STARTUP_TENANT_ID: \"${TENANT_ID}\"/g" \
         "${CONFIGMAP_SRC}" > "${TEMP_DIR}/configmap.yaml"
     
     # Generate app deployment (shared for all tenants)
@@ -562,16 +564,19 @@ PY
         fi
     fi
     
-    if [ -z "$CURRENT_STARTUP_TENANT" ]; then
-        echo "   📝 Setting STARTUP_TENANT_ID to '${TENANT_ID}' (first tenant)"
-        kubectl apply -f "${TEMP_DIR}/configmap.yaml"
+    # STARTUP_TENANT_ID: keep empty (or preserve existing empty). Never point the
+    # shared Deployment at the tenant being deployed — that races 3 replicas and
+    # leaves stale dbCache after destroy.
+    if [ -n "$CURRENT_STARTUP_TENANT" ]; then
+        echo "   ℹ️  Clearing STARTUP_TENANT_ID (was '${CURRENT_STARTUP_TENANT}') — tenants init on first request"
+    else
+        echo "   ℹ️  STARTUP_TENANT_ID left empty (tenants init on first request)"
+    fi
+    # Generated manifest already has STARTUP_TENANT_ID: ""
+    kubectl apply -f "${TEMP_DIR}/configmap.yaml"
+    if [ -n "$CURRENT_STARTUP_TENANT" ]; then
         CONFIGMAP_UPDATED=true
     else
-        echo "   ℹ️  STARTUP_TENANT_ID already set to '${CURRENT_STARTUP_TENANT}' (preserving to avoid pod restart)"
-        if [ -n "$CURRENT_STARTUP_TENANT" ]; then
-            sed -i "s/STARTUP_TENANT_ID: \"${TENANT_ID}\"/STARTUP_TENANT_ID: \"${CURRENT_STARTUP_TENANT}\"/g" "${TEMP_DIR}/configmap.yaml"
-        fi
-        kubectl apply -f "${TEMP_DIR}/configmap.yaml"
         CONFIGMAP_UPDATED=false
     fi
 else
@@ -617,7 +622,7 @@ kubectl apply -f "${TEMP_DIR}/app-deployment.yaml"
 if kubectl get deployment easy-kanban -n "${NAMESPACE}" &>/dev/null; then
     echo "   🎯 Application deployment applied (shared for all tenants)"
     if [ "$CONFIGMAP_UPDATED" = "true" ]; then
-        echo "   🔄 ConfigMap updated with STARTUP_TENANT_ID='${TENANT_ID}', waiting for rollout..."
+        echo "   🔄 ConfigMap updated (cleared STARTUP_TENANT_ID), waiting for rollout..."
         kubectl rollout status deployment/easy-kanban -n "${NAMESPACE}" --timeout=120s || echo "   ⚠️  Rollout may still be in progress"
     else
         echo "   ℹ️  Waiting for rollout if spec changed (e.g. new env refs)..."

--- a/server/config/database.js
+++ b/server/config/database.js
@@ -15,6 +15,7 @@ import {
   AGENT_DEFAULT_COLOR
 } from '../constants/agentIdentity.js';
 import { initializeDemoData, installDemoSeedAvatar } from './demoData.js';
+import { seedWelcomeTasks } from './welcomeTasks.js';
 import { wrapQuery } from '../utils/queryLogger.js';
 import { dbExec, dbGet, dbAll, dbRun } from '../utils/dbAsync.js';
 import { getTenantDomain, getManagedSmtpSeedDefaults } from '../utils/tenantDomain.js';
@@ -857,9 +858,16 @@ const initializeDefaultData = async (db, tenantId = null) => {
     const adminId = crypto.randomUUID();
     const adminPasswordHash = bcrypt.hashSync(adminPassword, 10);
     
+    // Demo uses a human persona; licensed/empty tenants keep a generic bootstrap name
+    // (removed after owner invite during admin-portal post-deploy).
+    const isDemo = process.env.DEMO_ENABLED === 'true';
+    const adminFirstName = isDemo ? 'Alex' : 'Admin';
+    const adminLastName = isDemo ? 'Morgan' : 'User';
+    const adminDisplayName = isDemo ? 'Alex Morgan' : 'Admin User';
+
     // Create admin avatar (optional demo photo, else letter SVG)
     let adminAvatarPath = null;
-    if (process.env.DEMO_ENABLED === 'true') {
+    if (isDemo) {
       adminAvatarPath = installDemoSeedAvatar('admin', adminId, tenantId);
     }
     if (!adminAvatarPath) {
@@ -869,7 +877,7 @@ const initializeDefaultData = async (db, tenantId = null) => {
     await wrapQuery(db.prepare(`
       INSERT INTO users (id, email, password_hash, first_name, last_name, avatar_path) 
       VALUES (?, ?, ?, ?, ?, ?)
-    `), 'INSERT').run(adminId, 'admin@kanban.local', adminPasswordHash, 'Alex', 'Morgan', adminAvatarPath);
+    `), 'INSERT').run(adminId, 'admin@kanban.local', adminPasswordHash, adminFirstName, adminLastName, adminAvatarPath);
 
     // Assign admin role to default user
     const adminRoleResult = await wrapQuery(db.prepare('SELECT id FROM roles WHERE name = ?'), 'SELECT').get('admin');
@@ -1119,7 +1127,7 @@ const initializeDefaultData = async (db, tenantId = null) => {
     const adminMemberId = crypto.randomUUID();
     await wrapQuery(db.prepare('INSERT INTO members (id, name, color, user_id) VALUES (?, ?, ?, ?)'), 'INSERT').run(
       adminMemberId, 
-      'Alex Morgan', 
+      adminDisplayName, 
       '#FF6B6B', 
       adminId
     );
@@ -1271,6 +1279,13 @@ const initializeDefaultData = async (db, tenantId = null) => {
         'INSERT'
       ).run('DEMO_RESET_AT', demoResetAt);
       console.log(`✅ DEMO_RESET_AT=${demoResetAt}`);
+    } else {
+      // Licensed / empty tenants: EN + FR welcome cards (demo board already has content)
+      try {
+        await seedWelcomeTasks(db, boardId, defaultColumns);
+      } catch (error) {
+        console.error('❌ Welcome task seed failed (continuing startup):', error);
+      }
     }
   }
 

--- a/server/config/postgresDatabase.js
+++ b/server/config/postgresDatabase.js
@@ -135,7 +135,23 @@ class PostgresDatabase {
 
     if (this.schema !== 'public') {
       const quotedSchema = `"${this.schema}"`;
-      await client.query(`SET search_path TO ${quotedSchema}, public`);
+      // Tenant-only search_path (no public fallback). If the schema is missing,
+      // Postgres would otherwise silently use public and pollute shared tables.
+      try {
+        await client.query(`SET search_path TO ${quotedSchema}`);
+        const check = await client.query(
+          `SELECT 1 FROM information_schema.schemata WHERE schema_name = $1`,
+          [this.schema]
+        );
+        if (!check.rows.length) {
+          throw new Error(
+            `Tenant schema "${this.schema}" does not exist (refusing public fallback)`
+          );
+        }
+      } catch (error) {
+        client.release();
+        throw error;
+      }
     }
 
     return client;
@@ -230,7 +246,7 @@ class PostgresDatabase {
 
         if (this.schema !== 'public') {
           const quotedSchema = `"${this.schema}"`;
-          await client.query(`SET LOCAL search_path TO ${quotedSchema}, public`);
+          await client.query(`SET LOCAL search_path TO ${quotedSchema}`);
         }
         const result = await callback(...args);
         await client.query('COMMIT');
@@ -273,7 +289,7 @@ class PostgresDatabase {
 
       if (this.schema !== 'public') {
         const quotedSchema = `"${this.schema}"`;
-        await client.query(`SET LOCAL search_path TO ${quotedSchema}, public`);
+        await client.query(`SET LOCAL search_path TO ${quotedSchema}`);
       }
 
       const results = [];
@@ -333,6 +349,13 @@ class PostgresDatabase {
     try {
       const quotedSchema = `"${this.schema}"`;
       await adminClient.query(`CREATE SCHEMA IF NOT EXISTS ${quotedSchema}`);
+      const check = await adminClient.query(
+        `SELECT 1 FROM information_schema.schemata WHERE schema_name = $1`,
+        [this.schema]
+      );
+      if (!check.rows.length) {
+        throw new Error(`Failed to create tenant schema "${this.schema}"`);
+      }
       console.log(`✅ Schema '${this.schema}' ready for tenant: ${this.tenantId}`);
     } catch (error) {
       if (error.code !== '42P06') {
@@ -340,6 +363,29 @@ class PostgresDatabase {
       }
     } finally {
       adminClient.release();
+    }
+  }
+
+  /**
+   * True when this adapter's tenant schema (and settings table) exist.
+   * Used to invalidate stale dbCache entries after DROP SCHEMA / destroy.
+   */
+  async tenantSchemaIsReady() {
+    if (this.schema === 'public') {
+      return true;
+    }
+    const client = await this.pool.connect();
+    try {
+      const result = await client.query(
+        `SELECT 1
+         FROM information_schema.tables
+         WHERE table_schema = $1 AND table_name = 'settings'
+         LIMIT 1`,
+        [this.schema]
+      );
+      return result.rows.length > 0;
+    } finally {
+      client.release();
     }
   }
 }

--- a/server/config/welcomeTasks.js
+++ b/server/config/welcomeTasks.js
@@ -1,0 +1,132 @@
+/**
+ * Seed welcome tasks for new non-demo tenants (empty board onboarding).
+ */
+import crypto from 'crypto';
+import { wrapQuery } from '../utils/queryLogger.js';
+import { tasks as taskQueries } from '../utils/sqlManager/index.js';
+
+export const WELCOME_TASK_TITLE_EN = 'Welcome to Agila!';
+export const WELCOME_TASK_TITLE_FR = 'Bienvenue sur Agila !';
+
+/**
+ * Keep these short — cards are a glance surface.
+ * TipTap/HTML; light emphasis only (Configuration guide / Help).
+ */
+export const WELCOME_TASK_DESCRIPTION_EN =
+  '<p>Use the <strong>Configuration guide</strong> to personalize your instance. Reopen it from <strong>Help</strong>.</p>';
+
+export const WELCOME_TASK_DESCRIPTION_FR =
+  '<p>Utilisez le <strong>Guide de configuration</strong> pour personnaliser votre instance. Rouvrez-le depuis <strong>Aide</strong>.</p>';
+
+const SYSTEM_MEMBER_ID = '00000000-0000-0000-0000-000000000001';
+
+function pickColumnId(columns, { titleMatch, fallbackIndex }) {
+  if (!Array.isArray(columns) || columns.length === 0) return null;
+  const byTitle = columns.find((c) => {
+    const t = String(c.title || '').toLowerCase();
+    return titleMatch.some((m) => t === m || t.includes(m));
+  });
+  if (byTitle?.id) return byTitle.id;
+  return columns[fallbackIndex]?.id || columns[0]?.id || null;
+}
+
+/**
+ * @param {object} db
+ * @param {string} boardId
+ * @param {Array<{ id: string, title?: string }>} columns - default columns
+ * @param {{ assigneeMemberId?: string|null }} [options]
+ * @returns {Promise<{ created: number, skipped: number }>}
+ */
+export async function seedWelcomeTasks(db, boardId, columns, options = {}) {
+  const todoColumnId = pickColumnId(columns, {
+    titleMatch: ['to do', 'todo', 'à faire', 'a faire'],
+    fallbackIndex: 0
+  });
+  const inProgressColumnId = pickColumnId(columns, {
+    titleMatch: ['in progress', 'progress', 'en cours'],
+    fallbackIndex: 1
+  });
+
+  if (!boardId || !todoColumnId) {
+    console.warn('⚠️ seedWelcomeTasks: missing board or To Do column — skipped');
+    return { created: 0, skipped: 0 };
+  }
+
+  const assigneeMemberId = options.assigneeMemberId || SYSTEM_MEMBER_ID;
+  const today = new Date().toISOString().split('T')[0];
+  const defs = [
+    {
+      title: WELCOME_TASK_TITLE_EN,
+      description: WELCOME_TASK_DESCRIPTION_EN,
+      ticket: 'TASK-00001',
+      columnId: todoColumnId,
+      position: 0
+    },
+    {
+      title: WELCOME_TASK_TITLE_FR,
+      description: WELCOME_TASK_DESCRIPTION_FR,
+      ticket: 'TASK-00002',
+      // Prefer In Progress so both cards aren't stacked in the first viewport column
+      columnId: inProgressColumnId || todoColumnId,
+      position: 0
+    }
+  ];
+
+  let created = 0;
+  let skipped = 0;
+
+  for (const def of defs) {
+    const existing = await wrapQuery(
+      db.prepare('SELECT id FROM tasks WHERE boardid = ? AND title = ? LIMIT 1'),
+      'SELECT'
+    ).get(boardId, def.title);
+
+    if (existing) {
+      skipped += 1;
+      continue;
+    }
+
+    await taskQueries.createTask(db, {
+      id: crypto.randomUUID(),
+      title: def.title,
+      description: def.description,
+      ticket: def.ticket,
+      memberId: assigneeMemberId,
+      requesterId: assigneeMemberId,
+      startDate: today,
+      effort: 1,
+      priority: 'medium',
+      columnId: def.columnId,
+      boardId,
+      position: def.position
+    });
+    created += 1;
+  }
+
+  if (created > 0) {
+    console.log(`✅ Seeded ${created} welcome task(s) on board ${boardId}`);
+  }
+
+  return { created, skipped };
+}
+
+/**
+ * Reassign existing welcome tasks on the default board to a member (e.g. new owner).
+ * @param {object} db
+ * @param {string} memberId
+ * @returns {Promise<number>} rows updated
+ */
+export async function reassignWelcomeTasksToMember(db, memberId) {
+  if (!memberId) return 0;
+
+  const result = await wrapQuery(
+    db.prepare(`
+      UPDATE tasks
+      SET memberid = ?, requesterid = ?, updated_at = CURRENT_TIMESTAMP
+      WHERE title IN (?, ?)
+    `),
+    'UPDATE'
+  ).run(memberId, memberId, WELCOME_TASK_TITLE_EN, WELCOME_TASK_TITLE_FR);
+
+  return result?.changes || 0;
+}

--- a/server/middleware/tenantRouting.js
+++ b/server/middleware/tenantRouting.js
@@ -113,10 +113,20 @@ const getTenantDatabase = async (tenantId) => {
   // Check cache first
   if (dbCache.has(cacheKey)) {
     const cached = dbCache.get(cacheKey);
-    // Verify database is still open
+    // Verify database is still open AND tenant schema still exists.
+    // SELECT 1 alone is not enough: after destroy (DROP SCHEMA), search_path
+    // used to fall through to public and the cache looked healthy forever.
     try {
       const { wrapQuery } = await import('../utils/queryLogger.js');
       await wrapQuery(cached.db.prepare('SELECT 1'), 'SELECT').get();
+      if (
+        tenantId &&
+        cached.db &&
+        typeof cached.db.tenantSchemaIsReady === 'function' &&
+        !(await cached.db.tenantSchemaIsReady())
+      ) {
+        throw new Error(`tenant schema missing or incomplete for ${tenantId}`);
+      }
       return cached;
     } catch (error) {
       const msg = error?.message || String(error);
@@ -128,7 +138,7 @@ const getTenantDatabase = async (tenantId) => {
         );
         return cached;
       }
-      // Database closed / broken, remove from cache (close old pool to avoid leaks)
+      // Database closed / broken / schema dropped — remove from cache and re-init
       console.warn(`⚠️ Database cache verification failed for tenant ${tenantId}, reinitializing:`, msg);
       try {
         if (cached.db && typeof cached.db.close === 'function') {

--- a/server/routes/adminPortal.js
+++ b/server/routes/adminPortal.js
@@ -13,7 +13,7 @@ import { getTenantId, getRequestDatabase } from '../middleware/tenantRouting.js'
 import { getTenantDomain } from '../utils/tenantDomain.js';
 import { clearSqlDebugSettingsCache } from '../utils/sqlDebugSettingsCache.js';
 // MIGRATED: Import sqlManager modules
-import { users as userQueries, settings as settingsQueries, licenseSettings as licenseSettingsQueries, auth as authQueries, adminUsers as adminUserQueries, helpers } from '../utils/sqlManager/index.js';
+import { users as userQueries, settings as settingsQueries, licenseSettings as licenseSettingsQueries, auth as authQueries, adminUsers as adminUserQueries, helpers, health as healthQueries } from '../utils/sqlManager/index.js';
 import { isSecretSettingKey, SECRET_SETTING_PLACEHOLDER } from '../constants/secretSettings.js';
 import {
   projectSecretForAdminApi,
@@ -163,6 +163,72 @@ router.put('/owner', authenticateAdminPortal, async (req, res) => {
     res.status(500).json({ 
       success: false,
       error: t('errors.failedToSetInstanceOwner') 
+    });
+  }
+});
+
+/**
+ * Ensure EN/FR welcome tasks exist and assign them to the owner member.
+ * Body: { email?: string } — defaults to OWNER setting.
+ */
+router.post('/onboarding/welcome-tasks', authenticateAdminPortal, async (req, res) => {
+  try {
+    const db = getRequestDatabase(req);
+    const { seedWelcomeTasks, reassignWelcomeTasksToMember } = await import('../config/welcomeTasks.js');
+
+    let ownerEmail = (req.body?.email || '').trim().toLowerCase();
+    if (!ownerEmail) {
+      ownerEmail = String((await helpers.getSetting(db, 'OWNER')) || '').trim().toLowerCase();
+    }
+
+    let assigneeMemberId = null;
+    if (ownerEmail) {
+      const ownerUser = await userQueries.getUserByEmail(db, ownerEmail);
+      if (ownerUser) {
+        const ownerMember = await userQueries.getMemberByUserId(db, ownerUser.id);
+        assigneeMemberId = ownerMember?.id || null;
+      }
+    }
+
+    const board = await wrapQuery(
+      db.prepare('SELECT id FROM boards ORDER BY position ASC, created_at ASC LIMIT 1'),
+      'SELECT'
+    ).get();
+    if (!board) {
+      return res.status(404).json({
+        success: false,
+        error: 'No board found'
+      });
+    }
+
+    const columns = await wrapQuery(
+      db.prepare('SELECT id, title, position FROM columns WHERE boardid = ? ORDER BY position ASC'),
+      'SELECT'
+    ).all(board.id);
+
+    const seedResult = await seedWelcomeTasks(db, board.id, columns, {
+      assigneeMemberId: assigneeMemberId || undefined
+    });
+
+    let reassigned = 0;
+    if (assigneeMemberId) {
+      reassigned = await reassignWelcomeTasksToMember(db, assigneeMemberId);
+    }
+
+    res.json({
+      success: true,
+      data: {
+        ...seedResult,
+        reassigned,
+        assigneeMemberId,
+        ownerEmail: ownerEmail || null
+      }
+    });
+  } catch (error) {
+    console.error('Error seeding welcome tasks:', error);
+    res.status(500).json({
+      success: false,
+      error: 'Failed to seed welcome tasks'
     });
   }
 });
@@ -690,11 +756,13 @@ router.put('/users/:userId', authenticateAdminPortal, async (req, res) => {
   }
 });
 
-// Delete user
+// Delete user (reassign tasks to System first — same as /api/users delete)
 router.delete('/users/:userId', authenticateAdminPortal, async (req, res) => {
   try {
     const db = getRequestDatabase(req);
     const { userId } = req.params;
+    const SYSTEM_USER_ID = '00000000-0000-0000-0000-000000000000';
+    const SYSTEM_MEMBER_ID = '00000000-0000-0000-0000-000000000001';
 
     const t = await getTranslator(db);
 
@@ -707,6 +775,21 @@ router.delete('/users/:userId', authenticateAdminPortal, async (req, res) => {
     }
 
     const userMember = await userQueries.getMemberByUserId(db, userId);
+
+    const existingSystemMember = await userQueries.getMemberById(db, SYSTEM_MEMBER_ID);
+    if (!existingSystemMember) {
+      await adminUserQueries.createSystemMember(db, SYSTEM_MEMBER_ID, SYSTEM_USER_ID);
+    }
+
+    await adminUserQueries.deleteUserActivity(db, userId);
+    await userQueries.deleteUserRoles(db, userId);
+    await adminUserQueries.deleteUserInvitations(db, userId);
+
+    if (userMember) {
+      await adminUserQueries.reassignTasksToSystemMember(db, SYSTEM_MEMBER_ID, userMember.id);
+      await adminUserQueries.reassignTaskRequestersToSystemMember(db, SYSTEM_MEMBER_ID, userMember.id);
+      await adminUserQueries.deleteMemberByUserId(db, userId);
+    }
 
     await adminUserQueries.deleteUser(db, userId);
 
@@ -768,11 +851,9 @@ router.delete('/users/:userId', authenticateAdminPortal, async (req, res) => {
 router.get('/health', authenticateAdminPortal, async (req, res) => {
   try {
     const db = getRequestDatabase(req);
-    // Check database connection
-    // MIGRATED: Simple health check - use a simple query
-    // For health check, we can just try to get a setting or use a simple query
-    const dbCheck = await helpers.getSetting(db, 'APP_URL');
-    
+    // Real connectivity check — do not infer from APP_URL (often unset on new tenants)
+    const dbCheck = await healthQueries.checkDatabaseConnection(db);
+
     res.json({
       success: true,
       status: 'healthy',


### PR DESCRIPTION
## Summary
- Prevent tenant schema init from falling through to `public` after destroy / missing schema; invalidate stale dbCache when settings table is gone
- Stop setting `STARTUP_TENANT_ID` on shared multi-tenant deploys
- Seed non-demo tenants as Admin User with slim EN/FR welcome cards; fix admin-portal health to use a real DB ping; harden admin-portal user delete

## Test plan
- [ ] Deploy a new tenant and confirm `tenant_*` schema has tables (not just `public` pollution)
- [ ] Destroy + redeploy same name: settings/SMTP succeed without stale-cache 500s
- [ ] Non-demo board shows EN welcome in To Do and FR in In Progress
- [ ] Inspect health shows Database connected without relying on APP_URL


Made with [Cursor](https://cursor.com)