### PR TITLE
Bump nanoid to 3.3.18 (npm audit high)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8243,9 +8243,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- Updates transitive `nanoid` to 3.3.18 so `npm audit --audit-level=high` is clean.

## Test plan
- [ ] CI `npm audit --audit-level=high` passes.


Made with [Cursor](https://cursor.com)