### PR TITLE
Shrink-mode description tooltips stay card-width and formatted

### DIFF
--- a/src/components/KanbanChromeTooltip.tsx
+++ b/src/components/KanbanChromeTooltip.tsx
@@ -95,6 +95,10 @@ type KanbanChromeTooltipProps = {
 const CHROME_TOOLTIP_WRAPPED_SURFACE_CLASS =
   `px-2 py-1.5 text-xs font-normal normal-case tracking-normal whitespace-pre-line text-left break-words leading-snug rounded shadow-lg ${CHROME_TOOLTIP_COLORS} ${CHROME_TOOLTIP_RING} pointer-events-none`;
 
+/** HTML preview (lists, breaks, tables) sized by maxWidth / widthAnchorRef. */
+const CHROME_TOOLTIP_HTML_SURFACE_CLASS =
+  `px-2 py-1.5 text-xs font-normal normal-case tracking-normal whitespace-normal text-left break-words leading-snug rounded shadow-lg ${CHROME_TOOLTIP_COLORS} ${CHROME_TOOLTIP_RING} pointer-events-none`;
+
 /**
  * App-wide chrome tooltips: inverted light/dark surface; optional delay (default ~native title).
  * Bubble is portaled to `document.body` so it is not trapped under sibling z-index.
@@ -176,11 +180,13 @@ export function KanbanChromeTooltip({
 
   // Board/column chrome often swaps label on select; leave tips open and they stick on the wrong tab.
   // Live labels (demo countdown) pass dismissOnLabelChange={false} so the bubble stays while hovering.
+  // Do not depend on `content`: callers often pass a new React node each render, which would
+  // hide the tip immediately (shrink description preview).
   useEffect(() => {
     if (!dismissOnLabelChange) return;
     hide();
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentional: reset only when tip copy changes
-  }, [label, content, dismissOnLabelChange]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- reset only when string label changes
+  }, [label, dismissOnLabelChange]);
 
   useEffect(() => {
     if (!hasBody) hide();
@@ -280,12 +286,14 @@ export function KanbanChromeTooltip({
   }
 
   const wrapToWidth = maxWidth != null || widthAnchorRef != null;
-  const tooltipClassName = content
-    ? interactive
-      ? CHROME_TOOLTIP_SELECTABLE_SURFACE_CLASS
-      : CHROME_TOOLTIP_RICH_SURFACE_CLASS
-    : wrapToWidth
-      ? CHROME_TOOLTIP_WRAPPED_SURFACE_CLASS
+  const tooltipClassName = wrapToWidth
+    ? content
+      ? CHROME_TOOLTIP_HTML_SURFACE_CLASS
+      : CHROME_TOOLTIP_WRAPPED_SURFACE_CLASS
+    : content
+      ? interactive
+        ? CHROME_TOOLTIP_SELECTABLE_SURFACE_CLASS
+        : CHROME_TOOLTIP_RICH_SURFACE_CLASS
       : label.includes('\n')
         ? CHROME_TOOLTIP_MULTILINE_SURFACE_CLASS
         : CHROME_TOOLTIP_SURFACE_CLASS;

--- a/src/components/ListView.tsx
+++ b/src/components/ListView.tsx
@@ -15,6 +15,7 @@ import { getLinkTarget, shouldOpenLinkInNewTab } from '../utils/linkUtils';
 import { truncateMemberName } from '../utils/memberUtils';
 import { commentTextToHtml } from '../utils/commentContent';
 import { generateUUID } from '../utils/uuid';
+import { truncateHtmlByChars } from '../utils/plainTextPreview';
 import MemberSearchList from './ui/MemberSearchList';
 import { CHROME_TOOLTIP_POPOVER_CLASS, CHROME_TOOLTIP_PANEL_SURFACE_CLASS, KanbanChromeTooltip } from './KanbanChromeTooltip';
 import AgentPanel from './AgentPanel';
@@ -2110,11 +2111,26 @@ export default function ListView({
                                 </div>
                               </div>
                             ) : (
+                              <KanbanChromeTooltip
+                                content={
+                                  taskViewMode === 'shrink' && task.description ? (
+                                    <div
+                                      className="chrome-tooltip-html-preview"
+                                      dangerouslySetInnerHTML={{
+                                        __html: truncateHtmlByChars(
+                                          buildListViewDescriptionHtml(task.description, siteSettings)
+                                        ),
+                                      }}
+                                    />
+                                  ) : undefined
+                                }
+                                maxWidth={280}
+                                wrapperClassName="block min-w-0"
+                              >
                               <div 
                                 className={`text-sm text-gray-500 dark:text-gray-400 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-600/60 rounded px-1 py-0.5 prose prose-sm dark:prose-invert max-w-none ${
                                   taskViewMode === 'shrink' ? 'task-description-shrink line-clamp-2 overflow-hidden' : 'break-words'
                                 }`} 
-                                title={task.description ? task.description.replace(/<[^>]*>/g, '') : ''}
                                 onClick={(e) => {
                                   e.stopPropagation();
                                   if ((e.target as HTMLElement).closest('a')) {
@@ -2151,6 +2167,7 @@ export default function ListView({
                                   __html: buildListViewDescriptionHtml(task.description, siteSettings),
                                 }}
                               />
+                              </KanbanChromeTooltip>
                             )
                           )}
                         </div>

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -27,6 +27,7 @@ import {
 } from '../api';
 import { generateTaskUrl } from '../utils/routingUtils';
 import { generateUUID } from '../utils/uuid';
+import { truncateHtmlByChars } from '../utils/plainTextPreview';
 import { mergeTaskTagsWithLiveData, getTagDisplayStyle } from '../utils/tagUtils';
 import { useSortable } from '@dnd-kit/sortable';
 import { useDroppable } from '@dnd-kit/core';
@@ -308,6 +309,22 @@ const TaskCard = React.memo(function TaskCard({
     return wrap.innerHTML;
   }, [task.description, taskAttachments, attachmentsLoaded, siteSettings?.SITE_OPENS_NEW_TAB]);
 
+  const shrinkTooltipHtml = useMemo(() => {
+    if (taskViewMode !== 'shrink' || !task.description) return '';
+    return truncateHtmlByChars(cardDescriptionHtml);
+  }, [taskViewMode, task.description, cardDescriptionHtml]);
+
+  const shrinkTooltipContent = useMemo(
+    () =>
+      shrinkTooltipHtml ? (
+        <div
+          className="chrome-tooltip-html-preview"
+          dangerouslySetInnerHTML={{ __html: shrinkTooltipHtml }}
+        />
+      ) : undefined,
+    [shrinkTooltipHtml]
+  );
+
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [editedTitle, setEditedTitle] = useState(task.title);
   const [isEditingEffort, setIsEditingEffort] = useState(false);
@@ -361,6 +378,7 @@ const TaskCard = React.memo(function TaskCard({
   const priorityDropdownRef = useRef<HTMLDivElement>(null);
   const clickTimerRef = useRef<NodeJS.Timeout | null>(null);
   const [cardElement, setCardElement] = useState<HTMLDivElement | null>(null);
+  const cardElRef = useRef<HTMLDivElement | null>(null);
   const isInteractingWithTagRef = useRef<boolean>(false); // Track if user is interacting with tags
   const isInteractingWithDropdownRef = useRef<boolean>(false); // Track if user is interacting with dropdowns (member, sprint, etc.)
   const isSelectingRef = useRef<boolean>(false); // Track if we're in the process of selecting this task
@@ -1533,6 +1551,7 @@ const TaskCard = React.memo(function TaskCard({
         ref={(node) => {
           setNodeRef(node);
           setCardElement(node);
+          cardElRef.current = node;
         }}
         style={{ 
           ...style, 
@@ -2169,11 +2188,8 @@ const TaskCard = React.memo(function TaskCard({
                 {...(isMultiSelectDragLocked ? {} : listeners)}
               >
                 <KanbanChromeTooltip
-                  label={
-                    taskViewMode === 'shrink' && task.description
-                      ? task.description.replace(/<[^>]*>/g, '')
-                      : ''
-                  }
+                  content={shrinkTooltipContent}
+                  widthAnchorRef={cardElRef}
                   wrapperClassName="block min-w-0"
                 >
                   <FirstLineEndAnchor

--- a/src/index.css
+++ b/src/index.css
@@ -355,6 +355,59 @@ body {
   overflow: hidden;
 }
 
+/* Shrink-mode hover preview: keep card HTML structure inside a card-width bubble */
+.chrome-tooltip-html-preview {
+  max-height: 12rem;
+  overflow: hidden;
+  word-break: break-word;
+  overflow-wrap: break-word;
+}
+
+.chrome-tooltip-html-preview p {
+  margin: 0.2em 0;
+}
+
+.chrome-tooltip-html-preview p:first-child {
+  margin-top: 0;
+}
+
+.chrome-tooltip-html-preview p:last-child {
+  margin-bottom: 0;
+}
+
+.chrome-tooltip-html-preview ul,
+.chrome-tooltip-html-preview ol {
+  margin: 0.2em 0;
+  padding-left: 1.25em;
+}
+
+.chrome-tooltip-html-preview li {
+  margin: 0;
+}
+
+.chrome-tooltip-html-preview table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 0.25em 0;
+}
+
+.chrome-tooltip-html-preview th,
+.chrome-tooltip-html-preview td {
+  border: 1px solid color-mix(in srgb, currentColor 35%, transparent);
+  padding: 0.15em 0.35em;
+  vertical-align: top;
+}
+
+.chrome-tooltip-html-preview img {
+  max-width: 100%;
+  max-height: 48px;
+  height: auto;
+  object-fit: cover;
+  border-radius: 2px;
+  display: block;
+  margin: 0.25em 0;
+}
+
 /* Compact image mode for inline editing in TaskCards */
 .ProseMirror .tiptap-image[data-compact="true"],
 .prose .tiptap-image[data-compact="true"] {

--- a/src/utils/plainTextPreview.ts
+++ b/src/utils/plainTextPreview.ts
@@ -1,0 +1,66 @@
+/** About 5–6 lines of 12px text at a typical Kanban card width. */
+export const SHRINK_CARD_TOOLTIP_MAX_CHARS = 220;
+
+export function htmlToPlainText(html: string): string {
+  return String(html || '')
+    .replace(/<br\s*\/?>/gi, ' ')
+    .replace(/<\/(p|div|li|h[1-6])>/gi, ' ')
+    .replace(/<[^>]*>/g, ' ')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function truncatePlainText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  return `${text.slice(0, Math.max(0, maxChars - 1)).trimEnd()}…`;
+}
+
+export function shrinkCardDescriptionPreview(html: string): string {
+  return truncatePlainText(htmlToPlainText(html), SHRINK_CARD_TOOLTIP_MAX_CHARS);
+}
+
+/** Keep lists, breaks, and tables; stop after a plain-text character budget. */
+export function truncateHtmlByChars(html: string, maxChars: number = SHRINK_CARD_TOOLTIP_MAX_CHARS): string {
+  if (typeof document === 'undefined') return html;
+  const root = document.createElement('div');
+  root.innerHTML = html;
+  const plain = (root.textContent || '').replace(/\s+/g, ' ').trim();
+  if (plain.length <= maxChars) return root.innerHTML;
+
+  let remaining = maxChars;
+  let cut = false;
+
+  const removeFollowing = (node: Node) => {
+    let current: Node | null = node;
+    while (current && current !== root) {
+      let sib = current.nextSibling;
+      while (sib) {
+        const next = sib.nextSibling;
+        sib.parentNode?.removeChild(sib);
+        sib = next;
+      }
+      current = current.parentNode;
+    }
+  };
+
+  const visit = (node: Node) => {
+    if (cut) return;
+    if (node.nodeType === Node.TEXT_NODE) {
+      const text = node.textContent || '';
+      if (text.length <= remaining) {
+        remaining -= text.length;
+        return;
+      }
+      node.textContent = `${text.slice(0, Math.max(0, remaining)).trimEnd()}…`;
+      remaining = 0;
+      cut = true;
+      removeFollowing(node);
+      return;
+    }
+    Array.from(node.childNodes).forEach(visit);
+  };
+
+  visit(root);
+  return root.innerHTML;
+}


### PR DESCRIPTION
## Summary
- Shrink/preview hover shows a card-width description tooltip with lists, line breaks, and tables.
- Caps length so the bubble does not span the viewport.
- Fixes the tooltip vanishing on hover (it was treating a new React node as a copy change).

## Test plan
- [ ] Board in Preview/shrink: hover a card with a long formatted description
- [ ] Tooltip is about card width, keeps bullets/breaks/tables, truncates
- [ ] Click still opens task details


Made with [Cursor](https://cursor.com)