### PR TITLE
fix: Live-remove deleted users in Admin and serve brand logo in emails.

### DIFF
--- a/server/routes/settings.js
+++ b/server/routes/settings.js
@@ -38,6 +38,7 @@ import {
   aiRunnerProbeBodySchema
 } from '../utils/requestValidation.js';
 import { validateUploadedFileMagic } from '../utils/fileMagicBytes.js';
+import { resolveDefaultBrandLogoPath } from '../utils/brandAssets.js';
 
 const router = express.Router();
 
@@ -155,8 +156,9 @@ router.get('/', async (req, res, next) => {
 
 /**
  * Public site logo for emails / unauthenticated branding.
- * Only serves the currently configured SITE_LOGO (or SITE_LOGO_DARK) file —
- * not arbitrary avatar filenames. User avatars remain auth-gated.
+ * Serves the configured SITE_LOGO (or SITE_LOGO_DARK) file when set;
+ * otherwise falls back to the shipping Agila logo under public/.
+ * User avatars remain auth-gated.
  */
 router.get('/site-logo', async (req, res, next) => {
   if (req.baseUrl === '/api/admin/settings') {
@@ -182,13 +184,20 @@ router.get('/site-logo', async (req, res, next) => {
         ? (dark?.value || light?.value || '').trim()
         : (light?.value || '').trim();
 
-    if (
+    const isBuiltinPath =
       !logoPath ||
       logoPath.startsWith('/agila') ||
       logoPath.startsWith('/kanban') ||
-      logoPath.startsWith('/assets/')
-    ) {
-      return res.status(404).json({ error: 'No site logo configured' });
+      logoPath.startsWith('/assets/');
+
+    if (isBuiltinPath) {
+      const defaultPath = resolveDefaultBrandLogoPath(variant);
+      if (!defaultPath) {
+        return res.status(404).json({ error: 'No site logo configured' });
+      }
+      res.setHeader('Content-Type', 'image/png');
+      res.setHeader('Cache-Control', 'public, max-age=86400');
+      return res.sendFile(defaultPath);
     }
 
     if (/^https?:\/\//i.test(logoPath)) {

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -376,28 +376,32 @@ router.delete("/account", authenticateToken, async (req, res) => {
       }
     }
 
-    notificationService.publish('member-deleted', {
-      userId,
-      memberId: userMember?.id || null,
-      userName: `${user.first_name} ${user.last_name}`,
-      userEmail: user.email,
-      timestamp: new Date().toISOString(),
-    }, tenantId).catch((err) => {
+    try {
+      await notificationService.publish('member-deleted', {
+        userId,
+        memberId: userMember?.id || null,
+        userName: `${user.first_name} ${user.last_name}`,
+        userEmail: user.email,
+        timestamp: new Date().toISOString(),
+      }, tenantId);
+    } catch (err) {
       console.error('Failed to publish member-deleted event:', err);
-    });
+    }
 
-    notificationService.publish('user-deleted', {
-      userId,
-      user: {
-        id: userId,
-        email: user.email,
-        first_name: user.first_name,
-        last_name: user.last_name,
-      },
-      timestamp: new Date().toISOString(),
-    }, tenantId).catch((err) => {
+    try {
+      await notificationService.publish('user-deleted', {
+        userId,
+        user: {
+          id: userId,
+          email: user.email,
+          first_name: user.first_name,
+          last_name: user.last_name,
+        },
+        timestamp: new Date().toISOString(),
+      }, tenantId);
+    } catch (err) {
       console.error('Failed to publish user-deleted event:', err);
-    });
+    }
 
     res.json({
       message: 'Account deleted successfully',

--- a/server/utils/brandAssets.js
+++ b/server/utils/brandAssets.js
@@ -1,0 +1,33 @@
+/**
+ * Shipping Agila brand assets (public/ → dist/ in production builds).
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Absolute path to the default Agila logo PNG, or null if missing.
+ * @param {'light'|'dark'} [variant='light']
+ * @returns {string|null}
+ */
+export function resolveDefaultBrandLogoPath(variant = 'light') {
+  const filename =
+    variant === 'dark' ? 'agila-logo-dark.png' : 'agila-logo.png';
+  const candidates = [
+    path.join(process.cwd(), 'public', filename),
+    path.join(process.cwd(), 'dist', filename),
+    path.join(here, '..', '..', 'public', filename),
+    path.join(here, '..', '..', 'dist', filename),
+  ];
+  for (const candidate of candidates) {
+    try {
+      if (fs.existsSync(candidate)) return candidate;
+    } catch {
+      // ignore
+    }
+  }
+  return null;
+}

--- a/server/utils/emailContent.js
+++ b/server/utils/emailContent.js
@@ -279,8 +279,8 @@ export async function buildEmailAuthorAvatar({
 
 /**
  * Build an <img> for the site logo in transactional emails (public URLs only — no CID).
- * Custom uploads → `${baseUrl}/api/settings/site-logo`.
- * Built-in / empty SITE_LOGO with embedDefaultBrandLogo → `${baseUrl}/agila-logo.png`.
+ * Uses `${baseUrl}/api/settings/site-logo`, which serves a custom upload or the
+ * shipping Agila logo (see GET /api/settings/site-logo).
  *
  * @returns {{ html: string, attachments: object[] }}
  */
@@ -300,35 +300,35 @@ export function buildEmailSiteLogo({
   const imgStyle =
     'max-height:48px;max-width:200px;width:auto;height:auto;display:block;margin:0 auto;border:0;outline:none;text-decoration:none;';
 
+  if (!origin) {
+    return { html: '', attachments: [] };
+  }
+
   const isBuiltinPath =
     !raw ||
     raw.startsWith('/agila') ||
     raw.startsWith('/kanban') ||
     raw.startsWith('/assets/');
 
-  let src = '';
-
-  if (raw && !isBuiltinPath) {
-    if (/^https?:\/\//i.test(raw)) {
-      src = raw;
-    } else if (origin) {
-      const cacheKey = raw.includes('/avatars/')
-        ? raw.split('/avatars/').pop()?.split('?')[0] || ''
-        : '';
-      src = `${origin}/api/settings/site-logo${cacheKey ? `?v=${encodeURIComponent(cacheKey)}` : ''}`;
-    }
-  } else if (embedDefaultBrandLogo && origin) {
-    // Shipping brand asset from public/ (also copied to dist/ in production)
-    const builtin =
-      raw.startsWith('/agila') || raw.startsWith('/kanban') || raw.startsWith('/assets/')
-        ? raw
-        : '/agila-logo.png';
-    src = `${origin}${builtin}`;
+  // Custom absolute URL — use as-is
+  if (raw && /^https?:\/\//i.test(raw)) {
+    return {
+      html: `<img src="${escapeHtml(raw)}" alt="${escapeHtml(alt)}" style="${imgStyle}" />`,
+      attachments: [],
+    };
   }
 
-  if (!src) {
+  // No custom logo and caller did not ask for the default brand mark
+  if (isBuiltinPath && !embedDefaultBrandLogo) {
     return { html: '', attachments: [] };
   }
+
+  // Custom upload or default brand — both via public API (works on API host, not only Vite)
+  const cacheKey =
+    raw && !isBuiltinPath && raw.includes('/avatars/')
+      ? raw.split('/avatars/').pop()?.split('?')[0] || ''
+      : '';
+  const src = `${origin}/api/settings/site-logo${cacheKey ? `?v=${encodeURIComponent(cacheKey)}` : ''}`;
 
   return {
     html: `<img src="${escapeHtml(src)}" alt="${escapeHtml(alt)}" style="${imgStyle}" />`,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1409,6 +1409,7 @@ function AppContent() {
     websocketClient.onMemberUpdated(memberWebSocket.handleMemberUpdated);
     websocketClient.onMemberCreated(memberWebSocket.handleMemberCreated);
     websocketClient.onMemberDeleted(memberWebSocket.handleMemberDeleted);
+    websocketClient.onUserDeleted(memberWebSocket.handleUserDeleted);
     websocketClient.onUserProfileUpdated(memberWebSocket.handleUserProfileUpdated);
     websocketClient.onActivityUpdated(memberWebSocket.handleActivityUpdated);
     websocketClient.onFilterCreated(memberWebSocket.handleFilterCreated);
@@ -1460,6 +1461,7 @@ function AppContent() {
       websocketClient.offMemberUpdated(memberWebSocket.handleMemberUpdated);
       websocketClient.offMemberCreated(memberWebSocket.handleMemberCreated);
       websocketClient.offMemberDeleted(memberWebSocket.handleMemberDeleted);
+      websocketClient.offUserDeleted(memberWebSocket.handleUserDeleted);
       websocketClient.offUserProfileUpdated(memberWebSocket.handleUserProfileUpdated);
       websocketClient.offActivityUpdated(memberWebSocket.handleActivityUpdated);
       websocketClient.offFilterCreated(memberWebSocket.handleFilterCreated);

--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -111,6 +111,9 @@ const Admin: React.FC<AdminProps> = ({
 }) => {
   const { t } = useTranslation('admin');
   const { systemSettings, refreshSettings, updateSiteSetting, updateSiteSettings } = useSettings(); // Use SettingsContext for admin settings
+  const refreshSettingsRef = useRef(refreshSettings);
+  refreshSettingsRef.current = refreshSettings;
+  const isAdminAccount = Boolean(currentUser?.roles?.includes('admin'));
   const [activeTab, setActiveTab] = useState(() => {
     const tab = adminTabFromHash(window.location.hash);
     return tab && ADMIN_TABS.includes(tab) ? tab : ROUTES.DEFAULT_ADMIN_TAB;
@@ -273,7 +276,7 @@ const Admin: React.FC<AdminProps> = ({
 
   // WebSocket event listeners for real-time updates
   useEffect(() => {
-    if (!currentUser?.roles?.includes('admin')) return;
+    if (!isAdminAccount) return;
 
     // Tag management event handlers
     const handleTagCreated = async (data: any) => {
@@ -349,50 +352,45 @@ const Admin: React.FC<AdminProps> = ({
     websocketClient.onPriorityReordered(handlePriorityReordered);
 
     // User management event handlers
-    const handleUserCreated = async (data: any) => {
-      try {
-        const usersResponse = await api.get('/admin/users');
-        setUsers(usersResponse.data || []);
-      } catch (error) {
-        console.error('Failed to refresh users after creation:', error);
+    const applyAdminUsersFromResponse = (payload: unknown) => {
+      if (Array.isArray(payload)) {
+        setUsers(payload);
       }
     };
 
-    const handleUserUpdated = async (data: any) => {
+    const refreshAdminUsers = async (reason: string) => {
       try {
         const usersResponse = await api.get('/admin/users');
-        setUsers(usersResponse.data || []);
+        applyAdminUsersFromResponse(usersResponse.data);
       } catch (error) {
-        console.error('Failed to refresh users after update:', error);
+        console.error(`Failed to refresh users after ${reason}:`, error);
       }
     };
 
-    const handleUserRoleUpdated = async (data: any) => {
-      try {
-        const usersResponse = await api.get('/admin/users');
-        setUsers(usersResponse.data || []);
-      } catch (error) {
-        console.error('Failed to refresh users after role update:', error);
-      }
+    const handleUserCreated = async () => {
+      await refreshAdminUsers('creation');
+    };
+
+    const handleUserUpdated = async () => {
+      await refreshAdminUsers('update');
+    };
+
+    const handleUserRoleUpdated = async () => {
+      await refreshAdminUsers('role update');
     };
 
     const handleUserDeleted = async (data: any) => {
-      try {
-        const usersResponse = await api.get('/admin/users');
-        setUsers(usersResponse.data || []);
-      } catch (error) {
-        console.error('Failed to refresh users after deletion:', error);
+      const deletedId = data?.userId ?? data?.user?.id;
+      if (deletedId != null) {
+        setUsers((prev) =>
+          Array.isArray(prev) ? prev.filter((u) => String(u.id) !== String(deletedId)) : prev
+        );
       }
+      await refreshAdminUsers('deletion');
     };
 
-    const handleUserProfileUpdated = async (data: any) => {
-      try {
-        // Refresh users list to get updated avatar/color/profile info
-        const usersResponse = await api.get('/admin/users');
-        setUsers(usersResponse.data || []);
-      } catch (error) {
-        console.error('Failed to refresh users after profile update:', error);
-      }
+    const handleUserProfileUpdated = async () => {
+      await refreshAdminUsers('profile update');
     };
 
     // Settings event handlers
@@ -449,7 +447,7 @@ const Admin: React.FC<AdminProps> = ({
           }
         } else {
           // Fallback: Refresh from SettingsContext if WebSocket data is incomplete
-          await refreshSettings();
+          await refreshSettingsRef.current();
           // SettingsContext will update, and our useEffect will trigger loadData() to sync local state
         }
       } catch (error) {
@@ -481,7 +479,7 @@ const Admin: React.FC<AdminProps> = ({
       websocketClient.offUserProfileUpdated(handleUserProfileUpdated);
       websocketClient.offSettingsUpdated(handleSettingsUpdated);
     };
-  }, [currentUser?.roles, refreshSettings]);
+  }, [isAdminAccount]);
 
   // System info fetching removed - Header.tsx handles all system info polling
   // Header is always loaded and has the same admin check, so no need for duplicate polling

--- a/src/hooks/useMemberWebSocket.ts
+++ b/src/hooks/useMemberWebSocket.ts
@@ -75,15 +75,39 @@ export const useMemberWebSocket = ({
     }
   }, [setMembers, taskFilters.includeSystem]);
 
-  const handleMemberDeleted = useCallback(async (data: any) => {
-    // Refresh members list from server (don't pass empty array!)
+  const applyMembersFromServer = useCallback(async () => {
     try {
       const loadedMembers = await getMembers(taskFilters.includeSystem);
       setMembers(Array.isArray(loadedMembers) ? loadedMembers : []);
     } catch (error) {
       console.error('Failed to refresh members after deletion:', error);
     }
-  }, [taskFilters.includeSystem, setMembers]);
+  }, [setMembers, taskFilters.includeSystem]);
+
+  const removeMemberLocally = useCallback((data: any) => {
+    const userId = data?.userId ?? data?.user?.id;
+    const memberId = data?.memberId;
+    const email = String(data?.userEmail || data?.user?.email || '').trim().toLowerCase();
+    setMembers((prev) => {
+      const list = Array.isArray(prev) ? prev : [];
+      return list.filter((m) => {
+        if (memberId != null && String(m.id) === String(memberId)) return false;
+        if (userId != null && m.user_id != null && String(m.user_id) === String(userId)) return false;
+        if (email && m.email && String(m.email).trim().toLowerCase() === email) return false;
+        return true;
+      });
+    });
+  }, [setMembers]);
+
+  const handleMemberDeleted = useCallback(async (data: any) => {
+    removeMemberLocally(data);
+    await applyMembersFromServer();
+  }, [removeMemberLocally, applyMembersFromServer]);
+
+  const handleUserDeleted = useCallback(async (data: any) => {
+    removeMemberLocally(data);
+    await applyMembersFromServer();
+  }, [removeMemberLocally, applyMembersFromServer]);
 
   const handleUserProfileUpdated = useCallback(async (data: any) => {
     // If this is the current user's profile update, refresh currentUser
@@ -156,6 +180,7 @@ export const useMemberWebSocket = ({
     handleMemberCreated,
     handleMemberUpdated,
     handleMemberDeleted,
+    handleUserDeleted,
     handleUserProfileUpdated,
     handleActivityUpdated,
     handleFilterCreated,


### PR DESCRIPTION
## Summary
- Remove deleted users/members from Admin Users and the board member list as soon as `user-deleted` arrives, and keep Admin websocket listeners from rebinding on every settings refresh.
- Await self-delete notify so other sessions receive the event before the HTTP response.
- Serve the shipping Agila logo from `GET /api/settings/site-logo` so invite/reset emails work on the API host.

## Test plan
- [ ] Two sessions on the same tenant: delete a non-owner from Profile; Admin → Users should drop the row live.
- [ ] Invite email shows the Agila header logo.
- [ ] Demo deploy after merge; demo reset succeeds.


Made with [Cursor](https://cursor.com)