### PR TITLE
Gate AI UI on plan (AI_TIER)

### DIFF
--- a/server/routes/settings.js
+++ b/server/routes/settings.js
@@ -13,6 +13,7 @@ import { AGENT_MEMBER_ID } from '../constants/agentIdentity.js';
 import { clearSqlDebugSettingsCache } from '../utils/sqlDebugSettingsCache.js';
 import { serverDebug } from '../utils/serverDebug.js';
 import { validateAiConnectivity, listAiModels } from '../utils/aiConnectivity.js';
+import { applyEffectiveAiEnabledToSettings, isAiAllowedByPlan } from '../utils/aiEnabled.js';
 import { AI_PROVIDER_PRESETS } from '../constants/aiProviders.js';
 import { isMaskedOrEmptyApiKey } from '../utils/maskSecret.js';
 import {
@@ -147,6 +148,7 @@ router.get('/', async (req, res, next) => {
     settings.forEach(setting => {
       settingsObj[setting.key] = setting.value;
     });
+    await applyEffectiveAiEnabledToSettings(db, settingsObj);
     // Per-tenant OAuth and site metadata must not be cached by browsers or intermediaries
     res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, private');
     res.json(settingsObj);
@@ -285,6 +287,8 @@ router.get('/', authenticateToken, requireRole(['admin']), async (req, res, next
         settingsObj.AI_RUNNER_TOKEN_SET = 'false';
       }
     }
+
+    await applyEffectiveAiEnabledToSettings(db, settingsObj);
     
     res.json(settingsObj);
   } catch (error) {
@@ -627,6 +631,9 @@ router.put('/', authenticateToken, requireRole(['admin']), async (req, res, next
 
     // Enabling AI requires a reachable configured provider (+ runner when configured)
     if (key === 'AI_ENABLED' && String(safeValue) === 'true') {
+      if (!(await isAiAllowedByPlan(db))) {
+        return res.status(403).json({ error: 'AI features are not available on this plan' });
+      }
       const creds = await resolveAiCredentials(db, {});
       const probe = await validateAiConnectivity(creds);
       if (!probe.ok) {

--- a/server/utils/aiEnabled.js
+++ b/server/utils/aiEnabled.js
@@ -60,6 +60,20 @@ export async function isAiEnabled(db) {
 }
 
 /**
+ * Present AI_ENABLED as off when the plan does not include AI, even if a leftover
+ * settings row is still "true" from before plan gating existed.
+ * @param {object} db
+ * @param {Record<string, string>} settingsObj
+ */
+export async function applyEffectiveAiEnabledToSettings(db, settingsObj) {
+  if (!settingsObj || typeof settingsObj !== 'object') return settingsObj;
+  if (!(await isAiAllowedByPlan(db))) {
+    settingsObj.AI_ENABLED = 'false';
+  }
+  return settingsObj;
+}
+
+/**
  * Factory that loads tenant DB and gates on plan + AI_ENABLED.
  * @param {Function} getRequestDatabase
  */


### PR DESCRIPTION
## Summary
- Public and admin settings return AI_ENABLED false when the plan does not allow AI.
- Enabling AI via Admin is rejected on those plans.

## Test plan
- [ ] Basic tenant with leftover AI_ENABLED=true: no Help chatbot, no Profile Dev tab, no Admin AI subtab.
- [ ] Pro / self-host with AI_ENABLED true: AI UI still appears.


Made with [Cursor](https://cursor.com)