### PR TITLE
fix: Seed avatars to S3 and disk-to-S3 migrate endpoint

### DIFF
--- a/.cursor/rules/dirty-save-forms.mdc
+++ b/.cursor/rules/dirty-save-forms.mdc
@@ -1,0 +1,23 @@
+---
+description: Dirty-save forms via JSON snapshot (Save disabled until changes)
+globs: "**/*{Settings,Form,Profile,Modal}*.{tsx,ts,jsx,js}"
+alwaysApply: false
+---
+
+# Dirty-save forms
+
+When building editable forms with an explicit Save action, use the JSON snapshot pattern (see also personal skill `dirty-save-forms`):
+
+1. Keep live form state in `settings` (or equivalent).
+2. After load (and after a successful save), store a JSON snapshot: `savedSnapshot = JSON.stringify(mapped)`.
+3. Dirty check:
+
+```ts
+const isDirty = savedSnapshot !== '' && snapshotOf(settings) !== savedSnapshot;
+```
+
+4. Save button: `disabled={saving || !isDirty}`.
+5. Save handler no-ops if `!isDirty || saving`.
+6. On success, refresh the snapshot so the form is clean again.
+
+Any field change via `setField` / `handleToggle` updates `settings` → snapshot differs → Save enables.

--- a/server/config/database.js
+++ b/server/config/database.js
@@ -54,12 +54,15 @@ const generateRandomPassword = (length = 12) => {
 
 // Function to create default letter-based avatars
 // tenantId: optional tenant identifier (for multi-tenant mode)
-function createLetterAvatar(letter, userId, role = 'user', tenantId = null) {
+// db: when provided, respects STORAGE_BACKEND (uploads to S3 when configured)
+async function createLetterAvatar(letter, userId, role = 'user', tenantId = null, db = null) {
   try {
     const colors = {
       admin: '#FF6B6B',
       demo: '#4ECDC4',
-      user: '#6366F1'
+      user: '#6366F1',
+      system: '#1E40AF',
+      agent: '#6366F1'
     };
     
     const backgroundColor = colors[role] || colors.user;
@@ -83,6 +86,24 @@ function createLetterAvatar(letter, userId, role = 'user', tenantId = null) {
     } else {
       // Single-tenant: backward compatible path
       avatarsDir = join(dirname(__dirname), 'avatars');
+    }
+
+    if (db) {
+      try {
+        const { putObject } = await import('../services/storage/index.js');
+        await putObject(
+          db,
+          { avatars: avatarsDir, attachments: null },
+          'avatars',
+          filename,
+          svg,
+          'image/svg+xml'
+        );
+        console.log(`✅ Created default ${role} avatar: ${filename}${tenantId ? ` (tenant: ${tenantId})` : ''} [storage backend]`);
+        return `/avatars/${filename}`;
+      } catch (storageErr) {
+        console.warn(`⚠️ Storage putObject failed for ${role} avatar, falling back to disk:`, storageErr.message);
+      }
     }
     
     // Ensure avatars directory exists
@@ -871,7 +892,7 @@ const initializeDefaultData = async (db, tenantId = null) => {
       adminAvatarPath = installDemoSeedAvatar('admin', adminId, tenantId);
     }
     if (!adminAvatarPath) {
-      adminAvatarPath = createLetterAvatar('A', adminId, 'admin', tenantId);
+      adminAvatarPath = await createLetterAvatar('A', adminId, 'admin', tenantId, db);
     }
     
     await wrapQuery(db.prepare(`
@@ -1138,7 +1159,8 @@ const initializeDefaultData = async (db, tenantId = null) => {
     const systemPasswordHash = bcrypt.hashSync(crypto.randomBytes(32).toString('hex'), 10); // Random unguessable password
     
     // Create system avatar (with tenant-specific path if in multi-tenant mode)
-    const systemAvatarPath = createLetterAvatar('S', systemUserId, 'system', tenantId);
+    // After managed S3 settings above when MANAGED_S3_BUCKET is set — putObject uses STORAGE_BACKEND.
+    const systemAvatarPath = await createLetterAvatar('S', systemUserId, 'system', tenantId, db);
     
     // Check if system user already exists
     const existingSystemUser = await wrapQuery(db.prepare('SELECT id FROM users WHERE id = ?'), 'SELECT').get(systemUserId);
@@ -1171,7 +1193,7 @@ const initializeDefaultData = async (db, tenantId = null) => {
       console.warn('Agent bot avatar install skipped:', e?.message || e);
     }
     if (!agentAvatarPath) {
-      agentAvatarPath = createLetterAvatar('A', AGENT_USER_ID, 'agent', tenantId);
+      agentAvatarPath = await createLetterAvatar('A', AGENT_USER_ID, 'agent', tenantId, db);
     }
     const existingAgentUser = await wrapQuery(db.prepare('SELECT id FROM users WHERE id = ?'), 'SELECT').get(AGENT_USER_ID);
     if (!existingAgentUser) {

--- a/server/routes/adminPortal.js
+++ b/server/routes/adminPortal.js
@@ -191,6 +191,30 @@ router.post('/storage/purge-managed', authenticateAdminPortal, async (req, res) 
 });
 
 /**
+ * Migrate local/NFS staged objects into S3 after managed storage is configured.
+ * Used by agila-admin post-deploy so seed avatars (disk-only at DB init) land in the bucket.
+ */
+router.post('/storage/migrate-disk-to-s3', authenticateAdminPortal, async (req, res) => {
+  try {
+    const db = getRequestDatabase(req);
+    const { startStorageMigration, getRequestStoragePaths } = await import('../services/storage/index.js');
+    const storagePaths = getRequestStoragePaths(req);
+    const deleteSource = req.body?.deleteSource === true;
+    const result = await startStorageMigration(db, storagePaths, 'disk-to-s3', { deleteSource });
+    res.json({
+      success: true,
+      ...result
+    });
+  } catch (error) {
+    console.error('Error starting disk-to-s3 migration:', error);
+    res.status(500).json({
+      success: false,
+      error: error.message || 'Failed to start storage migration'
+    });
+  }
+});
+
+/**
  * Ensure EN/FR welcome tasks exist and assign them to the owner member.
  * Body: { email?: string } — defaults to OWNER setting.
  */

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -69,7 +69,7 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [deleteConfirmation, setDeleteConfirmation] = useState('');
   const [isDeletingAccount, setIsDeletingAccount] = useState(false);
-  const [isInstanceOwner, setIsInstanceOwner] = useState(false);
+  const [isInstanceOwner, setIsInstanceOwner] = useState<boolean | null>(null);
 
   const websiteUrl = String(
     siteSettings?.WEBSITE_URL || contextSystemSettings?.WEBSITE_URL || ''
@@ -109,10 +109,11 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
   // Instance owner cannot self-delete — show customer portal instead of Danger Zone
   useEffect(() => {
     if (!isOpen) {
-      setIsInstanceOwner(false);
+      setIsInstanceOwner(null);
       return;
     }
     let cancelled = false;
+    setIsInstanceOwner(null);
     (async () => {
       try {
         const { data } = await api.get('/auth/is-owner');
@@ -523,21 +524,21 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
             <button
               onClick={handleClose}
               disabled={isSubmitting}
-              className="text-gray-400 hover:text-gray-600 disabled:opacity-50 transition-colors"
+              className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 disabled:opacity-50 transition-colors"
             >
               <X size={24} />
             </button>
           </div>
 
           {/* Tab Navigation */}
-          <div className="border-b border-gray-200 mb-6">
+          <div className="border-b border-gray-200 dark:border-gray-700 mb-6">
             <nav className="-mb-px flex space-x-8">
               <button
                 onClick={() => setActiveTab('profile')}
                 className={`py-2 px-1 border-b-2 font-medium text-sm ${
                   activeTab === 'profile'
-                    ? 'border-blue-500 text-blue-600'
-                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                    ? 'border-blue-500 text-blue-600 dark:text-blue-400'
+                    : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300 dark:hover:border-gray-500'
                 }`}
               >
                 {t('profile.profileSettings')}
@@ -546,8 +547,8 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
                 onClick={() => setActiveTab('app-settings')}
                 className={`py-2 px-1 border-b-2 font-medium text-sm ${
                   activeTab === 'app-settings'
-                    ? 'border-blue-500 text-blue-600'
-                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                    ? 'border-blue-500 text-blue-600 dark:text-blue-400'
+                    : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300 dark:hover:border-gray-500'
                 }`}
               >
                 {t('profile.appSettings')}
@@ -556,8 +557,8 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
                 onClick={() => setActiveTab('notifications')}
                 className={`py-2 px-1 border-b-2 font-medium text-sm ${
                   activeTab === 'notifications'
-                    ? 'border-blue-500 text-blue-600'
-                    : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                    ? 'border-blue-500 text-blue-600 dark:text-blue-400'
+                    : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300 dark:hover:border-gray-500'
                 }`}
               >
                 {t('profile.notifications')}
@@ -567,8 +568,8 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
                   onClick={() => setActiveTab('dev')}
                   className={`py-2 px-1 border-b-2 font-medium text-sm ${
                     activeTab === 'dev'
-                      ? 'border-blue-500 text-blue-600'
-                      : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
+                      ? 'border-blue-500 text-blue-600 dark:text-blue-400'
+                      : 'border-transparent text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:border-gray-300 dark:hover:border-gray-500'
                   }`}
                 >
                   {t('profile.dev')}
@@ -632,14 +633,14 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
                           <Upload className="h-3.5 w-3.5 mr-1.5" />
                           {currentUser?.avatarUrl || previewUrl ? t('profile.changePhoto') : t('profile.uploadPhoto')}
                         </button>
-                        <span className="text-xs text-gray-500">{t('profile.photoFormatHint')}</span>
+                        <span className="text-xs text-gray-500 dark:text-gray-400">{t('profile.photoFormatHint')}</span>
                       </div>
                     )}
                   </div>
                 </div>
 
                 {currentUser?.authProvider !== 'local' && (
-                  <p className="text-xs text-gray-500 -mt-2">
+                  <p className="text-xs text-gray-500 dark:text-gray-400 -mt-2">
                     {t('profile.profilePictureManagedBrief', {
                       provider: currentUser?.authProvider === 'google' ? 'Google' : 'SSO',
                     })}
@@ -661,7 +662,7 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
                     className="w-full px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 resize-y min-h-[7.5rem]"
                     placeholder={t('profile.bioPlaceholder')}
                   />
-                  <div className="mt-1 flex items-center justify-between gap-2 text-xs text-gray-500">
+                  <div className="mt-1 flex items-center justify-between gap-2 text-xs text-gray-500 dark:text-gray-400">
                     <p>{t('profile.bioHint')}</p>
                     <span className="shrink-0 tabular-nums">{bio.trim().length}/280</span>
                   </div>
@@ -669,8 +670,8 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
 
                 {/* Error Display */}
                 {error && (
-                  <div className="bg-red-50 border border-red-200 rounded-md p-3">
-                    <div className="text-sm text-red-600">{error}</div>
+                  <div className="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-md p-3">
+                    <div className="text-sm text-red-600 dark:text-red-300">{error}</div>
                   </div>
                 )}
 
@@ -679,7 +680,7 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
                   <button
                     type="submit"
                     disabled={isSubmitting}
-                    className={`flex-1 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 transition-colors ${
+                    className={`flex-1 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors ${
                       isSubmitting ? 'opacity-50 cursor-not-allowed' : ''
                     }`}
                   >
@@ -689,15 +690,16 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
                     type="button"
                     onClick={handleClose}
                     disabled={isSubmitting}
-                    className="flex-1 px-4 py-2 bg-gray-300 text-gray-700 rounded-md hover:bg-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 transition-colors"
+                    className="flex-1 px-4 py-2 bg-gray-300 dark:bg-gray-600 text-gray-700 dark:text-gray-100 rounded-md hover:bg-gray-400 dark:hover:bg-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors"
                   >
                     {t('buttons.cancel')}
                   </button>
                 </div>
               </form>
 
-              {/* Owner: customer portal. Everyone else: Danger Zone / self-delete. */}
-              {isInstanceOwner ? (
+              {/* Owner: customer portal. Everyone else: Danger Zone / self-delete.
+                  Wait for is-owner check to avoid flashing Danger Zone for owners. */}
+              {isInstanceOwner === null ? null : isInstanceOwner ? (
               <div className="mt-8 pt-6 border-t border-blue-200 dark:border-blue-800">
                 <div className="rounded-lg border border-blue-200 dark:border-blue-700 bg-blue-50 dark:bg-blue-900/40 p-4">
                   <h3 className="text-lg font-semibold text-blue-900 dark:text-blue-100 mb-2">
@@ -723,13 +725,13 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
                 </div>
               </div>
               ) : systemSettings.ALLOW_USER_SELF_DELETE !== 'false' ? (
-              <div className="mt-8 pt-6 border-t border-red-200">
-                <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-                  <h3 className="text-lg font-semibold text-red-800 mb-2 flex items-center">
+              <div className="mt-8 pt-6 border-t border-red-200 dark:border-red-900">
+                <div className="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded-lg p-4">
+                  <h3 className="text-lg font-semibold text-red-800 dark:text-red-200 mb-2 flex items-center">
                     <Trash2 className="h-5 w-5 mr-2" />
                     {t('profile.dangerZone')}
                   </h3>
-                  <p className="text-sm text-red-700 mb-4">
+                  <p className="text-sm text-red-700 dark:text-red-300 mb-4">
                     {t('profile.deleteAccountWarning')}
                   </p>
                   
@@ -738,17 +740,17 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
                       type="button"
                       onClick={() => setShowDeleteConfirm(true)}
                       disabled={isSubmitting || isDeletingAccount}
-                      className="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition-colors text-sm font-medium"
+                      className="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors text-sm font-medium"
                     >
                       {t('profile.deleteMyAccount')}
                     </button>
                   ) : (
                     <div className="space-y-4">
-                      <div className="bg-red-100 border border-red-300 rounded-md p-3">
-                        <p className="text-sm text-red-800 font-medium mb-2">
+                      <div className="bg-red-100 dark:bg-red-950/50 border border-red-300 dark:border-red-800 rounded-md p-3">
+                        <p className="text-sm text-red-800 dark:text-red-200 font-medium mb-2">
                           {t('profile.deleteAccountPermanent')}
                         </p>
-                        <ul className="text-sm text-red-700 list-disc list-inside space-y-1">
+                        <ul className="text-sm text-red-700 dark:text-red-300 list-disc list-inside space-y-1">
                           <li>{t('profile.deleteAccountList1')}</li>
                           <li>{t('profile.deleteAccountList2')}</li>
                           <li>{t('profile.deleteAccountList3')}</li>
@@ -758,7 +760,7 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
                       
                       <div className="space-y-3">
                         <div>
-                          <label className="block text-sm font-medium text-red-800 mb-2">
+                          <label className="block text-sm font-medium text-red-800 dark:text-red-200 mb-2">
                             {t('profile.typeDeleteToConfirm')}
                           </label>
                           <input
@@ -773,7 +775,7 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
                         </div>
                         
                         {error && (
-                          <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded p-2">
+                          <div className="text-sm text-red-600 dark:text-red-300 bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 rounded p-2">
                             {error}
                           </div>
                         )}
@@ -784,7 +786,7 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
                           type="button"
                           onClick={handleDeleteAccount}
                           disabled={deleteConfirmation !== 'DELETE' || isDeletingAccount}
-                          className="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 transition-colors text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
+                          className="px-4 py-2 bg-red-600 text-white rounded-md hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed"
                         >
                           {isDeletingAccount ? t('profile.deletingAccount') : t('profile.deleteMyAccountForever')}
                         </button>
@@ -796,7 +798,7 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
                             setError(null);
                           }}
                           disabled={isDeletingAccount}
-                          className="px-4 py-2 bg-gray-300 text-gray-700 rounded-md hover:bg-gray-400 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 transition-colors text-sm"
+                          className="px-4 py-2 bg-gray-300 dark:bg-gray-600 text-gray-700 dark:text-gray-100 rounded-md hover:bg-gray-400 dark:hover:bg-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors text-sm"
                         >
                           {t('buttons.cancel')}
                         </button>
@@ -825,20 +827,20 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
             <div className="space-y-6">
               <div>
                 <h4 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-4">{t('profile.applicationPreferences')}</h4>
-                <p className="text-sm text-gray-600 mb-6">
+                <p className="text-sm text-gray-600 dark:text-gray-400 mb-6">
                   {t('profile.appPreferencesDescription')}
                 </p>
               </div>
 
               {/* Task Delete Confirmation — hidden for view-only (cannot delete tasks) */}
               {!isViewOnlyUser && (
-              <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
+              <div className="bg-gray-50 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
                 <div className="flex items-start justify-between">
                   <div className="flex-1">
-                    <label className="text-sm font-medium text-gray-700 block mb-1">
+                    <label className="text-sm font-medium text-gray-700 dark:text-gray-300 block mb-1">
                       {t('profile.taskDeleteConfirmation')}
                     </label>
-                    <p className="text-sm text-gray-500">
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
                       {t('profile.taskDeleteConfirmationDescription')}
                       {systemSettings.TASK_DELETE_CONFIRM !== 'false' ? ` ${t('profile.systemDefaultEnabled')}` : ` ${t('profile.systemDefaultDisabled')}`}
                     </p>
@@ -857,7 +859,7 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
                           handleTaskDeleteConfirmChange(value === 'true');
                         }
                       }}
-                      className="block w-40 px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                      className="block w-40 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                     >
                       <option value="system">{t('profile.useSystemDefault')}</option>
                       <option value="true">{t('profile.alwaysConfirm')}</option>
@@ -869,13 +871,13 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
               )}
 
               {/* Preferred Language */}
-              <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
+              <div className="bg-gray-50 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
                 <div className="flex items-start justify-between">
                   <div className="flex-1">
-                    <label className="text-sm font-medium text-gray-700 block mb-1">
+                    <label className="text-sm font-medium text-gray-700 dark:text-gray-300 block mb-1">
                       {t('profile.preferredLanguage')}
                     </label>
-                    <p className="text-sm text-gray-500">
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
                       {t('profile.preferredLanguageDescription')}
                     </p>
                   </div>
@@ -885,7 +887,7 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
                       onChange={(e) =>
                         handleLanguageChange(e.target.value === 'fr' ? 'fr' : 'en')
                       }
-                      className="block w-40 px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                      className="block w-40 px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                     >
                       <option value="en">{t('profile.languageEnglish')}</option>
                       <option value="fr">{t('profile.languageFrench')}</option>
@@ -895,13 +897,13 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
               </div>
 
               {/* Activity Feed Setting */}
-              <div className="bg-gray-50 border border-gray-200 rounded-lg p-4">
+              <div className="bg-gray-50 dark:bg-gray-900/40 border border-gray-200 dark:border-gray-700 rounded-lg p-4">
                 <div className="flex items-start justify-between">
                   <div className="flex-1">
-                    <label className="text-sm font-medium text-gray-700 block mb-1">
+                    <label className="text-sm font-medium text-gray-700 dark:text-gray-300 block mb-1">
                       {t('profile.activityFeed')}
                     </label>
-                    <p className="text-sm text-gray-500">
+                    <p className="text-sm text-gray-500 dark:text-gray-400">
                       {t('profile.activityFeedDescription')}
                       {systemSettings.SHOW_ACTIVITY_FEED !== 'false' ? ` ${t('profile.systemDefaultEnabled')}` : ` ${t('profile.systemDefaultDisabled')}`}
                     </p>
@@ -914,13 +916,13 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
                         onChange={(e) => handleActivityFeedToggle(e.target.checked)}
                         className="sr-only peer"
                       />
-                      <div className="w-11 h-6 bg-gray-200 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
+                      <div className="w-11 h-6 bg-gray-200 dark:bg-gray-600 peer-focus:outline-none peer-focus:ring-4 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-blue-600"></div>
                     </label>
                   </div>
                 </div>
               </div>
 
-              <div className="text-sm text-gray-500 italic">
+              <div className="text-sm text-gray-500 dark:text-gray-400 italic">
                 {t('profile.changesSavedAutomatically')}
               </div>
             </div>
@@ -982,14 +984,14 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
                           className="sr-only peer"
                           disabled={!mailEnabled}
                         />
-                        <div className="relative w-9 h-5 bg-gray-200 rounded-full peer peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-300 peer-checked:bg-blue-600 after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:border after:border-gray-300 after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-4 peer-checked:after:border-white"></div>
+                        <div className="relative w-9 h-5 bg-gray-200 dark:bg-gray-600 rounded-full peer peer-focus:outline-none peer-focus:ring-2 peer-focus:ring-blue-300 dark:peer-focus:ring-blue-800 peer-checked:bg-blue-600 after:content-[''] after:absolute after:top-0.5 after:left-0.5 after:bg-white after:border after:border-gray-300 after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:after:translate-x-4 peer-checked:after:border-white"></div>
                       </label>
                     </div>
                   ))}
                 </div>
               </div>
 
-              <div className="text-xs text-gray-500 italic">
+              <div className="text-xs text-gray-500 dark:text-gray-400 italic">
                 {t('profile.changesSavedAutomatically')}
               </div>
             </div>

--- a/src/components/profile/ProfileDevTab.tsx
+++ b/src/components/profile/ProfileDevTab.tsx
@@ -440,14 +440,14 @@ const ProfileDevTab: React.FC = () => {
 
         <ul className="mt-2 divide-y divide-gray-200 dark:divide-gray-700">
           {tokens.length === 0 && (
-            <li className="py-1.5 text-xs text-gray-500">{t('profile.devNoTokens')}</li>
+            <li className="py-1.5 text-xs text-gray-500 dark:text-gray-400">{t('profile.devNoTokens')}</li>
           )}
           {tokens.map((tok) => (
             <li key={tok.id} className="py-2 flex items-center justify-between gap-3">
               <div className="min-w-0">
                 <div className="text-sm font-medium text-gray-900 dark:text-gray-100">{tok.name}</div>
-                <div className="text-xs text-gray-500 font-mono">{tok.tokenPrefix}…</div>
-                <div className="text-xs text-gray-400">
+                <div className="text-xs text-gray-500 dark:text-gray-400 font-mono">{tok.tokenPrefix}…</div>
+                <div className="text-xs text-gray-400 dark:text-gray-500">
                   {t('profile.devCreated')}: {new Date(tok.createdAt).toLocaleString()}
                   {tok.lastUsedAt
                     ? ` · ${t('profile.devLastUsed')}: ${new Date(tok.lastUsedAt).toLocaleString()}`


### PR DESCRIPTION
## Summary
- Upload letter/seed avatars to S3 when managed storage is configured
- Add admin-portal `storage/migrate-disk-to-s3` endpoint (fixes module export mismatch with purgeManagedTenantObjects)
- Harden Profile owner loading and dark-mode tab chrome

## Test plan
- [ ] Confirm `/api/admin-portal/info` loads on kanban.agila.dev after deploy
- [ ] New managed tenant gets seed avatars in S3 (or migrate kicks off after S3 configure)
- [ ] Profile owner portal / tabs still behave correctly

Made with [Cursor](https://cursor.com)