### PR TITLE
Purge managed S3 on destroy + owner setup guide polish

### DIFF
--- a/k8s/destroy-instance-pg.sh
+++ b/k8s/destroy-instance-pg.sh
@@ -12,6 +12,10 @@
 #   - Its own ingress rule (easy-kanban-ingress-${INSTANCE_NAME})
 #   - Its own PostgreSQL schema (tenant_${INSTANCE_NAME})
 #   - Its own tenant data in NFS subdirectories (attachments, avatars)
+#
+# Managed S3 objects (STORAGE_MANAGED=true, prefix tenants/{name}/) are purged by the
+# admin portal BEFORE this script runs (POST /api/admin-portal/storage/purge-managed).
+# This script does not talk to S3.
 
 set -e
 

--- a/server/routes/adminPortal.js
+++ b/server/routes/adminPortal.js
@@ -21,7 +21,7 @@ import {
 } from '../utils/settingsSecrets.js';
 import { deleteAvatarFileIfUnused } from '../utils/avatarCleanup.js';
 import { getRequestStoragePaths } from '../services/storage/index.js';
-import { getObject, filenameFromPublicUrl } from '../services/storage/objectStorage.js';
+import { getObject, filenameFromPublicUrl, purgeManagedTenantObjects } from '../services/storage/objectStorage.js';
 import path from 'path';
 
 const router = express.Router();
@@ -163,6 +163,29 @@ router.put('/owner', authenticateAdminPortal, async (req, res) => {
     res.status(500).json({ 
       success: false,
       error: t('errors.failedToSetInstanceOwner') 
+    });
+  }
+});
+
+/**
+ * Permanently delete all objects under this tenant's managed S3 prefix.
+ * Used by the admin portal before DROP SCHEMA on instance destroy.
+ * Skips when STORAGE_MANAGED is not true (custom buckets are left alone).
+ */
+router.post('/storage/purge-managed', authenticateAdminPortal, async (req, res) => {
+  try {
+    const db = getRequestDatabase(req);
+    const tenantId = getTenantId(req) || req.tenantId || null;
+    const result = await purgeManagedTenantObjects(db, { tenantId });
+    res.json({
+      success: true,
+      ...result
+    });
+  } catch (error) {
+    console.error('Error purging managed tenant storage:', error);
+    res.status(500).json({
+      success: false,
+      error: error.message || 'Failed to purge managed storage'
     });
   }
 });

--- a/server/services/storage/index.js
+++ b/server/services/storage/index.js
@@ -19,6 +19,7 @@ export {
   putObject,
   getObject,
   deleteObject,
+  purgeManagedTenantObjects,
   testS3Connection,
   migrateStorageObjects,
   startStorageMigration,

--- a/server/services/storage/objectStorage.js
+++ b/server/services/storage/objectStorage.js
@@ -9,7 +9,8 @@ import {
   buildObjectKey,
   validateS3Config,
   storageConfigFromOverrides,
-  filenameFromPublicUrl
+  filenameFromPublicUrl,
+  normalizeKeyPrefix
 } from './storageConfig.js';
 import { explainS3TestError } from './s3ErrorExplain.js';
 import { settings as settingsQueries } from '../../utils/sqlManager/index.js';
@@ -199,6 +200,73 @@ export async function deleteObject(db, storagePaths, category, filename) {
       console.warn('S3 delete failed:', err.message);
     }
   }
+}
+
+/**
+ * True when a key prefix is scoped to a specific tenant (safety guard for bulk delete).
+ * @param {string} prefix
+ * @param {string} tenantId
+ */
+function prefixBelongsToTenant(prefix, tenantId) {
+  const id = String(tenantId || '').trim();
+  if (!id) return false;
+  const p = normalizeKeyPrefix(prefix);
+  if (!p) return false;
+  return (
+    p === normalizeKeyPrefix(`tenants/${id}`) ||
+    p.includes(`/${id}/`) ||
+    p.startsWith(`${id}/`)
+  );
+}
+
+/**
+ * Permanently delete all objects under the tenant's S3_KEY_PREFIX when STORAGE_MANAGED=true.
+ * No-op (skipped) for custom / unmanaged storage so we never touch a customer bucket from destroy.
+ *
+ * @param {*} db
+ * @param {{ tenantId?: string | null }} [options]
+ * @returns {Promise<{
+ *   skipped?: boolean,
+ *   reason?: string,
+ *   deleted?: number,
+ *   prefix?: string,
+ *   bucket?: string
+ * }>}
+ */
+export async function purgeManagedTenantObjects(db, options = {}) {
+  const config = await loadStorageConfig(db);
+  if (!config.managed) {
+    return { skipped: true, reason: 'STORAGE_MANAGED is not true' };
+  }
+
+  const validation = validateS3Config(config);
+  if (!validation.ok) {
+    return { skipped: true, reason: validation.error || 'Invalid S3 configuration' };
+  }
+
+  const prefix = normalizeKeyPrefix(config.keyPrefix);
+  if (!prefix) {
+    throw new Error('Refusing managed S3 purge: empty S3_KEY_PREFIX');
+  }
+
+  const tenantId = options.tenantId != null ? String(options.tenantId).trim() : '';
+  if (tenantId && !prefixBelongsToTenant(prefix, tenantId)) {
+    throw new Error(
+      `Refusing managed S3 purge: prefix "${prefix}" is not scoped to tenant "${tenantId}"`
+    );
+  }
+
+  const { createS3Client, s3DeleteByPrefix } = await s3();
+  const client = await createS3Client(config);
+  const result = await s3DeleteByPrefix(client, config, prefix);
+  console.log(
+    `🗑️ Purged ${result.deleted} managed S3 object(s) under s3://${config.bucket}/${result.prefix}`
+  );
+  return {
+    deleted: result.deleted,
+    prefix: result.prefix,
+    bucket: config.bucket
+  };
 }
 
 const EMPTY_S3_BASE = Object.freeze({

--- a/server/services/storage/s3Client.js
+++ b/server/services/storage/s3Client.js
@@ -129,6 +129,62 @@ export async function s3Delete(client, config, key) {
 }
 
 /**
+ * Delete every object under a key prefix (paginated ListObjectsV2 + DeleteObjects).
+ * Refuses an empty prefix so we never wipe an entire bucket by accident.
+ *
+ * @param {any} client
+ * @param {import('./storageConfig.js').StorageConfig} config
+ * @param {string} prefix
+ * @returns {Promise<{ deleted: number, prefix: string }>}
+ */
+export async function s3DeleteByPrefix(client, config, prefix) {
+  const { ListObjectsV2Command, DeleteObjectsCommand } = await loadAwsS3();
+  let normalized = String(prefix || '').trim().replace(/^\/+/, '');
+  if (normalized && !normalized.endsWith('/')) normalized += '/';
+  if (!normalized) {
+    throw new Error('Refusing S3 prefix delete: empty key prefix');
+  }
+
+  let deleted = 0;
+  let continuationToken;
+  do {
+    const listed = await client.send(
+      new ListObjectsV2Command({
+        Bucket: config.bucket,
+        Prefix: normalized,
+        ContinuationToken: continuationToken
+      })
+    );
+    const contents = listed.Contents || [];
+    for (let i = 0; i < contents.length; i += 1000) {
+      const chunk = contents.slice(i, i + 1000).filter((o) => o?.Key);
+      if (chunk.length === 0) continue;
+      const out = await client.send(
+        new DeleteObjectsCommand({
+          Bucket: config.bucket,
+          Delete: {
+            Objects: chunk.map((o) => ({ Key: o.Key })),
+            Quiet: true
+          }
+        })
+      );
+      const errors = out.Errors || [];
+      if (errors.length > 0) {
+        const sample = errors
+          .slice(0, 3)
+          .map((e) => `${e.Key}: ${e.Code || e.Message}`)
+          .join('; ');
+        throw new Error(`S3 prefix delete failed for ${errors.length} object(s): ${sample}`);
+      }
+      deleted += chunk.length;
+    }
+    continuationToken = listed.IsTruncated ? listed.NextContinuationToken : undefined;
+  } while (continuationToken);
+
+  return { deleted, prefix: normalized };
+}
+
+/**
  * @param {any} client
  * @param {import('./storageConfig.js').StorageConfig} config
  * @param {string} key

--- a/src/components/ownerSetup/OwnerSetupChecklist.tsx
+++ b/src/components/ownerSetup/OwnerSetupChecklist.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import {
   Check,
   ChevronDown,
@@ -32,6 +32,32 @@ const EXPANDED_WIDTH = 384; // ~24rem
 const MINIMIZED_WIDTH = 320; // ~max-w-sm
 const MARGIN = 16;
 
+/** Same chip look as Admin → Mail Server “Switch to Custom SMTP” (non-interactive in the guide). */
+const SwitchToCustomSmtpChip: React.FC<{ className?: string }> = ({ className = '' }) => {
+  const { t } = useTranslation('admin');
+  return (
+    <span
+      className={`inline-flex align-middle text-xs bg-blue-100 dark:bg-blue-800 text-blue-800 dark:text-blue-200 px-2.5 py-1 rounded-md select-none whitespace-nowrap ${className}`}
+      role="note"
+    >
+      {t('mail.switchToCustomSMTP')}
+    </span>
+  );
+};
+
+const MailMultiTenantDescription: React.FC<{ textClassName: string }> = ({ textClassName }) => (
+  <p className={textClassName}>
+    <Trans
+      i18nKey="ownerSetup.steps.mail.descriptionMultiTenant"
+      ns="common"
+      components={{
+        platform: <strong className="font-semibold text-gray-800 dark:text-gray-100" />,
+        smtpButton: <SwitchToCustomSmtpChip className="mx-0.5 relative -top-px" />,
+      }}
+    />
+  </p>
+);
+
 const OwnerSetupChecklist: React.FC = () => {
   const { t } = useTranslation('common');
   const {
@@ -42,7 +68,6 @@ const OwnerSetupChecklist: React.FC = () => {
     dismissChecklist,
     minimizeChecklist,
     expandChecklist,
-    setActiveStep,
     markStep,
     goToStep,
     guideCurrentStep,
@@ -368,8 +393,8 @@ const OwnerSetupChecklist: React.FC = () => {
   const handleReopenStep = (stepId: OwnerSetupStepId) => {
     setStepFocused(false);
     closeGuide();
-    setActiveStep(stepId);
     markStep(stepId, 'todo');
+    goToStep(stepId);
   };
 
   const handleSelectStep = (stepId: OwnerSetupStepId) => {
@@ -378,7 +403,8 @@ const OwnerSetupChecklist: React.FC = () => {
     setPreferStepList(kind === 'task');
     setStepFocused(false);
     closeGuide();
-    setActiveStep(stepId);
+    // Navigate to the step's Admin / Kanban target by default (same as Go there).
+    goToStep(stepId);
   };
 
   const isGuiding = guidingStepId === activeId;
@@ -478,9 +504,13 @@ const OwnerSetupChecklist: React.FC = () => {
                     {t('ownerSetup.optional')}
                   </span>
                 )}
-                <p className="text-sm text-gray-600 dark:text-gray-300">
-                  {t(stepDescriptionKey)}
-                </p>
+                {activeId === 'mail' && guideFieldContext.multiTenant ? (
+                  <MailMultiTenantDescription textClassName="text-sm text-gray-600 dark:text-gray-300" />
+                ) : (
+                  <p className="text-sm text-gray-600 dark:text-gray-300">
+                    {t(stepDescriptionKey)}
+                  </p>
+                )}
                 {isGuiding && (
                   <div className="rounded-md bg-blue-50 dark:bg-blue-900/30 border border-blue-200 dark:border-blue-800 px-3 py-2 space-y-2">
                     <p className="text-xs font-medium text-blue-800 dark:text-blue-200">
@@ -607,16 +637,21 @@ const OwnerSetupChecklist: React.FC = () => {
                           </span>
                         )}
                       </div>
-                      {isActive && (
-                        <p className="mt-0.5 text-xs text-gray-600 dark:text-gray-300">
-                          {t(
-                            (step.id === 'mail' || step.id === 'storage') &&
-                              guideFieldContext.multiTenant
-                              ? `ownerSetup.steps.${step.id}.descriptionMultiTenant`
-                              : `ownerSetup.steps.${step.id}.description`
-                          )}
-                        </p>
-                      )}
+                      {isActive &&
+                        (step.id === 'mail' && guideFieldContext.multiTenant ? (
+                          <div className="mt-0.5">
+                            <MailMultiTenantDescription textClassName="text-xs text-gray-600 dark:text-gray-300 leading-relaxed" />
+                          </div>
+                        ) : (
+                          <p className="mt-0.5 text-xs text-gray-600 dark:text-gray-300">
+                            {t(
+                              (step.id === 'mail' || step.id === 'storage') &&
+                                guideFieldContext.multiTenant
+                                ? `ownerSetup.steps.${step.id}.descriptionMultiTenant`
+                                : `ownerSetup.steps.${step.id}.description`
+                            )}
+                          </p>
+                        ))}
                     </div>
                     {isActive ? (
                       <ChevronDown size={14} className="text-gray-400 mt-1 flex-shrink-0" />

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1522,7 +1522,7 @@
       },
       "siteIdentity": {
         "title": "Site name & URL",
-        "description": "Set your site name, logo, and public URL under Admin → Site Settings so emails and the header look correct. Using \"/\" for the URL is usually fine.",
+        "description": "Set your site name, logo, and public URL so emails and the header look correct. Using \"/\" for the URL is usually fine.",
         "guide": "Update these Site Settings fields.",
         "fields": {
           "SITE_NAME": "Enter your site name — it appears in the header and emails.",
@@ -1532,7 +1532,7 @@
       },
       "language": {
         "title": "Default language",
-        "description": "Choose the default language (EN/FR) in Admin → App Settings for new boards and system messages.",
+        "description": "Choose the default language (EN/FR) for new boards and system messages.",
         "guide": "Choose the default application language.",
         "fields": {
           "APP_LANGUAGE": "Default language for this instance (guest screens, invites, and emails when a user has no preferred language)."
@@ -1540,11 +1540,11 @@
       },
       "mail": {
         "title": "Mail server",
-        "description": "Under Admin → System Settings → Mail Server, configure SMTP and send a test email so invitations and password resets work. Skip if you only create users locally.",
-        "descriptionMultiTenant": "Email is managed by the platform. Under Admin → System Settings → Mail Server, switch to Custom SMTP first if you want your own mail server, then configure SMTP and send a test email so invitations and password resets work. Skip if you only create users locally.",
+        "description": "Configure SMTP and send a test email so invitations and password resets work. Skip this step if you don't need outbound email.",
+        "descriptionMultiTenant": "Email is managed <platform>by the platform</platform>. Click <smtpButton/> if you want to use your own mail server. Skip this step if you don't need to use your own mail server.",
         "guide": "Fill SMTP settings, test, then enable mail.",
         "fields": {
-          "switchToCustomSmtp": "First click Switch to Custom SMTP (confirm twice) so you can edit your own mail server settings.",
+          "switchToCustomSmtp": "Click Switch to Custom SMTP (confirm twice) to unlock your own SMTP settings.",
           "SMTP_HOST": "Enter your SMTP host (e.g. smtp.gmail.com).",
           "SMTP_PORT": "Enter the SMTP port (often 587 for TLS).",
           "SMTP_USERNAME": "Enter the SMTP username / account.",
@@ -1556,7 +1556,7 @@
       },
       "users": {
         "title": "Invite your team",
-        "description": "Create or invite teammates in Admin → Users. Promote another admin if you want backup.",
+        "description": "Create or invite teammates. Promote another admin if you want backup.",
         "guide": "Add or invite users here — either path works.",
         "fields": {
           "addUser": "Click Add User to create or invite a teammate.",
@@ -1580,16 +1580,16 @@
       },
       "tagsPriorities": {
         "title": "Tags & priorities",
-        "description": "Add tags your team will use on cards. Optionally review priority levels under Admin → Priorities.",
+        "description": "Add tags your team will use on cards. Optionally review priority levels.",
         "guide": "Set up tags on this screen.",
         "fields": {
           "addTag": "Add tags your team will use on cards.",
-          "prioritiesHint": "Optional: open Admin → Priorities anytime to review priority levels and colors."
+          "prioritiesHint": "Optional: open Priorities anytime to review priority levels and colors."
         }
       },
       "sprints": {
         "title": "Sprints",
-        "description": "Optional: under Admin → Project Settings → Sprint Settings, create planning periods if you want sprint filters and burndown.",
+        "description": "Optional: create planning periods if you want sprint filters and burndown.",
         "guide": "Create a sprint when you are ready.",
         "fields": {
           "createSprint": "Click Create Sprint to add a planning period."
@@ -1597,7 +1597,7 @@
       },
       "sso": {
         "title": "Google SSO",
-        "description": "Optional: under Admin → System Settings → SSO, enable Google OAuth so the team can sign in with Google.",
+        "description": "Optional: enable Google OAuth so the team can sign in with Google.",
         "guide": "Enter Google OAuth credentials.",
         "fields": {
           "GOOGLE_CLIENT_ID": "Paste your Google OAuth Client ID.",
@@ -1607,8 +1607,8 @@
       },
       "storage": {
         "title": "File storage (S3)",
-        "description": "Optional: under Admin → System Settings → Storage, use Disk or configure your own S3-compatible bucket for uploads and attachments. Test the connection before activating S3.",
-        "descriptionMultiTenant": "File storage is managed by the platform. Under Admin → System Settings → Storage, choose Use your own S3 bucket first if you want your own bucket, then enter credentials, test the connection, and finish the migration. Skip if platform storage is fine.",
+        "description": "Optional: use Disk or configure your own S3-compatible bucket for uploads and attachments. Test the connection before activating S3.",
+        "descriptionMultiTenant": "File storage is managed by the platform. Choose Use your own S3 bucket first if you want your own bucket, then enter credentials, test the connection, and finish the migration. Skip if platform storage is fine.",
         "guide": "Configure storage or move to your own S3 bucket.",
         "fields": {
           "switchToCustomStorage": "First click Use your own S3 bucket (confirm) so you can enter your own bucket settings.",
@@ -1630,7 +1630,7 @@
       },
       "reporting": {
         "title": "Reports",
-        "description": "Optional: under Admin → Project Settings → Reporting, enable reports and gamification if you want analytics for the team.",
+        "description": "Optional: enable reports and gamification if you want analytics for the team.",
         "guide": "Enable reporting if you want it.",
         "fields": {
           "REPORTS_ENABLED": "Toggle Reports on to give the team analytics and burndown."

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -1522,7 +1522,7 @@
       },
       "siteIdentity": {
         "title": "Nom du site et URL",
-        "description": "Définissez le nom du site, le logo et l'URL publique dans Admin → Paramètres du site pour les e-mails et l'en-tête. Utiliser « / » pour l'URL convient généralement.",
+        "description": "Définissez le nom du site, le logo et l'URL publique pour les e-mails et l'en-tête. Utiliser « / » pour l'URL convient généralement.",
         "guide": "Mettez à jour ces champs des Paramètres du site.",
         "fields": {
           "SITE_NAME": "Saisissez le nom du site — il apparaît dans l'en-tête et les e-mails.",
@@ -1532,7 +1532,7 @@
       },
       "language": {
         "title": "Langue par défaut",
-        "description": "Choisissez la langue par défaut (EN/FR) dans Admin → Paramètres de l'application pour les nouveaux tableaux et messages système.",
+        "description": "Choisissez la langue par défaut (EN/FR) pour les nouveaux tableaux et messages système.",
         "guide": "Choisissez la langue par défaut de l'application.",
         "fields": {
           "APP_LANGUAGE": "Langue par défaut de l'instance (écrans invités, invitations et emails lorsqu'un utilisateur n'a pas de langue préférée)."
@@ -1540,11 +1540,11 @@
       },
       "mail": {
         "title": "Serveur de messagerie",
-        "description": "Sous Admin → Paramètres système → Serveur de messagerie, configurez SMTP et envoyez un e-mail de test pour les invitations et réinitialisations. Passez si vous créez les utilisateurs uniquement en local.",
-        "descriptionMultiTenant": "L'e-mail est géré par la plateforme. Sous Admin → Paramètres système → Serveur de messagerie, passez d'abord à SMTP personnalisé si vous voulez votre propre serveur, puis configurez SMTP et envoyez un e-mail de test pour les invitations et réinitialisations. Passez si vous créez les utilisateurs uniquement en local.",
+        "description": "Configurez SMTP et envoyez un e-mail de test pour les invitations et réinitialisations. Passez cette étape si vous n'avez pas besoin d'e-mails sortants.",
+        "descriptionMultiTenant": "L'e-mail est géré <platform>par la plateforme</platform>. Cliquez sur <smtpButton/> si vous voulez utiliser votre propre serveur de messagerie. Passez cette étape si vous n'avez pas besoin de votre propre serveur.",
         "guide": "Remplissez SMTP, testez, puis activez le courrier.",
         "fields": {
-          "switchToCustomSmtp": "Cliquez d'abord sur Passer à SMTP personnalisé (confirmer deux fois) pour modifier vos propres paramètres de messagerie.",
+          "switchToCustomSmtp": "Cliquez sur Passer à SMTP personnalisé (confirmer deux fois) pour déverrouiller vos paramètres SMTP.",
           "SMTP_HOST": "Saisissez l'hôte SMTP (ex. smtp.gmail.com).",
           "SMTP_PORT": "Saisissez le port SMTP (souvent 587 pour TLS).",
           "SMTP_USERNAME": "Saisissez le nom d'utilisateur / compte SMTP.",
@@ -1556,7 +1556,7 @@
       },
       "users": {
         "title": "Inviter l'équipe",
-        "description": "Créez ou invitez des coéquipiers dans Admin → Utilisateurs. Promouvez un autre admin si vous voulez un relais.",
+        "description": "Créez ou invitez des coéquipiers. Promouvez un autre admin si vous voulez un relais.",
         "guide": "Ajoutez ou invitez des utilisateurs ici — les deux chemins fonctionnent.",
         "fields": {
           "addUser": "Cliquez sur Ajouter un utilisateur pour créer ou inviter un coéquipier.",
@@ -1580,16 +1580,16 @@
       },
       "tagsPriorities": {
         "title": "Étiquettes et priorités",
-        "description": "Ajoutez les étiquettes utilisées sur les cartes. Vous pouvez aussi revoir les priorités sous Admin → Priorités.",
+        "description": "Ajoutez les étiquettes utilisées sur les cartes. Vous pouvez aussi revoir les priorités.",
         "guide": "Configurez les étiquettes sur cet écran.",
         "fields": {
           "addTag": "Ajoutez les étiquettes que l'équipe utilisera sur les cartes.",
-          "prioritiesHint": "Facultatif : ouvrez Admin → Priorités à tout moment pour revoir les niveaux et couleurs."
+          "prioritiesHint": "Facultatif : ouvrez Priorités à tout moment pour revoir les niveaux et couleurs."
         }
       },
       "sprints": {
         "title": "Sprints",
-        "description": "Facultatif : sous Admin → Paramètres du projet → Paramètres du sprint, créez des périodes de planification pour les filtres de sprint et le burndown.",
+        "description": "Facultatif : créez des périodes de planification pour les filtres de sprint et le burndown.",
         "guide": "Créez un sprint quand vous êtes prêt.",
         "fields": {
           "createSprint": "Cliquez sur Créer un sprint pour ajouter une période de planification."
@@ -1597,7 +1597,7 @@
       },
       "sso": {
         "title": "SSO Google",
-        "description": "Facultatif : sous Admin → Paramètres système → Auth. unique, activez Google OAuth pour que l'équipe se connecte avec Google.",
+        "description": "Facultatif : activez Google OAuth pour que l'équipe se connecte avec Google.",
         "guide": "Saisissez les identifiants Google OAuth.",
         "fields": {
           "GOOGLE_CLIENT_ID": "Collez votre Client ID Google OAuth.",
@@ -1607,8 +1607,8 @@
       },
       "storage": {
         "title": "Stockage des fichiers (S3)",
-        "description": "Facultatif : sous Admin → Paramètres système → Stockage, utilisez le disque ou configurez votre propre bucket S3 compatible pour les téléversements. Testez la connexion avant d'activer S3.",
-        "descriptionMultiTenant": "Le stockage des fichiers est géré par la plateforme. Sous Admin → Paramètres système → Stockage, choisissez Utiliser votre propre bucket S3 d'abord si vous voulez votre propre bucket, puis saisissez les identifiants, testez la connexion et terminez la migration. Passez si le stockage de la plateforme convient.",
+        "description": "Facultatif : utilisez le disque ou configurez votre propre bucket S3 compatible pour les téléversements. Testez la connexion avant d'activer S3.",
+        "descriptionMultiTenant": "Le stockage des fichiers est géré par la plateforme. Choisissez Utiliser votre propre bucket S3 d'abord si vous voulez votre propre bucket, puis saisissez les identifiants, testez la connexion et terminez la migration. Passez si le stockage de la plateforme convient.",
         "guide": "Configurez le stockage ou passez à votre propre bucket S3.",
         "fields": {
           "switchToCustomStorage": "Cliquez d'abord sur Utiliser votre propre bucket S3 (confirmer) pour saisir les paramètres de votre bucket.",
@@ -1630,7 +1630,7 @@
       },
       "reporting": {
         "title": "Rapports",
-        "description": "Facultatif : sous Admin → Paramètres du projet → Rapports, activez les rapports et la gamification si vous voulez des analyses d'équipe.",
+        "description": "Facultatif : activez les rapports et la gamification si vous voulez des analyses d'équipe.",
         "guide": "Activez les rapports si vous le souhaitez.",
         "fields": {
           "REPORTS_ENABLED": "Activez Rapports pour offrir analyses et burndown à l'équipe."


### PR DESCRIPTION
## Summary
- Purge platform-managed S3 objects (`STORAGE_MANAGED=true`) via admin-portal before permanent tenant destroy / schema drop
- Improve configuration guide copy (drop Admin breadcrumb paths) and auto-navigate to each step’s Admin/Kanban screen

## Test plan
- [ ] Permanent destroy of a managed-S3 tenant deletes keys under `tenants/{name}/` before schema drop
- [ ] Destroy of custom/unmanaged storage skips S3 purge
- [ ] Purge failure aborts destroy (instance remains)
- [ ] Configuration guide steps open the matching Admin section on select


Made with [Cursor](https://cursor.com)