### PR TITLE
Speed up task delete and clarify bulk/keyboard board UX

### DIFF
--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -15,8 +15,9 @@ import { dbTransaction } from '../utils/dbAsync.js';
 import { tasks as taskQueries, boards as boardQueries, helpers, sprints as sprintQueries, taskWork as taskWorkQueries } from '../utils/sqlManager/index.js';
 import { AUTOMATION_CONFIG_KEYS } from '../constants/automation.js';
 import {
-  purgeTaskCompletelyAndUpdateStorage,
+  purgeTaskCompletely,
 } from '../services/taskPurgeService.js';
+import { updateStorageUsage } from '../utils/storageUtils.js';
 import { notifyCollaboratorAdded, notifyBulkColumnMove, notifyWatcherAdded } from '../services/taskEmailNotificationService.js';
 import {
   parseBody,
@@ -1861,22 +1862,6 @@ router.delete('/:id', authenticateToken, async (req, res) => {
       return res.status(404).json({ error: tTranslator('errors.taskNotFound') });
     }
 
-    const remainingTasks = await taskQueries.getRemainingTasksInColumn(db, columnId, boardId);
-    await taskQueries.renumberTasksInColumn(db, remainingTasks);
-
-    if (remainingTasks.length > 0) {
-      const positionUpdates = remainingTasks.map((taskItem, index) => ({
-        taskId: taskItem.id,
-        position: index,
-        columnId,
-      }));
-      await notificationService.publish('tasks-positions-updated', {
-        boardId,
-        updates: positionUpdates,
-        timestamp: new Date().toISOString(),
-      }, getTenantId(req));
-    }
-
     const taskRef = taskTicket ? ` (${taskTicket})` : '';
     const deleteDetails = JSON.stringify({
       en: t('activity.deletedTask', { taskTitle: task.title, taskRef, boardTitle }, 'en'),
@@ -1895,12 +1880,15 @@ router.delete('/:id', authenticateToken, async (req, res) => {
       console.error('Background activity logging failed:', error);
     });
 
-    await notificationService.publish('task-deleted', {
+    // Positions keep their gaps; dense 0..n renumber is unnecessary and slow on large columns.
+    notificationService.publish('task-deleted', {
       boardId,
       taskId: id,
       softDeleted: true,
       timestamp: new Date().toISOString(),
-    }, getTenantId(req));
+    }, getTenantId(req)).catch((error) => {
+      console.error('Background WebSocket publish failed:', error);
+    });
 
     res.json({ message: 'Task moved to trash', softDeleted: true });
   } catch (error) {
@@ -2059,16 +2047,13 @@ router.delete('/:id/permanent', authenticateToken, requireRole(['admin']), async
     }
     const boardId = task.boardid || task.boardId;
     const wasSoftDeleted = !!(task.deleted_at || task.deletedAt);
-    const columnId = task.columnid || task.columnId;
 
-    await purgeTaskCompletelyAndUpdateStorage(db, id, resolveTenantStoragePaths(req));
+    await purgeTaskCompletely(db, id, resolveTenantStoragePaths(req));
+    updateStorageUsage(db).catch((error) => {
+      console.error('Background storage usage update failed:', error);
+    });
 
-    if (!wasSoftDeleted) {
-      const remainingTasks = await taskQueries.getRemainingTasksInColumn(db, columnId, boardId);
-      await taskQueries.renumberTasksInColumn(db, remainingTasks);
-    }
-
-    await notificationService.publish(
+    notificationService.publish(
       wasSoftDeleted ? 'task-purged' : 'task-deleted',
       {
         boardId,
@@ -2076,7 +2061,9 @@ router.delete('/:id/permanent', authenticateToken, requireRole(['admin']), async
         timestamp: new Date().toISOString(),
       },
       getTenantId(req)
-    );
+    ).catch((error) => {
+      console.error('Background WebSocket publish failed:', error);
+    });
 
     res.json({ message: 'Task permanently deleted' });
   } catch (error) {
@@ -2102,14 +2089,9 @@ router.post('/permanent-batch', authenticateToken, requireRole(['admin']), async
       const task = await taskQueries.getTaskById(db, taskId);
       if (!task) continue;
       const boardId = task.boardid || task.boardId;
-      const columnId = task.columnid || task.columnId;
       const wasSoftDeleted = !!(task.deleted_at || task.deletedAt);
-      await purgeTaskCompletelyAndUpdateStorage(db, taskId, storagePaths);
-      if (!wasSoftDeleted && columnId && boardId) {
-        const remainingTasks = await taskQueries.getRemainingTasksInColumn(db, columnId, boardId);
-        await taskQueries.renumberTasksInColumn(db, remainingTasks);
-      }
-      await notificationService.publish(
+      await purgeTaskCompletely(db, taskId, storagePaths);
+      notificationService.publish(
         wasSoftDeleted ? 'task-purged' : 'task-deleted',
         {
           boardId,
@@ -2117,8 +2099,15 @@ router.post('/permanent-batch', authenticateToken, requireRole(['admin']), async
           timestamp: new Date().toISOString(),
         },
         getTenantId(req)
-      );
+      ).catch((error) => {
+        console.error('Background WebSocket publish failed:', error);
+      });
       purged.push(taskId);
+    }
+    if (purged.length > 0) {
+      updateStorageUsage(db).catch((error) => {
+        console.error('Background storage usage update failed:', error);
+      });
     }
     res.json({ purged });
   } catch (error) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -352,12 +352,6 @@ function AppContent() {
 
       await deleteTask(taskId, options);
       removeTaskFromLocalColumns(taskId);
-
-      // NOTE: Backend already renumbers tasks after deletion and sends a WebSocket event
-      await refreshBoardData();
-      await fetchQueryLogs();
-
-      // Do not rely only on WebSocket for the trash badge — refresh after HTTP success
       notifyBoardTrashChanged(boardIdForTrash);
     } catch (error) {
       throw error;
@@ -374,9 +368,6 @@ function AppContent() {
 
       await purgeTask(taskId);
       removeTaskFromLocalColumns(taskId);
-
-      await refreshBoardData();
-      await fetchQueryLogs();
     } catch (error: any) {
       toast.error(error?.response?.data?.error || t('trash.purgeFailed'));
       throw error;

--- a/src/components/ColumnBulkActionBar.tsx
+++ b/src/components/ColumnBulkActionBar.tsx
@@ -492,8 +492,14 @@ export default function ColumnBulkActionBar({
         )
       : null;
 
-  const confirmPortal =
-    (deleteConfirm || permanentDeleteConfirm || boardConfirm) && typeof document !== 'undefined'
+  const dismissConfirms = () => {
+    setDeleteConfirm(false);
+    setPermanentDeleteConfirm(false);
+    setBoardConfirm(null);
+  };
+
+  const boardConfirmPortal =
+    boardConfirm && typeof document !== 'undefined'
       ? createPortal(
           <div
             ref={confirmRef}
@@ -506,24 +512,16 @@ export default function ColumnBulkActionBar({
             }}
           >
             <p className="mb-2 text-xs text-gray-700 dark:text-gray-200">
-              {permanentDeleteConfirm
-                ? t('kanbanSelect.deleteConfirmPermanent', { count: selectedCount })
-                : deleteConfirm
-                  ? t('kanbanSelect.deleteConfirm', { count: selectedCount })
-                  : t('kanbanSelect.moveToBoardConfirm', {
-                      count: selectedCount,
-                      board: boardConfirm?.name,
-                    })}
+              {t('kanbanSelect.moveToBoardConfirm', {
+                count: selectedCount,
+                board: boardConfirm?.name,
+              })}
             </p>
             <div className="flex justify-end gap-2">
               <button
                 type="button"
                 className="rounded px-2 py-1 text-xs text-gray-600 hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-800"
-                onClick={() => {
-                  setDeleteConfirm(false);
-                  setPermanentDeleteConfirm(false);
-                  setBoardConfirm(null);
-                }}
+                onClick={dismissConfirms}
               >
                 {t('buttons.cancel', { ns: 'common' })}
               </button>
@@ -531,20 +529,77 @@ export default function ColumnBulkActionBar({
                 type="button"
                 className="rounded bg-red-600 px-2 py-1 text-xs text-white hover:bg-red-700"
                 onClick={() => {
-                  if (permanentDeleteConfirm) onPermanentDelete?.();
-                  else if (deleteConfirm) onDelete();
-                  else if (boardConfirm) onMoveToBoard(boardConfirm.id);
-                  setDeleteConfirm(false);
-                  setPermanentDeleteConfirm(false);
-                  setBoardConfirm(null);
+                  onMoveToBoard(boardConfirm.id);
+                  dismissConfirms();
                 }}
               >
-                {permanentDeleteConfirm
-                  ? t('kanbanSelect.deleteForever')
-                  : deleteConfirm
-                    ? t('kanbanSelect.delete')
-                    : t('kanbanSelect.moveToBoard')}
+                {t('kanbanSelect.moveToBoard')}
               </button>
+            </div>
+          </div>,
+          document.body
+        )
+      : null;
+
+  const deleteConfirmPortal =
+    (deleteConfirm || permanentDeleteConfirm) && typeof document !== 'undefined'
+      ? createPortal(
+          <div
+            className="fixed inset-0 z-[9991] flex items-center justify-center bg-black/45 p-4"
+            onClick={(e) => {
+              if (e.target === e.currentTarget) dismissConfirms();
+            }}
+          >
+            <div
+              ref={confirmRef}
+              role="dialog"
+              aria-modal="true"
+              aria-labelledby={`column-bulk-delete-title-${columnId}`}
+              className="w-full max-w-sm rounded-xl border-2 border-red-300 bg-white p-5 shadow-2xl dark:border-red-700 dark:bg-gray-900"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="mb-3 flex items-start gap-3">
+                <span className="mt-0.5 inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-red-100 text-red-600 dark:bg-red-950 dark:text-red-400">
+                  <Trash2 size={18} aria-hidden="true" />
+                </span>
+                <div>
+                  <h2
+                    id={`column-bulk-delete-title-${columnId}`}
+                    className="text-base font-semibold text-gray-900 dark:text-gray-100"
+                  >
+                    {permanentDeleteConfirm
+                      ? t('kanbanSelect.deleteConfirmPermanentTitle')
+                      : t('kanbanSelect.deleteConfirmTitle')}
+                  </h2>
+                  <p className="mt-1 text-sm text-gray-600 dark:text-gray-300">
+                    {permanentDeleteConfirm
+                      ? t('kanbanSelect.deleteConfirmPermanent', { count: selectedCount })
+                      : t('kanbanSelect.deleteConfirm', { count: selectedCount })}
+                  </p>
+                </div>
+              </div>
+              <div className="flex justify-end gap-2">
+                <button
+                  type="button"
+                  className="rounded-md px-3 py-1.5 text-sm text-gray-700 hover:bg-gray-100 dark:text-gray-200 dark:hover:bg-gray-800"
+                  onClick={dismissConfirms}
+                >
+                  {t('buttons.cancel', { ns: 'common' })}
+                </button>
+                <button
+                  type="button"
+                  className="rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700"
+                  onClick={() => {
+                    if (permanentDeleteConfirm) onPermanentDelete?.();
+                    else onDelete();
+                    dismissConfirms();
+                  }}
+                >
+                  {permanentDeleteConfirm
+                    ? t('kanbanSelect.deleteForever')
+                    : t('kanbanSelect.delete')}
+                </button>
+              </div>
             </div>
           </div>,
           document.body
@@ -768,7 +823,11 @@ export default function ColumnBulkActionBar({
                 <button
                   type="button"
                   disabled={busy}
-                  className={`${btnClass} text-red-600 hover:text-red-700`}
+                  className={`${btnClass} text-red-600 hover:text-red-700 ${
+                    deleteConfirm || permanentDeleteConfirm
+                      ? 'ring-2 ring-red-500 ring-offset-2 dark:ring-offset-gray-900'
+                      : ''
+                  }`}
                   onClick={(e) => {
                     if (deleteConfirm || permanentDeleteConfirm) {
                       setDeleteConfirm(false);
@@ -811,7 +870,8 @@ export default function ColumnBulkActionBar({
       {actionBarPortal}
       {menuPortal}
       {addTagModalPortal}
-      {confirmPortal}
+      {boardConfirmPortal}
+      {deleteConfirmPortal}
     </>
   );
 }

--- a/src/components/dnd/SimpleDragDropManager.tsx
+++ b/src/components/dnd/SimpleDragDropManager.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
 import { 
   DndContext, 
   DragEndEvent, 
@@ -274,7 +275,9 @@ export const SimpleDragDropManager: React.FC<SimpleDragDropManagerProps> = React
   onBoardTabHover,
   onDragPreviewChange
 }) => {
+  const { t } = useTranslation('tasks');
   const activeBulkTaskIdsRef = useRef<string[]>([]);
+  const [keyboardMoveLabel, setKeyboardMoveLabel] = useState<string | null>(null);
   
   // Y-coordinate based tab area detection
   const [isHoveringBoardTabDelayed, setIsHoveringBoardTabDelayed] = useState(false);
@@ -396,6 +399,14 @@ export const SimpleDragDropManager: React.FC<SimpleDragDropManagerProps> = React
     
     if (activeData?.type === 'task') {
       const task = activeData.task as Task;
+      const isKeyboard =
+        typeof KeyboardEvent !== 'undefined' &&
+        event.activatorEvent instanceof KeyboardEvent;
+      if (isKeyboard) {
+        setKeyboardMoveLabel(task.ticket || task.title || '');
+      } else {
+        setKeyboardMoveLabel(null);
+      }
       const checked = checkedTaskIds;
       const isChecked = !!checked?.has(task.id);
 
@@ -613,6 +624,7 @@ export const SimpleDragDropManager: React.FC<SimpleDragDropManagerProps> = React
       onBoardTabHover?.(false);
       onDragPreviewChange?.(null);
       clearBulkDrag();
+      setKeyboardMoveLabel(null);
       return;
     }
     
@@ -882,6 +894,7 @@ export const SimpleDragDropManager: React.FC<SimpleDragDropManagerProps> = React
       onDragPreviewChange?.(null);
       setIsHoveringBoardTabDelayed(false);
       clearBulkDrag();
+      setKeyboardMoveLabel(null);
     }
   };
 
@@ -895,6 +908,7 @@ export const SimpleDragDropManager: React.FC<SimpleDragDropManagerProps> = React
     setIsHoveringBoardTabDelayed(false);
     activeBulkTaskIdsRef.current = [];
     onDraggedTaskIdsChange?.([]);
+    setKeyboardMoveLabel(null);
   };
 
   return (
@@ -907,6 +921,19 @@ export const SimpleDragDropManager: React.FC<SimpleDragDropManagerProps> = React
       sensors={sensors}
     >
       {children}
+      {keyboardMoveLabel != null && (
+        <div
+          className="pointer-events-none fixed top-4 left-1/2 z-[10000] -translate-x-1/2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-lg"
+          role="status"
+        >
+          <div className="flex items-center space-x-2">
+            <span aria-hidden="true">↕️</span>
+            <span>
+              {t('dnd.keyboardMoveHint', { label: keyboardMoveLabel })}
+            </span>
+          </div>
+        </div>
+      )}
     </DndContext>
   );
 }, (prevProps, nextProps) => {

--- a/src/hooks/useKanbanMultiSelect.ts
+++ b/src/hooks/useKanbanMultiSelect.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   addCollaboratorToTask,
@@ -15,7 +15,9 @@ import {
   getCheckedColumnIds,
   getTaskColumnId,
   pruneCheckedTaskIds,
+  readKanbanMultiSelectSession,
   selectionSpansMultipleColumns as spansMultipleColumns,
+  writeKanbanMultiSelectSession,
 } from '../utils/kanbanMultiSelect';
 import { hasEscapeConsumingOverlay, isEditableEscapeTarget } from '../utils/escapeKeyUtils';
 
@@ -108,6 +110,8 @@ export function useKanbanMultiSelect({
   const [checkedTaskIds, setCheckedTaskIds] = useState<Set<string>>(() => new Set());
   const [bulkBusy, setBulkBusy] = useState(false);
   const [bulkUndo, setBulkUndo] = useState<BulkUndoSnapshot | null>(null);
+  const previousBoardRef = useRef<string | null | undefined>(undefined);
+  const skipFirstSelectionPersistRef = useRef(true);
 
   const clearAllChecked = useCallback(() => {
     setCheckedTaskIds(new Set());
@@ -122,11 +126,37 @@ export function useKanbanMultiSelect({
     setBulkUndo(snapshot);
   }, []);
 
-  // Clear on board switch
+  // Restore checks after refresh (same tab). Real board switches drop selection.
   useEffect(() => {
-    setCheckedTaskIds(new Set());
-    setBulkUndo(null);
+    const prev = previousBoardRef.current;
+
+    if (prev === undefined || prev == null) {
+      previousBoardRef.current = selectedBoard ?? null;
+      if (selectedBoard) {
+        const saved = readKanbanMultiSelectSession();
+        if (saved?.boardId === selectedBoard && saved.taskIds.length > 0) {
+          setCheckedTaskIds(new Set(saved.taskIds));
+        }
+      }
+      return;
+    }
+
+    if (prev !== selectedBoard) {
+      previousBoardRef.current = selectedBoard;
+      setCheckedTaskIds(new Set());
+      setBulkUndo(null);
+      writeKanbanMultiSelectSession(null, new Set());
+    }
   }, [selectedBoard]);
+
+  // Skip the initial empty Set so we do not wipe sessionStorage before restore.
+  useEffect(() => {
+    if (skipFirstSelectionPersistRef.current) {
+      skipFirstSelectionPersistRef.current = false;
+      return;
+    }
+    writeKanbanMultiSelectSession(selectedBoard, checkedTaskIds);
+  }, [selectedBoard, checkedTaskIds]);
 
   // Clear while linking
   useEffect(() => {
@@ -143,8 +173,9 @@ export function useKanbanMultiSelect({
     return () => window.clearTimeout(timer);
   }, [bulkUndo]);
 
-  // Prune ids that left the board
+  // Prune ids that left the board (wait until columns are loaded so refresh restore is not wiped)
   useEffect(() => {
+    if (Object.keys(columns).length === 0) return;
     setCheckedTaskIds((prev) => pruneCheckedTaskIds(prev, columns));
   }, [columns]);
 

--- a/src/i18n/locales/en/tasks.json
+++ b/src/i18n/locales/en/tasks.json
@@ -129,6 +129,9 @@
     "relationshipChild": "child",
     "relationshipRelated": "related"
   },
+  "dnd": {
+    "keyboardMoveHint": "Moving {{label}} — arrow keys to reposition, Enter to drop, Esc to cancel"
+  },
   "toolbar": {
     "dragToMove": "Drag to move task",
     "addComment": "Add comment",
@@ -295,7 +298,9 @@
     "moveToBoard": "Move to board",
     "noSprint": "None (Backlog)",
     "deleteConfirm": "Move {{count}} selected task(s) to trash?",
+    "deleteConfirmTitle": "Move to trash?",
     "deleteConfirmPermanent": "Permanently delete {{count}} selected task(s)? This cannot be undone.",
+    "deleteConfirmPermanentTitle": "Delete forever?",
     "moveToBoardConfirm": "Move {{count}} task(s) to “{{board}}”? Relationships may be removed.",
     "copiedCount": "{{count}} task(s) duplicated",
     "archivedCount": "{{count}} task(s) archived",

--- a/src/i18n/locales/fr/tasks.json
+++ b/src/i18n/locales/fr/tasks.json
@@ -129,6 +129,9 @@
     "relationshipChild": "enfant",
     "relationshipRelated": "lié"
   },
+  "dnd": {
+    "keyboardMoveHint": "Déplacement de {{label}} — flèches pour repositionner, Entrée pour déposer, Échap pour annuler"
+  },
   "toolbar": {
     "dragToMove": "Glisser pour déplacer la tâche",
     "addComment": "Ajouter un commentaire",
@@ -295,7 +298,9 @@
     "moveToBoard": "Déplacer vers un tableau",
     "noSprint": "Aucun (Backlog)",
     "deleteConfirm": "Déplacer {{count}} tâche(s) sélectionnée(s) vers la corbeille ?",
+    "deleteConfirmTitle": "Mettre à la corbeille ?",
     "deleteConfirmPermanent": "Supprimer définitivement {{count}} tâche(s) sélectionnée(s) ? Cette action est irréversible.",
+    "deleteConfirmPermanentTitle": "Supprimer définitivement ?",
     "moveToBoardConfirm": "Déplacer {{count}} tâche(s) vers « {{board}} » ? Les relations peuvent être supprimées.",
     "copiedCount": "{{count}} tâche(s) dupliquée(s)",
     "archivedCount": "{{count}} tâche(s) archivée(s)",

--- a/src/utils/kanbanMultiSelect.ts
+++ b/src/utils/kanbanMultiSelect.ts
@@ -80,6 +80,49 @@ export function orderedCheckedTasksInColumn(
     .sort((a, b) => (Number(a.position) || 0) - (Number(b.position) || 0));
 }
 
+/** sessionStorage: survive refresh in this tab; cleared on tab close. */
+export const KANBAN_MULTISELECT_SESSION_KEY = 'agila:kanbanMultiSelect';
+
+export type KanbanMultiSelectSession = {
+  boardId: string;
+  taskIds: string[];
+};
+
+export function readKanbanMultiSelectSession(): KanbanMultiSelectSession | null {
+  try {
+    const raw = sessionStorage.getItem(KANBAN_MULTISELECT_SESSION_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    const boardId = typeof parsed?.boardId === 'string' ? parsed.boardId : '';
+    const taskIds = Array.isArray(parsed?.taskIds)
+      ? parsed.taskIds.filter((id: unknown) => typeof id === 'string' && id)
+      : [];
+    if (!boardId || taskIds.length === 0) return null;
+    return { boardId, taskIds };
+  } catch {
+    return null;
+  }
+}
+
+export function writeKanbanMultiSelectSession(
+  boardId: string | null | undefined,
+  taskIds: Set<string>
+): void {
+  try {
+    if (!boardId || taskIds.size === 0) {
+      sessionStorage.removeItem(KANBAN_MULTISELECT_SESSION_KEY);
+      return;
+    }
+    const payload: KanbanMultiSelectSession = {
+      boardId,
+      taskIds: Array.from(taskIds),
+    };
+    sessionStorage.setItem(KANBAN_MULTISELECT_SESSION_KEY, JSON.stringify(payload));
+  } catch {
+    /* private mode / quota */
+  }
+}
+
 export function pruneCheckedTaskIds(
   checkedTaskIds: Set<string>,
   columns: Columns


### PR DESCRIPTION
## Summary
- Trash/purge no longer waits on a full board reload or per-task column renumber.
- Multi-select checks survive refresh in the same tab and clear on board switch.
- Bulk delete confirm is a centered overlay; keyboard card-move shows a top hint banner.

## Test plan
- [ ] Delete a task to trash and purge one — UI should feel immediate.
- [ ] Select 2+ cards, refresh, selection remains; switch board, selection clears.
- [ ] Bulk delete shows a centered confirm dialog.
- [ ] Focus a card, press Enter, see the move banner; Esc/Enter to exit.


Made with [Cursor](https://cursor.com)