### PR TITLE
Run demo in production (Vite preview + built assets)

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -4,11 +4,11 @@
 # Stage 1: Build the frontend
 FROM node:22-alpine AS frontend-builder
 
-# Build argument for MULTI_TENANT (needed for frontend build)
+# Build arguments baked into the Vite bundle (define + import.meta.env)
 ARG MULTI_TENANT=false
-
-# Set as environment variable so Vite can access it during build
+ARG DEMO_ENABLED=false
 ENV MULTI_TENANT=${MULTI_TENANT}
+ENV DEMO_ENABLED=${DEMO_ENABLED}
 
 WORKDIR /app
 

--- a/docker-compose-demo.yml
+++ b/docker-compose-demo.yml
@@ -3,13 +3,20 @@ name: easy-kanban
 
 services:
   agila-app:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile.prod
+      args:
+        DEMO_ENABLED: "true"
+        MULTI_TENANT: "false"
     container_name: agila
+    # Named volumes were created by the old root/dev image; stay root so writes keep working.
+    user: "0:0"
     ports:
       - "3221:3010"
       - "3222:3222"
     environment:
-      - NODE_ENV=development
+      - NODE_ENV=production
       - DOCKER_ENV=true
       - PORT=3222
       - VITE_API_URL=http://localhost:3222
@@ -37,8 +44,6 @@ services:
       # Application version (optional, will override database value if set)
       - APP_VERSION=0.9-beta
     volumes:
-      - .:/app
-      - /app/node_modules
       - kanban-data:/app/server/data
       - kanban-attachments:/app/server/attachments
       - kanban-avatars:/app/server/avatars


### PR DESCRIPTION
## Summary
- Demo Compose now builds \`Dockerfile.prod\` (\`npm run start:prod\`) with \`NODE_ENV=production\` and \`DEMO_ENABLED=true\` as a build arg so the UI flag is inlined.
- Removes the \`.:/app\` bind-mount so the container serves \`dist/\`, not the Vite dev server.

## Test plan
- [ ] Homepage HTML references hashed \`/assets/\` (not \`/src/components/Login.tsx\`)
- [ ] \`/ready\` and \`/api/auth/demo-credentials\` succeed
- [ ] Demo login, language pick, open a task — no dispatcher error
- [ ] Logs show \`NODE_ENV=production\` / vite preview, not Vite transform errors


Made with [Cursor](https://cursor.com)