### PR TITLE
Update GitHub references in README and scripts to use 'drenlia-inc' f…

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ A collaborative **Kanban workspace** for teams: multi-board drag-and-drop, List 
 **Step 1: Clone and setup**
 ```bash
 # Clone the repo
-git clone https://github.com/drenlia/agila.git
+git clone https://github.com/drenlia-inc/agila.git
 cd agila
 cp docker-compose-example.yml docker-compose.yml
 ```

--- a/scripts/deploy-demo.sh
+++ b/scripts/deploy-demo.sh
@@ -13,7 +13,7 @@ ssh -o BatchMode=yes "$REMOTE" bash -s <<EOF
 set -euo pipefail
 cd ${DEST}
 
-git remote set-url origin https://github.com/Drenlia-Inc/agila.git
+git remote set-url origin https://github.com/drenlia-inc/agila.git
 git fetch origin main
 git checkout main
 git reset --hard origin/main

--- a/src/constants/brand.ts
+++ b/src/constants/brand.ts
@@ -3,7 +3,7 @@
  * Keep in sync with `server/constants/brand.js`.
  */
 
-export const AGILA_GITHUB_OWNER = 'drenlia';
+export const AGILA_GITHUB_OWNER = 'drenlia-inc';
 export const AGILA_GITHUB_REPO = 'agila';
 export const AGILA_GITHUB_URL = `https://github.com/${AGILA_GITHUB_OWNER}/${AGILA_GITHUB_REPO}`;
 export const AGILA_GITHUB_CLONE_URL = `${AGILA_GITHUB_URL}.git`;


### PR DESCRIPTION
…or consistency. Change AGILA_GITHUB_OWNER in brand constants to reflect the new organization name.