### PR TITLE
Agent automation, sprint badge clicks, and demo/dev updates

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -72,6 +72,10 @@ services:
       - PORT=8080
       - MAX_CONCURRENT=1
       - RUNNER_TOKEN=${RUNNER_TOKEN:-kanban-runner-dev-token-change-me}
+    volumes:
+      # Live prompt/tool schemas in local Docker
+      - ./runner/src:/app/src
+    command: ["node", "--watch", "src/index.js"]
     # Internal only — no host ports
     restart: unless-stopped
 

--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -58,6 +58,9 @@ services:
       - PORT=8080
       - MAX_CONCURRENT=1
       - RUNNER_TOKEN=${RUNNER_TOKEN:-kanban-runner-dev-token-change-me}
+    volumes:
+      - ./runner/src:/app/src
+    command: ["node", "--watch", "src/index.js"]
     # Internal only — no host ports
     restart: unless-stopped
 

--- a/runner/src/agentLoop.js
+++ b/runner/src/agentLoop.js
@@ -20,6 +20,7 @@ import {
 } from './git.js';
 import { updateJob, removeJob } from './jobQueue.js';
 import { runAutomationJob } from './automationLoop.js';
+import { replyLanguageInstruction } from './replyLanguage.js';
 
 const execFileAsync = promisify(execFile);
 const MAX_STEPS = 40;
@@ -178,6 +179,7 @@ function buildSystemPrompt(payload, agentsMd) {
     'You are the Easy Kanban coding agent. Implement the assigned task in this git repository.',
     'Use tools to explore and edit files. Prefer small, focused changes.',
     'When done, call the finish tool with a short summary for stakeholders (outcome only; no chain-of-thought or step-by-step diary).',
+    replyLanguageInstruction(payload),
     'Never include <think> or reasoning blocks in tool arguments or summaries.',
     'Do not print secrets. Do not access paths outside the repo.',
     agentsMd ? `Repository AGENTS.md:\n${agentsMd.slice(0, 12000)}` : '',
@@ -206,7 +208,8 @@ async function runAssistJob(job, payload) {
       content:
         'You are a helpful engineering assistant for Easy Kanban. ' +
         'Answer based on the task title, description, and comments. Use Markdown. ' +
-        'Do not invent repo file contents you have not seen. ' +
+        replyLanguageInstruction(payload) +
+        ' Do not invent repo file contents you have not seen. ' +
         'Reply with the final answer only — no chain-of-thought, <think> blocks, or hidden reasoning. ' +
         'Match the user\'s requested brevity: if they ask for a short or literal reply (e.g. "say hello"), ' +
         'output only that. Do not add Summary, Guidance, Questions, Next steps, or similar meta sections unless asked.'

--- a/runner/src/automationLoop.js
+++ b/runner/src/automationLoop.js
@@ -8,6 +8,7 @@ import { stripModelReasoning } from './stripReasoning.js';
 import { sendCallback } from './callback.js';
 import { updateJob, removeJob } from './jobQueue.js';
 import { AUTOMATION_MAX_TOOL_STEPS } from './automationConstants.js';
+import { replyLanguageInstruction } from './replyLanguage.js';
 
 const MAX_STEPS = AUTOMATION_MAX_TOOL_STEPS || 40;
 
@@ -54,7 +55,7 @@ const TOOLS = [
   {
     name: 'search_tasks',
     description:
-      'Search tasks in scope. Excludes the automation launch task. Returns compact rows with boardTitle, columnTitle, and descriptionPreview (first 500 chars) so you usually do NOT need get_task for each match. Filter by boardId, sprintId, columnId, text, assigneeId, tagId. Set includeDescription:false only if you need ids only. Use boardTitle in summaries; boardId only in tool args.',
+      'Search live tasks in scope (trash is excluded by default). Excludes the automation launch task. Returns compact rows with boardTitle, columnTitle, and descriptionPreview. Set trashOnly:true (or includeTrash:true) only when the user asked to find or recover tasks from trash. Then use restore_tasks.',
     parameters: {
       type: 'object',
       properties: {
@@ -65,7 +66,15 @@ const TOOLS = [
         assigneeId: { type: 'string' },
         tagId: { type: 'string' },
         limit: { type: 'number' },
-        includeDescription: { type: 'boolean' }
+        includeDescription: { type: 'boolean' },
+        includeTrash: {
+          type: 'boolean',
+          description: 'Include live and trashed tasks. Prefer trashOnly for recovery.'
+        },
+        trashOnly: {
+          type: 'boolean',
+          description: 'Search only tasks in trash (for recovery).'
+        }
       }
     }
   },
@@ -117,6 +126,19 @@ const TOOLS = [
         dryRun: { type: 'boolean' }
       },
       required: ['taskIds', 'fields']
+    }
+  },
+  {
+    name: 'restore_tasks',
+    description:
+      'Restore tasks from trash onto their board. Use only when the user asked to recover trashed work. Discover with search_tasks trashOnly:true first. Use dryRun:true while planning.',
+    parameters: {
+      type: 'object',
+      properties: {
+        taskIds: { type: 'array', items: { type: 'string' } },
+        dryRun: { type: 'boolean' }
+      },
+      required: ['taskIds']
     }
   },
   {
@@ -353,6 +375,35 @@ async function applyPlan(automation) {
   return body;
 }
 
+const AGENT_MEMBER_ID = '00000000-0000-0000-0000-000000000011';
+
+function commentPlainText(c) {
+  return String(c?.text || '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function isAgentComment(c) {
+  const authorId = String(c?.authorId || '').trim();
+  if (authorId && authorId === AGENT_MEMBER_ID) return true;
+  const author = String(c?.author || '').trim().toLowerCase();
+  return author === 'agent' || author.endsWith(' agent');
+}
+
+/** Human comments posted after the last Agent reply — this run's instruction. */
+function thisTurnHumanComments(payload) {
+  const comments = Array.isArray(payload.comments) ? payload.comments : [];
+  let lastAgent = -1;
+  for (let i = comments.length - 1; i >= 0; i--) {
+    if (isAgentComment(comments[i])) {
+      lastAgent = i;
+      break;
+    }
+  }
+  return comments.slice(lastAgent + 1).filter((c) => !isAgentComment(c) && commentPlainText(c));
+}
+
 function buildContext(payload) {
   const boards = payload.automation?.boards;
   const boardLines =
@@ -364,15 +415,23 @@ function buildContext(payload) {
         ? `Board IDs: ${payload.automation.boardIds.join(', ')}`
         : '';
 
+  const thisTurn = thisTurnHumanComments(payload);
+  const thisTurnBlock = thisTurn.length
+    ? `This run's human messages (since last Agent reply) — this is the current instruction:\n${thisTurn
+        .map((c) => `- ${c.author || 'user'}: ${commentPlainText(c)}`)
+        .join('\n')}`
+    : 'This run has no new human comments since the last Agent reply. Execute the standing recipe.';
+
   return [
     `Task ticket: ${payload.ticket || '(none)'}`,
     `Title: ${payload.title || ''}`,
-    `Description:\n${payload.description || '(none)'}`,
+    `Standing recipe (task description):\n${payload.description || '(none)'}`,
+    thisTurnBlock,
     `Scope: ${payload.automation?.scopeType || 'this_board'}`,
     boardLines,
     payload.comments?.length
-      ? `Recent comments:\n${payload.comments
-          .map((c) => `- ${c.author || 'user'}: ${c.text}`)
+      ? `Full thread (context only — do not re-do already completed Agent work unless this run asks):\n${payload.comments
+          .map((c) => `- ${c.author || 'user'}: ${commentPlainText(c)}`)
           .join('\n')
           .slice(0, 6000)}`
       : ''
@@ -408,15 +467,19 @@ export async function runAutomationJob(job) {
     'You are the Easy Kanban Automation agent (admin-only board operations).',
     'Discover data with list/search tools, then plan mutations with dryRun:true.',
     'Never delete tasks, boards, or columns — those are denied.',
+    'search_tasks excludes trash by default. Only use trashOnly/includeTrash when the user asked to find or recover trashed tasks; then restore_tasks (not update/move).',
     'The automation launch task (this recipe card) is NEVER a target: search/get/move/update skip it automatically. Do not try to move or edit it.',
     'Prefer search_tasks for analysis — results include descriptionPreview, boardTitle, and columnTitle. Avoid calling get_task once per match; use get_tasks only when you need fuller fields for a small set.',
     'When names are ambiguous, prefer IDs from list tools; refuse to guess.',
     'In human-facing text (submit_dry_run_plan summary, finish, comments), always use board titles and column titles — never raw board/column UUIDs. Keep using IDs only in tool arguments.',
+    replyLanguageInstruction(payload),
     'When the plan is ready, call submit_dry_run_plan with a clear summary and operations array',
     '(operations should use dryRun:false arguments — the server applies them only after admin Apply).',
     'If there is nothing to change, submit_dry_run_plan with an empty operations array, then call finish immediately (no Apply).',
     'After submit_dry_run_plan with non-empty operations you will wait; do not mutate further until told Apply succeeded.',
     'Finally call finish with a human summary.',
+    'The standing recipe is the default job when this run has no new human comments.',
+    'If this run has new human comments, that is the current instruction. Use the full thread as context (follow-ups like "those", "also", questions). Do not also execute the recipe in the same run unless they asked. If the new instruction conflicts with the recipe, follow this run.',
     'Reply with tool calls only when acting; keep summaries concise.',
     buildContext(payload)
   ].join('\n\n');
@@ -426,7 +489,7 @@ export async function runAutomationJob(job) {
     {
       role: 'user',
       content:
-        'Execute the automation described in the task. Discover first, then submit_dry_run_plan.'
+        'Follow the current instruction in context (this run vs standing recipe). Discover with tools first. For trash/recovery, use search_tasks with trashOnly:true then restore_tasks. Then submit_dry_run_plan.'
     }
   ];
 
@@ -492,6 +555,7 @@ export async function runAutomationJob(job) {
         'rename_column',
         'create_board',
         'rename_board',
+        'restore_tasks',
         'add_comment',
         'export_tasks_xlsx',
         'export_tasks_csv'
@@ -515,8 +579,7 @@ export async function runAutomationJob(job) {
             await sendCallback(job, {
               event: 'progress',
               progress: 90,
-              log: `[runner] Empty plan — nothing to apply; finishing`,
-              comment: summaryText
+              log: `[runner] Empty plan — nothing to apply; finishing`
             });
             messages.push({
               role: 'tool',

--- a/runner/src/replyLanguage.js
+++ b/runner/src/replyLanguage.js
@@ -1,0 +1,13 @@
+/**
+ * Human-facing Agent replies follow the owner's preferred language (en|fr).
+ */
+export function replyLanguageInstruction(payload) {
+  const raw = String(payload?.replyLanguage || 'en').toLowerCase();
+  const lang = raw.startsWith('fr') ? 'fr' : 'en';
+  const name = lang === 'fr' ? 'French' : 'English';
+  return (
+    `Write all human-facing text (finish summaries, dry-run plan summaries, comments) in ${name} ` +
+    `(user preferred language: ${lang}). Keep board, column, and task titles exactly as stored. ` +
+    `Tool names and JSON argument keys stay as specified.`
+  );
+}

--- a/server/constants/automation.js
+++ b/server/constants/automation.js
@@ -62,6 +62,7 @@ export const AUTOMATION_CAPABILITIES = Object.freeze({
     'create_task',
     'update_tasks',
     'move_tasks',
+    'restore_tasks',
     'create_sprint',
     'update_sprint',
     'set_task_sprint',

--- a/server/routes/agentRunnerCallback.js
+++ b/server/routes/agentRunnerCallback.js
@@ -105,7 +105,17 @@ router.post('/callback', async (req, res) => {
         // Agent replies are Markdown; TipTap UI expects HTML
         const cleaned = stripModelReasoning(String(body.comment));
         const htmlBody = markdownToHtml(cleaned || String(body.comment));
-        await commentQueries.createComment(
+        const normalizeComment = (s) =>
+          String(s || '')
+            .replace(/<[^>]+>/g, ' ')
+            .replace(/\s+/g, ' ')
+            .trim();
+        const existingComments = await commentQueries.getCommentsForTask(db, taskId);
+        const lastAgent = [...existingComments].reverse().find((c) => c.authorId === AGENT_MEMBER_ID);
+        if (lastAgent && normalizeComment(lastAgent.text) === normalizeComment(htmlBody)) {
+          // Same summary posted twice (empty-plan progress + done)
+        } else {
+          await commentQueries.createComment(
           db,
           commentId,
           taskId,
@@ -133,6 +143,7 @@ router.post('/callback', async (req, res) => {
           'agent comment',
           { db, tenantId, commentContent: htmlBody }
         ).catch((err) => console.error('Agent comment activity log failed:', err));
+        }
       } catch (e) {
         console.error('Runner callback comment error:', e);
       }

--- a/server/services/agentJobDispatcher.js
+++ b/server/services/agentJobDispatcher.js
@@ -30,6 +30,7 @@ import {
   AUTOMATION_SCOPE
 } from '../constants/automation.js';
 import { wrapQuery } from '../utils/queryLogger.js';
+import { resolveCorrespondenceLanguage } from '../utils/i18n.js';
 
 async function getSetting(db, key) {
   const { getDecryptedSetting } = await import('../utils/settingsSecrets.js');
@@ -158,6 +159,7 @@ export async function launchSingleTask(db, tenantId, taskId, ctx = {}) {
     ? task.comments.slice(-20).map((c) => ({
         text: c.text || c.content || '',
         author: c.author_name || c.authorName || c.name || '',
+        authorId: c.author_id || c.authorId || '',
         createdAt: c.created_at || c.createdAt
       }))
     : [];
@@ -171,6 +173,7 @@ export async function launchSingleTask(db, tenantId, taskId, ctx = {}) {
         commentList = rows.slice(-20).map((c) => ({
           text: c.text || '',
           author: c.authorName || c.author_name || c.name || '',
+          authorId: c.authorId || c.author_id || '',
           createdAt: c.createdAt || c.created_at
         }));
       }
@@ -293,6 +296,7 @@ export async function launchSingleTask(db, tenantId, taskId, ctx = {}) {
     repoBranch: mode === AUTOMATION_MODE ? '' : work.repo_branch || '',
     mode,
     ownerUserId,
+    replyLanguage: await resolveCorrespondenceLanguage(db, ownerUserId || null),
     githubToken: mode === AUTOMATION_MODE ? '' : githubToken,
     sshPrivateKey: mode === AUTOMATION_MODE ? '' : sshPrivateKey,
     llm: {

--- a/server/services/automationTools.js
+++ b/server/services/automationTools.js
@@ -106,6 +106,11 @@ function compactTask(task, { includeDescription = false } = {}) {
     base.descriptionPreview = plain.slice(0, 500);
     base.descriptionLength = plain.length;
   }
+  const deletedAt = task.deleted_at || task.deletedAt || null;
+  if (deletedAt) {
+    base.inTrash = true;
+    base.deletedAt = deletedAt;
+  }
   return base;
 }
 
@@ -151,6 +156,10 @@ async function enrichTaskTitles(ctx, task) {
 /** Never mutate/search the automation launch card itself (avoids self-matching the recipe text). */
 function isLaunchTask(ctx, taskId) {
   return Boolean(ctx.launchTaskId && taskId && String(taskId) === String(ctx.launchTaskId));
+}
+
+function isTaskInTrash(task) {
+  return Boolean(task && (task.deleted_at || task.deletedAt));
 }
 
 function filterOutLaunchTaskIds(ctx, taskIds) {
@@ -370,6 +379,14 @@ async function searchTasksInternal(ctx, args = {}, allowedBoardIds) {
   conditions.push(`t.boardid IN (${scopePlaceholders})`);
   params.push(...scopeIds);
 
+  const trashOnly = args.trashOnly === true;
+  const includeTrash = trashOnly || args.includeTrash === true;
+  if (trashOnly) {
+    conditions.push('t.deleted_at IS NOT NULL');
+  } else if (!includeTrash) {
+    conditions.push('t.deleted_at IS NULL');
+  }
+
   if (args.sprintId) {
     conditions.push(`t.sprint_id = $${idx++}`);
     params.push(args.sprintId);
@@ -400,7 +417,7 @@ async function searchTasksInternal(ctx, args = {}, allowedBoardIds) {
   params.push(limit);
   const query = `
     SELECT t.id, t.ticket, t.title, t.boardid, t.columnid, t.sprint_id, t.memberid, t.priority, t.description,
-           b.title AS board_title, c.title AS column_title
+           t.deleted_at, b.title AS board_title, c.title AS column_title
     FROM tasks t
     LEFT JOIN boards b ON b.id = t.boardid
     LEFT JOIN columns c ON c.id = t.columnid
@@ -429,7 +446,8 @@ async function searchTasksInternal(ctx, args = {}, allowedBoardIds) {
     excludedLaunchTask: Boolean(ctx.launchTaskId),
     note: ctx.launchTaskId
       ? 'The automation launch task itself is excluded from search results. Prefer boardTitle/columnTitle in human summaries.'
-      : 'Prefer boardTitle/columnTitle in human summaries; use boardId/columnId only in tool arguments.'
+      : 'Prefer boardTitle/columnTitle in human summaries; use boardId/columnId only in tool arguments.',
+    trash: trashOnly ? 'only' : includeTrash ? 'include' : 'exclude'
   };
 }
 
@@ -625,6 +643,12 @@ async function toolUpdateTasks(ctx, args, { dryRun }, allowedBoardIds) {
     const before = await taskQueries.getTaskById(ctx.db, taskId);
     if (!before) return { error: `Task not found: ${taskId}` };
     assertTaskInScope(ctx, before, allowedBoardIds);
+    if (isTaskInTrash(before)) {
+      return {
+        error: `Task ${taskId} is in trash — use restore_tasks first (or search with trashOnly:true)`,
+        inTrash: true
+      };
+    }
     wouldAffect.push({ taskId, before: taskSnapshot(before), after: { ...taskSnapshot(before), ...updates } });
   }
 
@@ -674,6 +698,12 @@ async function toolMoveTasks(ctx, args, { dryRun }, allowedBoardIds) {
     const task = await taskQueries.getTaskById(ctx.db, taskId);
     if (!task) return { error: `Task not found: ${taskId}` };
     assertTaskInScope(ctx, task, allowedBoardIds);
+    if (isTaskInTrash(task)) {
+      return {
+        error: `Task ${taskId} is in trash — use restore_tasks first (or search with trashOnly:true)`,
+        inTrash: true
+      };
+    }
 
     const taskBoard = taskBoardId(task);
     if (taskBoard !== targetBoardId && taskBoard !== column.boardId) {
@@ -726,6 +756,123 @@ async function toolMoveTasks(ctx, args, { dryRun }, allowedBoardIds) {
   }
 
   return { moved: wouldAffect.map((w) => w.taskId), skippedLaunchTask: skippedLaunchTask || undefined };
+}
+
+async function toolRestoreTasks(ctx, args, { dryRun }, allowedBoardIds) {
+  const rawIds = args?.taskIds;
+  if (!Array.isArray(rawIds) || !rawIds.length) {
+    return { error: 'taskIds array is required' };
+  }
+  const { taskIds, skippedLaunchTask } = filterOutLaunchTaskIds(ctx, rawIds);
+  if (!taskIds.length) {
+    return {
+      error: 'No restorable tasks after excluding the automation launch task',
+      skippedLaunchTask: true
+    };
+  }
+
+  const wouldAffect = [];
+  const skippedLive = [];
+  for (const taskId of taskIds) {
+    const task = await taskQueries.getTaskById(ctx.db, taskId);
+    if (!task) return { error: `Task not found: ${taskId}` };
+    assertTaskInScope(ctx, task, allowedBoardIds);
+    if (!isTaskInTrash(task)) {
+      skippedLive.push(taskId);
+      continue;
+    }
+
+    const boardId = taskBoardId(task);
+    const board = await boardQueries.getBoardById(ctx.db, boardId);
+    if (!board || board.deleted_at || board.deletedAt) {
+      return {
+        error: `Restore the board before restoring task ${taskId}`,
+        code: 'board_soft_deleted'
+      };
+    }
+
+    const originalColumnId = taskColumnId(task);
+    const boardColumns = await helpers.getColumnsForBoard(ctx.db, boardId);
+    let columnId = originalColumnId;
+    const colOnBoard = (boardColumns || []).find((c) => c.id === columnId);
+    if (!colOnBoard) {
+      const fallback = (boardColumns || []).find(
+        (c) => !(c.is_archived === true || c.is_archived === 1)
+      );
+      if (!fallback) {
+        return { error: `No column available to restore task ${taskId}` };
+      }
+      columnId = fallback.id;
+    }
+
+    wouldAffect.push({
+      taskId,
+      boardId,
+      columnId,
+      originalPosition: Number(task.position),
+      before: taskSnapshot(task)
+    });
+  }
+
+  if (!wouldAffect.length) {
+    return {
+      restored: [],
+      skippedLive,
+      skippedLaunchTask: skippedLaunchTask || undefined,
+      note: 'No tasks were in trash'
+    };
+  }
+
+  if (dryRun) {
+    return {
+      wouldAffect: wouldAffect.map((w) => ({
+        taskId: w.taskId,
+        boardId: w.boardId,
+        columnId: w.columnId
+      })),
+      skippedLive,
+      dryRun: true,
+      skippedLaunchTask: skippedLaunchTask || undefined
+    };
+  }
+
+  const restoredIds = [];
+  for (const item of wouldAffect) {
+    const origPos = Number.isFinite(item.originalPosition) ? item.originalPosition : NaN;
+    let position = origPos;
+    if (Number.isFinite(origPos) && origPos >= 0) {
+      await taskQueries.shiftLiveTasksFromPosition(ctx.db, item.columnId, origPos);
+    } else {
+      const maxPos = await taskQueries.getMaxLivePositionInColumn(ctx.db, item.columnId);
+      position = maxPos + 1;
+    }
+    const restored = await taskQueries.restoreTask(
+      ctx.db,
+      item.taskId,
+      item.columnId,
+      item.boardId,
+      position
+    );
+    if (!restored) continue;
+    await enrichTaskTitles(ctx, restored);
+    await journal(ctx, 'restore_task', 'task', item.taskId, item.before, taskSnapshot(restored));
+    await notificationService.publish(
+      'task-restored',
+      {
+        boardId: item.boardId,
+        task: restored,
+        timestamp: new Date().toISOString()
+      },
+      ctx.tenantId || null
+    );
+    restoredIds.push(item.taskId);
+  }
+
+  return {
+    restored: restoredIds,
+    skippedLive,
+    skippedLaunchTask: skippedLaunchTask || undefined
+  };
 }
 
 async function toolCreateSprint(ctx, args, { dryRun }) {
@@ -1453,6 +1600,8 @@ export async function executeTool(ctx, name, args = {}, { dryRun = false } = {})
         return await toolUpdateTasks(ctx, args, opts, allowedBoardIds);
       case 'move_tasks':
         return await toolMoveTasks(ctx, args, opts, allowedBoardIds);
+      case 'restore_tasks':
+        return await toolRestoreTasks(ctx, args, opts, allowedBoardIds);
       case 'create_sprint':
         return await toolCreateSprint(ctx, args, opts);
       case 'update_sprint':
@@ -1546,6 +1695,9 @@ async function reverseJournalEntry(ctx, entry) {
         );
         await publishTaskUpdated(ctx, entityId, before.boardId);
       }
+      break;
+    case 'restore_task':
+      await taskQueries.softDeleteTask(ctx.db, entityId, ctx.userId || 'system');
       break;
     case 'create_task':
       await taskQueries.deleteTask(ctx.db, entityId);

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -2239,14 +2239,15 @@ const TaskCard = React.memo(function TaskCard({
           const displayName = sprintName.length > 20 ? sprintName.substring(0, 17) + '...' : sprintName;
           
           return (
-            <div className="flex justify-end mb-2" data-sprint-badge="true">
+            <div className="mb-2 flex justify-end">
               <KanbanChromeTooltip
                 label={t('taskCard.clickToSelectSprint')}
                 delayMs={0}
-                wrapperClassName="inline-flex max-w-full justify-end"
+                wrapperClassName="inline-flex max-w-full shrink-0"
               >
                 <span
                   ref={sprintBadgeRef}
+                  data-sprint-badge="true"
                   className={`px-2 py-0.5 rounded text-[10px] font-medium bg-indigo-100 text-indigo-700 max-w-full truncate transition-colors ${
                     allowMutations ? 'cursor-pointer hover:bg-indigo-200' : 'cursor-default'
                   }`}

--- a/src/components/tour/TourProvider.tsx
+++ b/src/components/tour/TourProvider.tsx
@@ -48,7 +48,10 @@ const TourProvider: React.FC<TourProviderProps> = ({ children, currentUser }) =>
         color: '#ffffff',
         fontSize: 14,
         fontWeight: 500,
-        padding: '8px 16px',
+        padding: '8px 12px',
+        whiteSpace: 'pre-line',
+        textAlign: 'center' as const,
+        lineHeight: 1.25,
       },
       buttonBack: {
         color: isDark ? '#9ca3af' : '#6b7280',

--- a/src/contexts/TourContext.tsx
+++ b/src/contexts/TourContext.tsx
@@ -150,7 +150,10 @@ export const TourProvider: React.FC<TourProviderProps> = ({ children, currentUse
         color: '#ffffff',
         fontSize: 14,
         fontWeight: 500,
-        padding: '8px 16px',
+        padding: '8px 12px',
+        whiteSpace: 'pre-line',
+        textAlign: 'center' as const,
+        lineHeight: 1.25,
       },
       buttonBack: {
         color: isDark ? '#9ca3af' : '#6b7280',

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1437,7 +1437,7 @@
     "close": "Close",
     "last": "Finish Tour",
     "next": "Next ↵",
-    "nextWithProgress": "Next ↵ (Step {step} of {steps})",
+    "nextWithProgress": "Next ↵\n(Step {step}/{steps})",
     "skip": "Skip Tour",
     "nudgeTitle": "Take a quick tour?",
     "nudgeDescription": "Learn the basics of boards, tasks, and views in a few steps. You can start the tutorial anytime from Help.",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -1437,7 +1437,7 @@
     "close": "Fermer",
     "last": "Terminer",
     "next": "Suivant ↵",
-    "nextWithProgress": "Suivant ↵ (Étape {step} de {steps})",
+    "nextWithProgress": "Suivant ↵\n(Étape {step}/{steps})",
     "skip": "Sortir",
     "nudgeTitle": "Faire une visite rapide ?",
     "nudgeDescription": "Découvrez les bases des tableaux, des tâches et des vues en quelques étapes. Vous pouvez relancer le tutoriel à tout moment depuis Aide.",


### PR DESCRIPTION
## Summary
- Agent automation: trash search/restore, no duplicate empty-plan comments, this-turn comments vs standing recipe, replies in the owner’s preferred language.
- Sprint badge hit target is only the chip, so clicks to the left still open task details.
- Local compose examples bind-mount runner source with `--watch`. Tour Next button wrapping.

## Test plan
- [ ] Recover from trash via an automation comment; follow-up comments keep thread context
- [ ] Agent comments are not duplicated on empty plans
- [ ] Agent summary matches Profile language (en/fr)
- [ ] Click left of sprint badge opens task details; click badge opens sprint picker
- [ ] Demo deploy on web01 after merge to main


Made with [Cursor](https://cursor.com)