### PR TITLE
Improve profile save UX and pass app language into the customer portal

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ A collaborative **Kanban workspace** for teams: multi-board drag-and-drop, List 
 
 *[View sample screenshots →](/screenshots/SCREENSHOTS.md)*
 
+**Quick start (Docker):** `git clone https://github.com/drenlia-inc/agila.git && cd agila && cp docker-compose-example.yml docker-compose.yml && docker compose up --build` — then open http://localhost:3010. Default admin is created on first boot; see [Installation](#installation).
+
 ## Key Features
 
 ### Core Functionality
@@ -97,11 +99,7 @@ A collaborative **Kanban workspace** for teams: multi-board drag-and-drop, List 
 
 **Product Owners / Scrum Masters:** after the instance is up, follow the **[Delivery Playbook](docs/DELIVERY_PLAYBOOK.md)** (first-hour setup, board & WIP conventions, rituals, anti-patterns).
 
-**Default Admin Account:**
-- Email: `admin@kanban.local`
-- Password: `generated` at initialization - look for it in the backend console log (or on the login page when demo mode is enabled)
-
-1. Log in with the default admin account
+1. Log in with the default admin account (see [Installation](#installation))
 2. Go to the admin panel and setup:
    1. The site name and URL in Site Settings
    2. In the App Settings, choose the default language (FR/EN)
@@ -153,33 +151,41 @@ A collaborative **Kanban workspace** for teams: multi-board drag-and-drop, List 
 
 ## Installation
 
-### Docker
+### Docker (recommended)
 
-**Step 1: Clone and setup**
 ```bash
-# Clone the repo
 git clone https://github.com/drenlia-inc/agila.git
 cd agila
 cp docker-compose-example.yml docker-compose.yml
+docker compose up --build
 ```
 
-**Step 2: Configure and run**
-1. Edit `docker-compose.yml` and update the following environment variables:
-   - `JWT_SECRET`: Set a strong secret key for authentication
-   - `ALLOWED_ORIGINS`: Set your domain(s), e.g., `yourdomain.com`
-   - `DEMO_ENABLED`: Set to `true` to try the demo with generated data, `false` for production
-   - Optional AI runner (for Agent **Code** jobs): `AI_RUNNER_URL`, `AI_CALLBACK_BASE_URL`, `RUNNER_TOKEN` (see `docker-compose-example.yml` / `docker-compose-dev.yml`)
+(`npm run docker:dev` is the same command: `docker compose up --build`.)
 
-2. Start the application:
-```bash
-npm run docker:dev
+Before the first production run, edit `docker-compose.yml`:
+- `JWT_SECRET`: strong secret for authentication
+- `ALLOWED_ORIGINS`: your domain(s), e.g. `yourdomain.com`
+- `DEMO_ENABLED`: `false` for a real instance; `true` only for a generated demo dataset
+- Optional AI runner (Agent **Code** jobs): `AI_RUNNER_URL`, `AI_CALLBACK_BASE_URL`, `RUNNER_TOKEN`
+
+**Access:** frontend http://localhost:3010 · API http://localhost:3222
+
+More detail: [DOCKER.md](/DOCKER.md)
+
+### Default admin (first boot)
+
+On a **new empty database**, Agila creates `admin@kanban.local` with a **random password** and prints it **once** in the app container logs:
+
+```text
+Email: admin@kanban.local
+Password: <generated>
 ```
 
-**Access the application:**
-- Frontend: http://localhost:3010
-- Backend API: http://localhost:3222
+Follow the logs with `docker compose logs -f agila`.
 
-*For more Docker information, see [DOCKER.md](/DOCKER.md)*
+- **`DEMO_ENABLED=true`:** the login page also shows this password (and a one-click sign-in on the public demo).
+- **`DEMO_ENABLED=false`:** the password is **not** shown on the login page — only in those first-boot logs.
+- Later restarts **do not** print the password again. If you lose it, reset it from another admin account; it will not reappear in logs.
 
 ## Database Backup & Restore
 

--- a/server/constants/brand.js
+++ b/server/constants/brand.js
@@ -3,7 +3,9 @@
  * Keep in sync with `src/constants/brand.ts`.
  */
 
-export const AGILA_GITHUB_OWNER = 'drenlia';
+export const AGILA_GITHUB_OWNER = 'drenlia-inc';
 export const AGILA_GITHUB_REPO = 'agila';
 export const AGILA_GITHUB_URL = `https://github.com/${AGILA_GITHUB_OWNER}/${AGILA_GITHUB_REPO}`;
 export const AGILA_GITHUB_CLONE_URL = `${AGILA_GITHUB_URL}.git`;
+export const AGILA_GITHUB_IDEAS_URL = `${AGILA_GITHUB_URL}/discussions/categories/ideas`;
+export const AGILA_GITHUB_ISSUES_URL = `${AGILA_GITHUB_URL}/issues`;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import DebugPanel from './components/DebugPanel';
 import { ThemeProvider } from './contexts/ThemeContext';
 import { TourProvider } from './contexts/TourContext';
 import TourNudge from './components/tour/TourNudge';
+import MobileUnoptimizedBanner from './components/MobileUnoptimizedBanner';
 import { OwnerSetupProvider } from './contexts/OwnerSetupContext';
 import OwnerSetupChecklist from './components/ownerSetup/OwnerSetupChecklist';
 import { SettingsProvider, useSettings } from './contexts/SettingsContext';
@@ -4910,6 +4911,8 @@ function AppContent() {
         boards={boards}
         sprints={availableSprints}
       />
+
+      <MobileUnoptimizedBanner enabled={currentPage === 'kanban'} />
 
       {/* Network Status Indicator */}
       <NetworkStatusIndicator isOnline={isOnline} />

--- a/src/components/ActivityFeed.tsx
+++ b/src/components/ActivityFeed.tsx
@@ -837,9 +837,10 @@ const ActivityFeed: React.FC<ActivityFeedProps> = ({
         height: dimensions.height,
         zIndex: ACTIVITY_FEED_Z,
       }}
+      aria-label={t('activityFeed.title')}
     >
-      {/* Header */}
-      <div className="flex items-center gap-1.5 px-2.5 py-2 border-b border-slate-100 dark:border-slate-800 bg-slate-50/80 dark:bg-slate-950/40">
+      {/* Header: controls only (title is rarely visible over the board) */}
+      <div className="flex items-center gap-1.5 px-2.5 py-1.5 border-b border-slate-100 dark:border-slate-800 bg-slate-50/80 dark:bg-slate-950/40">
         <div 
           className="cursor-grab active:cursor-grabbing p-1 rounded-lg text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 hover:bg-slate-200/60 dark:hover:bg-slate-800"
           onMouseDown={handleDragStart}
@@ -848,14 +849,6 @@ const ActivityFeed: React.FC<ActivityFeedProps> = ({
         </div>
         
         <div className="flex items-center gap-2 flex-1 min-w-0">
-          <span className="shrink-0 flex h-6 w-6 items-center justify-center rounded-full bg-sky-100 dark:bg-sky-950/60 text-sky-600 dark:text-sky-400">
-            <Activity className="w-3.5 h-3.5" />
-          </span>
-          {!isExtraNarrowMode && (
-            <h3 className="font-semibold text-slate-900 dark:text-slate-100 text-xs truncate tracking-tight">
-              {isNarrowMode ? t('activityFeed.titleShort') : t('activityFeed.title')}
-            </h3>
-          )}
           {unreadCount > 0 && (
             <span className="shrink-0 min-w-[1.25rem] h-5 px-1.5 rounded-full bg-sky-600 text-white text-[10px] font-semibold leading-5 text-center tabular-nums">
               {unreadBadgeLabel}

--- a/src/components/MobileUnoptimizedBanner.tsx
+++ b/src/components/MobileUnoptimizedBanner.tsx
@@ -1,0 +1,87 @@
+import React, { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Smartphone, X } from 'lucide-react';
+
+const STORAGE_KEY = 'agila.mobileUnoptimizedDismissed';
+/** Tailwind `md` — phones and small portrait devices. */
+const MOBILE_QUERY = '(max-width: 767px)';
+
+type Props = {
+  /** Show only on the board after login. */
+  enabled: boolean;
+};
+
+function readDismissed(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+export default function MobileUnoptimizedBanner({ enabled }: Props) {
+  const { t } = useTranslation('common');
+  const [isMobile, setIsMobile] = useState(false);
+  const [dismissed, setDismissed] = useState(true);
+
+  useEffect(() => {
+    setDismissed(readDismissed());
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mq = window.matchMedia(MOBILE_QUERY);
+    const sync = () => setIsMobile(mq.matches);
+    sync();
+    mq.addEventListener('change', sync);
+    return () => mq.removeEventListener('change', sync);
+  }, []);
+
+  const dismiss = () => {
+    try {
+      localStorage.setItem(STORAGE_KEY, 'true');
+    } catch {
+      // ignore quota / private mode
+    }
+    setDismissed(true);
+  };
+
+  if (!enabled || !isMobile || dismissed) {
+    return null;
+  }
+
+  return (
+    <div
+      className="shrink-0 border-b border-amber-300/80 dark:border-amber-700/70 bg-amber-50 dark:bg-amber-950/50 px-3 py-2.5"
+      role="status"
+      aria-labelledby="mobile-unoptimized-title"
+      aria-describedby="mobile-unoptimized-body"
+    >
+      <div className="flex items-start gap-2.5 max-w-3xl mx-auto">
+        <Smartphone
+          className="w-4 h-4 mt-0.5 shrink-0 text-amber-700 dark:text-amber-400"
+          aria-hidden
+        />
+        <div className="min-w-0 flex-1">
+          <p
+            id="mobile-unoptimized-title"
+            className="text-sm font-semibold text-amber-950 dark:text-amber-100"
+          >
+            {t('mobileWarning.title')}
+          </p>
+          <p
+            id="mobile-unoptimized-body"
+            className="mt-0.5 text-xs text-amber-900/90 dark:text-amber-200/90 leading-snug"
+          >
+            {t('mobileWarning.body')}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={dismiss}
+          className="shrink-0 p-1 rounded-md text-amber-800 dark:text-amber-200 hover:bg-amber-200/70 dark:hover:bg-amber-900/80"
+          aria-label={t('mobileWarning.dismiss')}
+        >
+          <X size={16} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Profile.tsx
+++ b/src/components/Profile.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import { X, Upload, Trash2, ExternalLink } from 'lucide-react';
+import { X, Upload, Trash2, ExternalLink, Lightbulb, Bug } from 'lucide-react';
 import { uploadAvatar, deleteAccount, getUserSettings } from '../api';
 import {
   loadUserPreferences,
@@ -15,7 +15,8 @@ import { useSettings } from '../contexts/SettingsContext';
 import ProfileDevTab from './profile/ProfileDevTab';
 import { useEscapeDismiss } from '../hooks/useEscapeDismiss';
 import { setExplicitGuestLanguage } from '../utils/guestLanguage';
-import { userIsViewer } from '../utils/permissions';
+import { userIsViewer, userIsAdmin } from '../utils/permissions';
+import { agilaGithubFeedbackUrls } from '../constants';
 import { isDemoModeClient } from '../utils/demoReset';
 import { buildCustomerPortalUrl } from '../utils/customerPortalUrl';
 
@@ -32,6 +33,27 @@ const NOTIFICATION_PREF_KEYS: NotificationPreferenceKey[] = [
   'requesterTaskCreated',
   'requesterTaskUpdated',
 ];
+
+type ProfileFormSnapshot = {
+  displayName: string;
+  bio: string;
+};
+
+function snapshotOfProfileForm(data: ProfileFormSnapshot): string {
+  return JSON.stringify({
+    displayName: data.displayName.trim(),
+    bio: data.bio.trim(),
+  });
+}
+
+function displayNameFromSnapshot(snapshot: string): string {
+  try {
+    const parsed = JSON.parse(snapshot) as ProfileFormSnapshot;
+    return typeof parsed.displayName === 'string' ? parsed.displayName : '';
+  } catch {
+    return '';
+  }
+}
 
 interface ProfileProps {
   isOpen: boolean;
@@ -51,6 +73,8 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
   const { systemSettings: contextSystemSettings, siteSettings } = useSettings(); // Use SettingsContext instead of fetching
   const aiEnabled = siteSettings?.AI_ENABLED === 'true' || contextSystemSettings?.AI_ENABLED === 'true';
   const isViewOnlyUser = userIsViewer(currentUser);
+  const isAdminUser = userIsAdmin(currentUser);
+  const githubFeedback = agilaGithubFeedbackUrls(i18n.language);
   const [activeTab, setActiveTab] = useState<'profile' | 'app-settings' | 'notifications' | 'dev'>('profile');
   const [displayName, setDisplayName] = useState(currentUser?.firstName + ' ' + currentUser?.lastName || '');
   const [bio, setBio] = useState(currentUser?.bio || '');
@@ -83,7 +107,7 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
 
   const handleOpenCustomerPortal = () => {
     if (!websiteUrl) return;
-    const target = buildCustomerPortalUrl(websiteUrl, currentUser?.email);
+    const target = buildCustomerPortalUrl(websiteUrl, currentUser?.email, i18n.language);
     if (opensPortalInNewTab) {
       window.open(target, '_blank', 'noopener,noreferrer');
     } else {
@@ -97,10 +121,7 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
   const activityFeedPrefRef = useRef<HTMLDivElement>(null);
   const deleteConfirmationRef = useRef<HTMLInputElement>(null);
   
-  // Track original values to detect changes
-  const [originalDisplayName, setOriginalDisplayName] = useState(currentUser?.displayName || currentUser?.firstName + ' ' + currentUser?.lastName || '');
-  const [originalBio, setOriginalBio] = useState(currentUser?.bio || '');
-  const [originalAvatarUrl, setOriginalAvatarUrl] = useState(currentUser?.googleAvatarUrl || currentUser?.avatarUrl || '');
+  const [savedSnapshot, setSavedSnapshot] = useState('');
 
   // Load system settings when modal opens - use SettingsContext instead of fetching
   useEffect(() => {
@@ -164,14 +185,11 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
   useEffect(() => {
     if (isOpen && !isProfileBeingEdited) {
       const initialDisplayName = currentUser?.displayName || currentUser?.firstName + ' ' + currentUser?.lastName || '';
-      const initialAvatarUrl = currentUser?.googleAvatarUrl || currentUser?.avatarUrl || '';
       const initialBio = currentUser?.bio || '';
       
       setDisplayName(initialDisplayName);
-      setOriginalDisplayName(initialDisplayName);
       setBio(initialBio);
-      setOriginalBio(initialBio);
-      setOriginalAvatarUrl(initialAvatarUrl);
+      setSavedSnapshot(snapshotOfProfileForm({ displayName: initialDisplayName, bio: initialBio }));
       setSelectedFile(null);
       setPreviewUrl(null);
       setError(null);
@@ -195,18 +213,15 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
     }
   }, [aiEnabled, isViewOnlyUser, activeTab]);
 
-  // Monitor for changes to display name, bio, or avatar to set editing state
+  const isDirty =
+    savedSnapshot !== '' &&
+    (snapshotOfProfileForm({ displayName, bio }) !== savedSnapshot || selectedFile !== null);
+
   useEffect(() => {
     if (isOpen) {
-      const hasDisplayNameChanged = displayName.trim() !== originalDisplayName.trim();
-      const hasBioChanged = bio.trim() !== originalBio.trim();
-      const hasAvatarChanged = selectedFile !== null || 
-        (currentUser?.authProvider === 'local' && !currentUser?.avatarUrl && originalAvatarUrl);
-
-      const isEditing = hasDisplayNameChanged || hasBioChanged || hasAvatarChanged;
-      onProfileEditingChange(isEditing);
+      onProfileEditingChange(isDirty);
     }
-  }, [displayName, bio, selectedFile, originalDisplayName, originalBio, originalAvatarUrl, currentUser, isOpen, onProfileEditingChange]);
+  }, [isDirty, isOpen, onProfileEditingChange]);
 
   // Focus the requested field when the modal opens
   useEffect(() => {
@@ -299,6 +314,7 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
   // Handle form submission
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (!isDirty || isSubmitting) return;
     if (!displayName.trim()) {
       setError(t('profile.displayNameRequired'));
       return;
@@ -323,6 +339,9 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
         }
       }
       
+      setSavedSnapshot(snapshotOfProfileForm({ displayName: displayName.trim(), bio: bio.trim() }));
+      setSelectedFile(null);
+
       // Call the callback to refresh user data AFTER all updates
       onProfileUpdated();
       
@@ -442,6 +461,27 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
     return 'system';
   };
 
+  const revertDisplayNameAndBlur = useCallback(() => {
+    setDisplayName(displayNameFromSnapshot(savedSnapshot));
+    setError(null);
+    displayNameRef.current?.blur();
+  }, [savedSnapshot]);
+
+  const handleDisplayNameKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      if (isDirty) {
+        e.currentTarget.form?.requestSubmit();
+      }
+      return;
+    }
+    if (e.key === 'Escape' && displayName.trim() !== displayNameFromSnapshot(savedSnapshot)) {
+      e.preventDefault();
+      e.stopPropagation();
+      revertDisplayNameAndBlur();
+    }
+  };
+
   const handleEscape = useCallback(() => {
     if (isSubmitting || isDeletingAccount) return;
     if (showDeleteConfirm) {
@@ -449,12 +489,29 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
       setDeleteConfirmation('');
       return;
     }
+    if (
+      document.activeElement === displayNameRef.current &&
+      displayName.trim() !== displayNameFromSnapshot(savedSnapshot)
+    ) {
+      revertDisplayNameAndBlur();
+      return;
+    }
     if (previewUrl) {
       URL.revokeObjectURL(previewUrl);
     }
     onProfileEditingChange(false);
     onClose();
-  }, [isSubmitting, isDeletingAccount, showDeleteConfirm, previewUrl, onProfileEditingChange, onClose]);
+  }, [
+    isSubmitting,
+    isDeletingAccount,
+    showDeleteConfirm,
+    previewUrl,
+    displayName,
+    savedSnapshot,
+    revertDisplayNameAndBlur,
+    onProfileEditingChange,
+    onClose,
+  ]);
 
   useEscapeDismiss(handleEscape, { enabled: isOpen });
 
@@ -542,12 +599,13 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
         onClick={e => e.stopPropagation()}
       >
         <div className="mt-3">
-          <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center justify-between mb-4">
             <h3 className="text-xl font-semibold text-gray-900 dark:text-gray-100">{t('profile.title')}</h3>
             <button
               onClick={handleClose}
               disabled={isSubmitting}
               className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 disabled:opacity-50 transition-colors"
+              aria-label={t('buttons.close')}
             >
               <X size={24} />
             </button>
@@ -604,7 +662,7 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
           {/* Profile Tab Content */}
           {activeTab === 'profile' && (
             <>
-              <form onSubmit={handleSubmit} className="space-y-4">
+              <form id="profile-settings-form" onSubmit={handleSubmit} className="space-y-4">
                 {/* Avatar + display name */}
                 <div className="flex items-start gap-3">
                   <div className="flex-shrink-0 relative">
@@ -621,22 +679,42 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
                     )}
                   </div>
 
-                  <div className="flex-1 min-w-0 space-y-2">
+                  <div className="min-w-0 space-y-2">
                     <div>
                       <label htmlFor="displayName" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                         {t('profile.displayName')}
                       </label>
-                      <input
-                        ref={displayNameRef}
-                        type="text"
-                        id="displayName"
-                        value={displayName}
-                        onChange={(e) => setDisplayName(e.target.value)}
-                        maxLength={30}
-                        className="w-full px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
-                        placeholder={t('profile.displayNamePlaceholder')}
-                        required
-                      />
+                      <div className="flex flex-wrap items-center gap-2">
+                        <input
+                          ref={displayNameRef}
+                          type="text"
+                          id="displayName"
+                          value={displayName}
+                          onChange={(e) => setDisplayName(e.target.value)}
+                          onKeyDown={handleDisplayNameKeyDown}
+                          maxLength={30}
+                          className="w-56 max-w-full px-3 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
+                          placeholder={t('profile.displayNamePlaceholder')}
+                          required
+                        />
+                        <button
+                          type="button"
+                          onClick={handleClose}
+                          disabled={isSubmitting}
+                          className="px-3 py-1.5 text-sm bg-gray-300 dark:bg-gray-600 text-gray-700 dark:text-gray-100 rounded-md hover:bg-gray-400 dark:hover:bg-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors disabled:opacity-50"
+                        >
+                          {t('buttons.cancel')}
+                        </button>
+                        <button
+                          type="submit"
+                          disabled={isSubmitting || !isDirty}
+                          className={`px-3 py-1.5 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors ${
+                            isSubmitting || !isDirty ? 'opacity-50 cursor-not-allowed' : ''
+                          }`}
+                        >
+                          {isSubmitting ? t('profile.saving') : t('buttons.save')}
+                        </button>
+                      </div>
                     </div>
                     {currentUser?.authProvider === 'local' && (
                       <div className="flex flex-wrap items-center gap-2">
@@ -697,28 +775,38 @@ export default function Profile({ isOpen, onClose, currentUser, onProfileUpdated
                     <div className="text-sm text-red-600 dark:text-red-300">{error}</div>
                   </div>
                 )}
-
-                {/* Action Buttons */}
-                <div className="flex space-x-3 pt-4">
-                  <button
-                    type="submit"
-                    disabled={isSubmitting}
-                    className={`flex-1 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors ${
-                      isSubmitting ? 'opacity-50 cursor-not-allowed' : ''
-                    }`}
-                  >
-                    {isSubmitting ? t('profile.saving') : t('profile.saveChanges')}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleClose}
-                    disabled={isSubmitting}
-                    className="flex-1 px-4 py-2 bg-gray-300 dark:bg-gray-600 text-gray-700 dark:text-gray-100 rounded-md hover:bg-gray-400 dark:hover:bg-gray-500 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-colors"
-                  >
-                    {t('buttons.cancel')}
-                  </button>
-                </div>
               </form>
+
+              {isAdminUser && !isViewOnlyUser && !isDemoModeClient() && (
+                <div className="mt-8 pt-6 border-t border-gray-200 dark:border-gray-700">
+                  <h4 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-1">
+                    {t('profile.communityFeedback')}
+                  </h4>
+                  <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
+                    {t('profile.communityFeedbackHint')}
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    <a
+                      href={githubFeedback.ideas}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-700"
+                    >
+                      <Lightbulb size={16} aria-hidden />
+                      {t('profile.suggestFeature')}
+                    </a>
+                    <a
+                      href={githubFeedback.issues}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium rounded-md border border-gray-300 dark:border-gray-600 text-gray-800 dark:text-gray-100 hover:bg-gray-50 dark:hover:bg-gray-700"
+                    >
+                      <Bug size={16} aria-hidden />
+                      {t('profile.reportBug')}
+                    </a>
+                  </div>
+                </div>
+              )}
 
               {/* Owner: customer portal. Demo: no self-delete (shared sandbox).
                   Everyone else: Danger Zone / self-delete when allowed.

--- a/src/components/admin/AdminLicensingTab.tsx
+++ b/src/components/admin/AdminLicensingTab.tsx
@@ -48,7 +48,7 @@ interface AdminLicensingTabProps {
 }
 
 const AdminLicensingTab: React.FC<AdminLicensingTabProps> = ({ currentUser, settings }) => {
-  const { t } = useTranslation('admin');
+  const { t, i18n } = useTranslation('admin');
   const [activeSubTab, setActiveSubTab] = useState<'overview' | 'subscription'>('overview');
   const [licenseInfo, setLicenseInfo] = useState<LicenseInfo | null>(null);
   const [loading, setLoading] = useState(true);
@@ -592,7 +592,7 @@ const AdminLicensingTab: React.FC<AdminLicensingTabProps> = ({ currentUser, sett
                 onClick={() => {
                   // Check SITE_OPENS_NEW_TAB setting (default to true if not set)
                   const opensInNewTab = settings?.SITE_OPENS_NEW_TAB === undefined || settings?.SITE_OPENS_NEW_TAB === 'true';
-                  const target = buildCustomerPortalUrl(websiteUrl, currentUser?.email);
+                  const target = buildCustomerPortalUrl(websiteUrl, currentUser?.email, i18n.language);
                   if (opensInNewTab) {
                     window.open(target, '_blank', 'noopener,noreferrer');
                   } else {

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect, useMemo } from 'react';
-import { Github, HelpCircle, LogOut, User, RefreshCw, UserPlus, Mail, X, Send, Monitor, MonitorOff, MoreHorizontal, Menu, Check, Eye, Shield } from 'lucide-react';
+import { Bug, Github, HelpCircle, Lightbulb, LogOut, User, RefreshCw, UserPlus, Mail, X, Send, Monitor, MonitorOff, MoreHorizontal, Menu, Check, Eye, Shield } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { CurrentUser, SiteSettings, TeamMember } from '../../types';
 import ThemeToggle from '../ThemeToggle';
@@ -16,6 +16,7 @@ import { toast } from '../../utils/toast';
 import { getAuthenticatedAvatarUrl } from '../../utils/authImageUrl';
 import {
   AGILA_GITHUB_URL,
+  agilaGithubFeedbackUrls,
   DEFAULT_SITE_LOGO,
   DEFAULT_SITE_LOGO_DARK,
   isPublicBrandAssetPath,
@@ -1036,7 +1037,7 @@ const Header: React.FC<HeaderProps> = ({
               {showProfileMenu && (
                 <div
                   role="menu"
-                  className="absolute right-0 top-full mt-2 min-w-[12rem] bg-white dark:bg-gray-800 rounded-lg shadow-lg z-[70] border border-gray-200 dark:border-gray-700"
+                  className="absolute right-0 top-full mt-2 min-w-[14rem] bg-white dark:bg-gray-800 rounded-lg shadow-lg z-[70] border border-gray-200 dark:border-gray-700"
                 >
                   <div className="border-b border-gray-100 px-4 py-2.5 dark:border-gray-700">
                     <div className="truncate text-sm font-medium text-gray-900 dark:text-gray-100">
@@ -1073,6 +1074,32 @@ const Header: React.FC<HeaderProps> = ({
                       <User size={18} />
                       {t('navigation.profile')}
                     </button>
+                    {isAdminAccount && !isViewOnlyAccount && !isDemoMode && (
+                      <>
+                        <a
+                          role="menuitem"
+                          href={agilaGithubFeedbackUrls(i18n.language).ideas}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={() => setShowProfileMenu(false)}
+                          className="w-full text-left px-4 py-2.5 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 flex items-center gap-2 transition-colors whitespace-nowrap"
+                        >
+                          <Lightbulb size={18} />
+                          {t('navigation.suggestFeature')}
+                        </a>
+                        <a
+                          role="menuitem"
+                          href={agilaGithubFeedbackUrls(i18n.language).issues}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={() => setShowProfileMenu(false)}
+                          className="w-full text-left px-4 py-2.5 text-sm font-medium text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-gray-700 flex items-center gap-2 transition-colors whitespace-nowrap"
+                        >
+                          <Bug size={18} />
+                          {t('navigation.reportBug')}
+                        </a>
+                      </>
+                    )}
                     <button
                       type="button"
                       role="menuitem"

--- a/src/components/profile/ProfileDevTab.tsx
+++ b/src/components/profile/ProfileDevTab.tsx
@@ -404,7 +404,10 @@ const ProfileDevTab: React.FC = () => {
       <section>
         <div className="mb-2">
           <h3 className="text-base font-medium text-gray-900 dark:text-gray-100">
-            {t('profile.devApiTokens')}
+            <span>{t('profile.devApiTokens')}</span>
+            <sup className="ml-1 text-[0.58em] font-medium uppercase tracking-[0.12em] text-slate-500 dark:text-gray-400">
+              {t('help.assistant.beta')}
+            </sup>
           </h3>
           <p className="mt-0.5 text-xs text-gray-500 dark:text-gray-400">
             {t('profile.devApiTokensHint')}

--- a/src/constants/brand.ts
+++ b/src/constants/brand.ts
@@ -7,3 +7,16 @@ export const AGILA_GITHUB_OWNER = 'drenlia-inc';
 export const AGILA_GITHUB_REPO = 'agila';
 export const AGILA_GITHUB_URL = `https://github.com/${AGILA_GITHUB_OWNER}/${AGILA_GITHUB_REPO}`;
 export const AGILA_GITHUB_CLONE_URL = `${AGILA_GITHUB_URL}.git`;
+export const AGILA_GITHUB_IDEAS_URL = `${AGILA_GITHUB_URL}/discussions/categories/ideas`;
+export const AGILA_GITHUB_ISSUES_URL = `${AGILA_GITHUB_URL}/issues`;
+
+/** GitHub.com has no locale in the URL; we localize the bug-report compose form. */
+export function agilaGithubFeedbackUrls(lang?: string): { ideas: string; issues: string } {
+  const fr = (lang || 'en').toLowerCase().startsWith('fr');
+  const issueTitle = fr ? 'Rapport de bogue' : 'Bug report';
+  const issueBody = fr
+    ? '## Description\n\n## Étapes pour reproduire\n1.\n2.\n\n## Comportement attendu\n\n## Déploiement (Docker, démo, auto-hébergé)\n'
+    : '## Description\n\n## Steps to reproduce\n1.\n2.\n\n## Expected behavior\n\n## Deploy (Docker, demo, self-hosted)\n';
+  const issues = `${AGILA_GITHUB_URL}/issues/new?title=${encodeURIComponent(issueTitle)}&body=${encodeURIComponent(issueBody)}`;
+  return { ideas: AGILA_GITHUB_IDEAS_URL, issues };
+}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,8 +1,11 @@
 export {
   AGILA_GITHUB_CLONE_URL,
+  AGILA_GITHUB_IDEAS_URL,
+  AGILA_GITHUB_ISSUES_URL,
   AGILA_GITHUB_OWNER,
   AGILA_GITHUB_REPO,
   AGILA_GITHUB_URL,
+  agilaGithubFeedbackUrls,
 } from './brand';
 
 // Application constants

--- a/src/hooks/useSocket.ts
+++ b/src/hooks/useSocket.ts
@@ -24,7 +24,7 @@ interface SocketEvents {
   'column:updated': (data: { column: any; timestamp: string }) => void;
   'column:deleted': (data: { columnId: string; boardId: string; timestamp: string }) => void;
   
-  // User presence events
+  // Board join/leave events
   'user:joined': (data: { userId: string; firstName: string; lastName: string; timestamp: string }) => void;
   'user:left': (data: { userId: string; firstName: string; lastName: string; timestamp: string }) => void;
   

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -22,6 +22,11 @@
     "continue": "Continue",
     "back": "Back"
   },
+  "mobileWarning": {
+    "title": "Not optimized for mobile yet",
+    "body": "Agila is designed for a larger screen. You can browse, but the board works best on a computer or tablet.",
+    "dismiss": "Dismiss"
+  },
   "labels": {
     "name": "Name",
     "title": "Title",
@@ -78,7 +83,9 @@
     "more": "More",
     "menu": "Menu",
     "github": "GitHub",
-    "profileMenu": "Account menu"
+    "profileMenu": "Account menu",
+    "suggestFeature": "Suggest a feature",
+    "reportBug": "Report a bug"
   },
   "theme": {
     "switchToDark": "Switch to dark mode",
@@ -190,6 +197,10 @@
   "profile": {
     "title": "User Settings",
     "profileSettings": "Profile Settings",
+    "communityFeedback": "Product feedback",
+    "communityFeedbackHint": "Opens GitHub.",
+    "suggestFeature": "Suggest a feature",
+    "reportBug": "Report a bug",
     "appSettings": "App Settings",
     "notifications": "Notifications",
     "profilePicture": "Profile Picture",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -22,6 +22,11 @@
     "continue": "Continuer",
     "back": "Retour"
   },
+  "mobileWarning": {
+    "title": "Pas encore adaptée au mobile",
+    "body": "Agila est conçue pour un écran plus large. Vous pouvez explorer, mais le tableau fonctionne mieux sur un ordinateur ou une tablette.",
+    "dismiss": "Fermer"
+  },
   "labels": {
     "name": "Nom",
     "title": "Titre",
@@ -78,7 +83,9 @@
     "more": "Plus",
     "menu": "Menu",
     "github": "GitHub",
-    "profileMenu": "Menu du compte"
+    "profileMenu": "Menu du compte",
+    "suggestFeature": "Suggérer une fonctionnalité",
+    "reportBug": "Signaler un bogue"
   },
   "theme": {
     "switchToDark": "Passer en mode sombre",
@@ -190,6 +197,10 @@
   "profile": {
     "title": "Paramètres utilisateur",
     "profileSettings": "Paramètres du profil",
+    "communityFeedback": "Retour produit",
+    "communityFeedbackHint": "Ouvre GitHub.",
+    "suggestFeature": "Suggérer une fonctionnalité",
+    "reportBug": "Signaler un bogue",
     "appSettings": "Paramètres de l'application",
     "notifications": "Notifications",
     "profilePicture": "Photo de profil",

--- a/src/utils/customerPortalUrl.ts
+++ b/src/utils/customerPortalUrl.ts
@@ -1,10 +1,16 @@
+/** agila.dev i18next query param (`lng`). */
+export function portalLngFromAppLanguage(language?: string | null): 'en' | 'fr' {
+  return String(language || '').toLowerCase().startsWith('fr') ? 'fr' : 'en';
+}
+
 /**
  * Build a marketing-site URL that opens the customer-portal sign-in modal
  * (and optionally prefills email), then returns to the portal dashboard.
  */
 export function buildCustomerPortalUrl(
   websiteUrl: string,
-  email?: string | null
+  email?: string | null,
+  language?: string | null
 ): string {
   const base = String(websiteUrl || '').trim();
   if (!base) return '';
@@ -22,6 +28,7 @@ export function buildCustomerPortalUrl(
 
   url.searchParams.set('login', '1');
   url.searchParams.set('returnTo', '/portal/dashboard');
+  url.searchParams.set('lng', portalLngFromAppLanguage(language));
 
   const trimmed = String(email || '')
     .trim()


### PR DESCRIPTION
## Summary
- Profile Save stays disabled until display name, bio, or avatar is dirty; Enter submits and Escape reverts the name field.
- Customer portal links include `lng` so owners opening agila.dev match the app language.
- Related chrome: compact activity-feed header, mobile unoptimized banner, GitHub feedback links, API tokens beta label.

## Test plan
- [ ] Open Profile: Save is disabled until a field changes; changing back disables Save again.
- [ ] Enter on display name saves when dirty; Escape reverts the name and blurs.
- [ ] From a French session, Open customer portal and confirm the sign-in modal is in French (after agila-web is deployed).

Made with [Cursor](https://cursor.com)