### PR TITLE
Improve viewer UX, assignee pickers, and automation reliability

### DIFF
--- a/runner/src/automationLoop.js
+++ b/runner/src/automationLoop.js
@@ -11,6 +11,46 @@ import { AUTOMATION_MAX_TOOL_STEPS } from './automationConstants.js';
 import { replyLanguageInstruction } from './replyLanguage.js';
 
 const MAX_STEPS = AUTOMATION_MAX_TOOL_STEPS || 40;
+const TOOL_RESULT_MAX = 20000;
+
+/** Keep search/list payloads valid JSON; never cut mid-object (that hid remaining task ids). */
+function toolResultContent(result) {
+  let payload = result;
+  let text = JSON.stringify(payload);
+  if (text.length <= TOOL_RESULT_MAX) return text;
+
+  if (payload && Array.isArray(payload.tasks)) {
+    payload = {
+      ...payload,
+      truncatedForLlm: true,
+      note: `${payload.note || ''} Rows compacted for size; use offset/hasMore if incomplete.`.trim(),
+      tasks: payload.tasks.map((t) => ({
+        id: t.id,
+        ticket: t.ticket,
+        memberId: t.memberId,
+        boardTitle: t.boardTitle,
+        columnTitle: t.columnTitle
+      }))
+    };
+    text = JSON.stringify(payload);
+  }
+  if (text.length <= TOOL_RESULT_MAX) return text;
+
+  if (payload && Array.isArray(payload.tasks) && payload.tasks.length > 60) {
+    const kept = payload.tasks.slice(0, 60);
+    payload = {
+      ...payload,
+      truncatedForLlm: true,
+      hasMore: true,
+      count: kept.length,
+      note: `${payload.note || ''} Returning first ${kept.length} of ${payload.totalCount ?? payload.tasks.length} in this page; call search_tasks with offset.`.trim(),
+      tasks: kept
+    };
+    text = JSON.stringify(payload);
+  }
+  if (text.length <= TOOL_RESULT_MAX) return text;
+  return `${text.slice(0, TOOL_RESULT_MAX - 80)}\n[TRUNCATED — page with search_tasks offset; do not assume this is the full set]`;
+}
 
 const TOOLS = [
   {
@@ -55,7 +95,7 @@ const TOOLS = [
   {
     name: 'search_tasks',
     description:
-      'Search live tasks in scope (trash is excluded by default). Excludes the automation launch task. Returns compact rows with boardTitle, columnTitle, and descriptionPreview. Set trashOnly:true (or includeTrash:true) only when the user asked to find or recover tasks from trash. Then use restore_tasks.',
+      'Search live tasks in scope (trash excluded by default). Excludes the launch task. Returns compact rows (id, ticket, titles, memberId) plus totalCount/hasMore/offset. Page with offset until hasMore is false before bulk updates. For “assigned to X”, use assigneeId from list_members — not text. Set includeDescription:true only when you need previews. trashOnly/includeTrash only for recovery, then restore_tasks.',
     parameters: {
       type: 'object',
       properties: {
@@ -66,6 +106,10 @@ const TOOLS = [
         assigneeId: { type: 'string' },
         tagId: { type: 'string' },
         limit: { type: 'number' },
+        offset: {
+          type: 'number',
+          description: 'Skip this many matches (use with hasMore / totalCount).'
+        },
         includeDescription: { type: 'boolean' },
         includeTrash: {
           type: 'boolean',
@@ -117,7 +161,8 @@ const TOOLS = [
   },
   {
     name: 'update_tasks',
-    description: 'Bulk update task fields. Use dryRun:true while planning.',
+    description:
+      'Bulk update task fields (e.g. memberId). Pass fields:{ memberId } (top-level memberId is also accepted). Use dryRun:true while planning.',
     parameters: {
       type: 'object',
       properties: {
@@ -337,6 +382,15 @@ function automationHeaders(automation, extra = {}) {
   return headers;
 }
 
+function toolCallLogStatus(result) {
+  if (!result || typeof result !== 'object') return 'ok';
+  if (result.denied === true) {
+    return `denied${result.error ? `: ${String(result.error).slice(0, 180)}` : ''}`;
+  }
+  if (result.error) return `error: ${String(result.error).slice(0, 180)}`;
+  return 'ok';
+}
+
 async function callToolApi(automation, name, args, dryRun = false) {
   const base = String(automation.apiBaseUrl || '').replace(/\/+$/, '');
   const res = await fetch(`${base}/api/agent/automation/tools`, {
@@ -469,7 +523,7 @@ export async function runAutomationJob(job) {
     'Never delete tasks, boards, or columns — those are denied.',
     'search_tasks excludes trash by default. Only use trashOnly/includeTrash when the user asked to find or recover trashed tasks; then restore_tasks (not update/move).',
     'The automation launch task (this recipe card) is NEVER a target: search/get/move/update skip it automatically. Do not try to move or edit it.',
-    'Prefer search_tasks for analysis — results include descriptionPreview, boardTitle, and columnTitle. Avoid calling get_task once per match; use get_tasks only when you need fuller fields for a small set.',
+    'Prefer search_tasks for discovery. Rows are compact (no descriptionPreview unless includeDescription:true). Always read totalCount and hasMore; if hasMore, call search_tasks again with offset until complete, then plan. For “all tasks assigned to X”, list_members then search_tasks assigneeId — never match the name via text. After applying a bulk assignee change, search that assigneeId again; if any remain, continue or report the remainder — do not claim “all” unless a verify search returns totalCount 0.',
     'When names are ambiguous, prefer IDs from list tools; refuse to guess.',
     'In human-facing text (submit_dry_run_plan summary, finish, comments), always use board titles and column titles — never raw board/column UUIDs. Keep using IDs only in tool arguments.',
     replyLanguageInstruction(payload),
@@ -584,7 +638,7 @@ export async function runAutomationJob(job) {
             messages.push({
               role: 'tool',
               tool_call_id: tc.id,
-              content: JSON.stringify(result).slice(0, 20000)
+              content: toolResultContent(result)
             });
             // Prefer finishing immediately with the plan summary
             finished = {
@@ -614,15 +668,13 @@ export async function runAutomationJob(job) {
         messages.push({
           role: 'tool',
           tool_call_id: tc.id,
-          content: JSON.stringify(result).slice(0, 20000)
+          content: toolResultContent(result)
         });
       }
 
       await sendCallback(job, {
         event: 'log',
-        log: `[runner] tool ${tc.name}${dryRun ? ' (dry-run)' : ''}: ${
-          result.error || result.denied ? 'denied/error' : 'ok'
-        }`
+        log: `[runner] tool ${tc.name}${dryRun ? ' (dry-run)' : ''}: ${toolCallLogStatus(result)}`
       });
     }
 

--- a/server/config/database.js
+++ b/server/config/database.js
@@ -329,7 +329,7 @@ const CREATE_SCHEMA_SQL = `
       PRIMARY KEY (task_id, key)
     );
     CREATE INDEX IF NOT EXISTS idx_task_work_task_id ON task_work(task_id);
-    CREATE INDEX IF NOT EXISTS idx_task_work_key_value ON task_work(key, value);
+    CREATE INDEX IF NOT EXISTS idx_task_work_status_value ON task_work (value) WHERE key = 'status';
 
     CREATE TABLE IF NOT EXISTS user_api_tokens (
       id TEXT PRIMARY KEY,
@@ -754,6 +754,9 @@ const CREATE_SCHEMA_SQL = `
     CREATE INDEX IF NOT EXISTS idx_notification_queue_scheduled_send ON notification_queue(scheduled_send_time, status);
     CREATE INDEX IF NOT EXISTS idx_notification_queue_user_task ON notification_queue(user_id, task_id, status);
     CREATE INDEX IF NOT EXISTS idx_notification_queue_created_at ON notification_queue(created_at);
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_notification_queue_pending_user_task
+      ON notification_queue (user_id, task_id)
+      WHERE status = 'pending';
     
     -- Migration 8: Performance indexes on tasks
     CREATE INDEX IF NOT EXISTS idx_tasks_start_date ON tasks(startdate);

--- a/server/i18n/locales/en.json
+++ b/server/i18n/locales/en.json
@@ -68,6 +68,8 @@
     "failedToMoveTaskToBoard": "Failed to move task to board",
     "failedToGetTasks": "Failed to get tasks",
     "failedToAddWatcher": "Failed to add watcher",
+    "cannotAssignViewer": "View-only members cannot be assigned to tasks",
+    "readOnly": "Read-only role cannot modify data",
     "failedToRemoveWatcher": "Failed to remove watcher",
     "failedToAddCollaborator": "Failed to add collaborator",
     "failedToRemoveCollaborator": "Failed to remove collaborator",
@@ -187,7 +189,7 @@
     },
     "taskNotification": {
       "newTaskAssigned": {
-        "subject": "📋 New task assigned: {taskTitle}",
+        "subject": "✨ Task assigned to you: {taskTitle}",
         "title": "New Task Assigned",
         "taskId": "Task ID:",
         "assignedBy": "Assigned by:",
@@ -195,7 +197,7 @@
         "receivingReason": "You're receiving this because you were assigned to this task."
       },
       "myTaskUpdated": {
-        "subject": "📝 Your task was updated: {taskTitle}",
+        "subject": "✏️ Task updated: {taskTitle}",
         "title": "Task Updated",
         "taskId": "Task ID:",
         "updatedBy": "Updated by:",
@@ -204,7 +206,7 @@
         "receivingReason": "You're receiving this because you're assigned to this task."
       },
       "watchedTaskUpdated": {
-        "subject": "👀 Watched task updated: {taskTitle}",
+        "subject": "🔖 Watched task updated: {taskTitle}",
         "title": "Watched Task Updated",
         "taskId": "Task ID:",
         "updatedBy": "Updated by:",
@@ -213,7 +215,7 @@
         "receivingReason": "You're receiving this because you're watching this task."
       },
       "addedAsCollaborator": {
-        "subject": "🤝 Added as collaborator: {taskTitle}",
+        "subject": "👥 Added as collaborator: {taskTitle}",
         "title": "Added as Collaborator",
         "taskId": "Task ID:",
         "addedBy": "Added by:",
@@ -221,7 +223,7 @@
         "receivingReason": "You're now collaborating on this task and will receive updates about changes."
       },
       "addedAsWatcher": {
-        "subject": "👀 Added as watcher: {taskTitle}",
+        "subject": "🔖 Added as watcher: {taskTitle}",
         "title": "Added as Watcher",
         "taskId": "Task ID:",
         "addedBy": "Added by:",
@@ -229,7 +231,7 @@
         "receivingReason": "You're now watching this task and will receive updates about changes."
       },
       "collaboratingTaskUpdated": {
-        "subject": "🤝 Collaborating task updated: {taskTitle}",
+        "subject": "👥 Collaborating task updated: {taskTitle}",
         "title": "Collaborating Task Updated",
         "taskId": "Task ID:",
         "updatedBy": "Updated by:",
@@ -238,7 +240,7 @@
         "receivingReason": "You're receiving this because you're collaborating on this task."
       },
       "requesterTaskCreated": {
-        "subject": "✅ Your requested task was created: {taskTitle}",
+        "subject": "✨ Requested task created: {taskTitle}",
         "title": "Task Created",
         "taskId": "Task ID:",
         "createdBy": "Created by:",
@@ -246,7 +248,7 @@
         "receivingReason": "You're receiving this because you requested this task."
       },
       "requesterTaskUpdated": {
-        "subject": "📋 Your requested task was updated: {taskTitle}",
+        "subject": "✏️ Requested task updated: {taskTitle}",
         "title": "Requested Task Updated",
         "taskId": "Task ID:",
         "updatedBy": "Updated by:",
@@ -257,7 +259,7 @@
       "common": {
         "taskNotification": "Task Notification",
         "hi": "Hi {firstName},",
-        "actionInBoard": "{actionMessage} in {boardName}:",
+        "actionInBoard": "{actionMessage} in {boardName}.",
         "actionMessage": {
           "created": "A new task has been created",
           "assigned": "You have been assigned to a task",
@@ -289,6 +291,14 @@
         "fieldRequester": "Requester",
         "fieldPriority": "Priority",
         "fieldSprint": "Sprint",
+        "fieldDate": "Date",
+        "fromTo": "from \"{from}\" to \"{to}\"",
+        "detailsDeleted": "\"{taskTitle}\" ({ticket}) was deleted.",
+        "subjectDeleted": "🗑️ Task deleted: {taskTitle}",
+        "tagsAdded": "New tag associated:",
+        "tagsAddedPlural": "New tag(s) associated:",
+        "tagsRemoved": "Tag removed:",
+        "tagsRemovedPlural": "Tag(s) removed:",
         "timestamp": "Date/Time",
         "viewTask": "View Task",
         "viewTaskReply": "💬 View Task & Reply",

--- a/server/i18n/locales/fr.json
+++ b/server/i18n/locales/fr.json
@@ -68,6 +68,8 @@
     "failedToMoveTaskToBoard": "Échec du déplacement de la tâche vers le tableau",
     "failedToGetTasks": "Échec de la récupération des tâches",
     "failedToAddWatcher": "Échec de l'ajout de l'observateur",
+    "cannotAssignViewer": "Les membres en lecture seule ne peuvent pas être assignés aux tâches",
+    "readOnly": "Le rôle en lecture seule ne peut pas modifier les données",
     "failedToRemoveWatcher": "Échec de la suppression de l'observateur",
     "failedToAddCollaborator": "Échec de l'ajout du collaborateur",
     "failedToRemoveCollaborator": "Échec de la suppression du collaborateur",
@@ -187,7 +189,7 @@
     },
     "taskNotification": {
       "newTaskAssigned": {
-        "subject": "📋 Nouvelle tâche assignée : {taskTitle}",
+        "subject": "✨ Tâche assignée : {taskTitle}",
         "title": "Nouvelle tâche assignée",
         "taskId": "ID de la tâche :",
         "assignedBy": "Assignée par :",
@@ -195,7 +197,7 @@
         "receivingReason": "Vous recevez ceci car vous avez été assigné à cette tâche."
       },
       "myTaskUpdated": {
-        "subject": "📝 Votre tâche a été mise à jour : {taskTitle}",
+        "subject": "✏️ Tâche mise à jour : {taskTitle}",
         "title": "Tâche mise à jour",
         "taskId": "ID de la tâche :",
         "updatedBy": "Mise à jour par :",
@@ -204,7 +206,7 @@
         "receivingReason": "Vous recevez ceci car vous êtes assigné à cette tâche."
       },
       "watchedTaskUpdated": {
-        "subject": "👀 Tâche surveillée mise à jour : {taskTitle}",
+        "subject": "🔖 Tâche surveillée mise à jour : {taskTitle}",
         "title": "Tâche surveillée mise à jour",
         "taskId": "ID de la tâche :",
         "updatedBy": "Mise à jour par :",
@@ -213,7 +215,7 @@
         "receivingReason": "Vous recevez ceci car vous surveillez cette tâche."
       },
       "addedAsCollaborator": {
-        "subject": "🤝 Ajouté en tant que collaborateur : {taskTitle}",
+        "subject": "👥 Ajouté en tant que collaborateur : {taskTitle}",
         "title": "Ajouté en tant que collaborateur",
         "taskId": "ID de la tâche :",
         "addedBy": "Ajouté par :",
@@ -221,7 +223,7 @@
         "receivingReason": "Vous collaborez maintenant sur cette tâche et recevrez des mises à jour sur les changements."
       },
       "addedAsWatcher": {
-        "subject": "👀 Ajouté en tant que surveillant : {taskTitle}",
+        "subject": "🔖 Ajouté en tant que surveillant : {taskTitle}",
         "title": "Ajouté en tant que surveillant",
         "taskId": "ID de la tâche :",
         "addedBy": "Ajouté par :",
@@ -229,7 +231,7 @@
         "receivingReason": "Vous surveillez maintenant cette tâche et recevrez des mises à jour sur les changements."
       },
       "collaboratingTaskUpdated": {
-        "subject": "🤝 Tâche en collaboration mise à jour : {taskTitle}",
+        "subject": "👥 Tâche en collaboration mise à jour : {taskTitle}",
         "title": "Tâche en collaboration mise à jour",
         "taskId": "ID de la tâche :",
         "updatedBy": "Mise à jour par :",
@@ -238,7 +240,7 @@
         "receivingReason": "Vous recevez ceci car vous collaborez sur cette tâche."
       },
       "requesterTaskCreated": {
-        "subject": "✅ Votre tâche demandée a été créée : {taskTitle}",
+        "subject": "✨ Votre tâche demandée a été créée : {taskTitle}",
         "title": "Tâche créée",
         "taskId": "ID de la tâche :",
         "createdBy": "Créée par :",
@@ -246,7 +248,7 @@
         "receivingReason": "Vous recevez ceci car vous avez demandé cette tâche."
       },
       "requesterTaskUpdated": {
-        "subject": "📋 Votre tâche demandée a été mise à jour : {taskTitle}",
+        "subject": "✏️ Votre tâche demandée a été mise à jour : {taskTitle}",
         "title": "Tâche demandée mise à jour",
         "taskId": "ID de la tâche :",
         "updatedBy": "Mise à jour par :",
@@ -257,7 +259,7 @@
       "common": {
         "taskNotification": "Notification de tâche",
         "hi": "Bonjour {firstName},",
-        "actionInBoard": "{actionMessage} dans {boardName} :",
+        "actionInBoard": "{actionMessage} dans {boardName}.",
         "actionMessage": {
           "created": "Une nouvelle tâche a été créée",
           "assigned": "Vous avez été assigné à une tâche",
@@ -289,6 +291,14 @@
         "fieldRequester": "Demandeur",
         "fieldPriority": "Priorité",
         "fieldSprint": "Sprint",
+        "fieldDate": "Date",
+        "fromTo": "de « {from} » à « {to} »",
+        "detailsDeleted": "« {taskTitle} » ({ticket}) a été supprimée.",
+        "subjectDeleted": "🗑️ Tâche supprimée : {taskTitle}",
+        "tagsAdded": "Nouvelle étiquette associée :",
+        "tagsAddedPlural": "Nouvelles étiquettes associées :",
+        "tagsRemoved": "Étiquette retirée :",
+        "tagsRemovedPlural": "Étiquettes retirées :",
         "timestamp": "Date/Heure",
         "viewTask": "Voir la tâche",
         "viewTaskReply": "💬 Voir la tâche et répondre",

--- a/server/middleware/auth.js
+++ b/server/middleware/auth.js
@@ -72,6 +72,13 @@ function isAllowedViewerMutation(req) {
   // Comment attachments (upload only; attachment DELETE stays blocked)
   if (method === 'POST' && /\/api\/upload\/?$/.test(raw)) return true;
   if (method === 'POST' && /\/api\/(users|user)\/upload\/?$/.test(raw)) return true;
+  // Own watcher add/remove (self-check in the route)
+  if (
+    (method === 'POST' || method === 'DELETE') &&
+    /\/api\/tasks\/[^/]+\/watchers\/[^/]+\/?$/.test(raw)
+  ) {
+    return true;
+  }
   return false;
 }
 

--- a/server/migrations/index.js
+++ b/server/migrations/index.js
@@ -108,7 +108,7 @@ const migrations = [
           PRIMARY KEY (task_id, key)
         );
         CREATE INDEX IF NOT EXISTS idx_task_work_task_id ON task_work(task_id);
-        CREATE INDEX IF NOT EXISTS idx_task_work_key_value ON task_work(key, value);
+        CREATE INDEX IF NOT EXISTS idx_task_work_status_value ON task_work (value) WHERE key = 'status';
 
         CREATE TABLE IF NOT EXISTS user_api_tokens (
           id TEXT PRIMARY KEY,
@@ -811,6 +811,53 @@ const migrations = [
         await settingsQueries.createSetting(db, DEFAULT_BOARD_COLUMNS_SETTING_KEY, DEFAULT_BOARD_COLUMNS_JSON);
       }
       console.log('✅ Migration 38: DEFAULT_BOARD_COLUMNS ready');
+    }
+  },
+  {
+    version: 39,
+    name: 'unique_pending_notification_per_user_task',
+    description:
+      'One pending notification_queue row per user+task so delayed emails consolidate',
+    up: async (db) => {
+      await dbExec(
+        db,
+        `
+          DELETE FROM notification_queue a
+          USING notification_queue b
+          WHERE a.status = 'pending'
+            AND b.status = 'pending'
+            AND a.user_id = b.user_id
+            AND a.task_id = b.task_id
+            AND a.created_at < b.created_at
+        `
+      );
+      await dbExec(
+        db,
+        `
+          CREATE UNIQUE INDEX IF NOT EXISTS idx_notification_queue_pending_user_task
+          ON notification_queue (user_id, task_id)
+          WHERE status = 'pending'
+        `
+      );
+      console.log('✅ Migration 39: unique pending notification per user+task');
+    }
+  },
+  {
+    version: 40,
+    name: 'task_work_drop_value_btree',
+    description:
+      'Stop btree-indexing task_work.value (plans/logs exceed 2704-byte index rows)',
+    up: async (db) => {
+      await dbExec(db, 'DROP INDEX IF EXISTS idx_task_work_key_value');
+      await dbExec(
+        db,
+        `
+          CREATE INDEX IF NOT EXISTS idx_task_work_status_value
+          ON task_work (value)
+          WHERE key = 'status'
+        `
+      );
+      console.log('✅ Migration 40: task_work status partial index (no value btree)');
     }
   }
 ];

--- a/server/routes/adminNotificationQueue.js
+++ b/server/routes/adminNotificationQueue.js
@@ -1,9 +1,11 @@
 import express from 'express';
 import { authenticateToken, requireRole } from '../middleware/auth.js';
-import { getRequestDatabase } from '../middleware/tenantRouting.js';
+import { getRequestDatabase, getTenantId } from '../middleware/tenantRouting.js';
+import { publishNotificationQueueUpdated } from '../utils/publishNotificationQueueUpdated.js';
 import EmailService from '../services/emailService.js';
 import { EmailTemplates } from '../services/emailTemplates.js';
 import { buildTaskEmailUrl } from '../utils/emailContent.js';
+import { ensureTagEmailChange } from '../utils/taskEmailPayload.js';
 import { getUserTimeZone } from '../utils/dateFormatter.js';
 // MIGRATED: Import sqlManager modules
 import { notificationQueue as notificationQueueQueries, users as userQueries, boards as boardQueries, helpers } from '../utils/sqlManager/index.js';
@@ -159,10 +161,20 @@ router.post('/send', authenticateToken, requireRole(['admin']), async (req, res)
         const siteName = siteNameSetting || 'Agila';
 
         // Determine action type and details
-        const actionType = notification.change_count > 1 ? 'consolidated_update' : notification.action;
+        const emailChange = await ensureTagEmailChange(
+          db,
+          notification.action,
+          actor?.emailChange || null,
+          notification.details,
+          actor?.tagId || null
+        );
+        const visibleItems = (emailChange?.items || []).filter(
+          (i) => i && i.field !== 'effort' && i.field !== 'generic'
+        );
+        const actionType =
+          visibleItems.length > 1 ? 'consolidated_update' : notification.action;
         const actionDetails = notification.details;
 
-        // Create email template data
         const recipientTimeZone = await getUserTimeZone(db, recipientUser.id);
         const emailTemplateData = {
           user: recipientUser,
@@ -175,8 +187,11 @@ router.post('/send', authenticateToken, requireRole(['admin']), async (req, res)
           siteName: siteName,
           oldValue: notification.old_value,
           newValue: notification.new_value,
+          changedField: actor?.changedField || null,
+          notificationType: notification.notification_type || notification.notificationType || null,
           timestamp: notification.last_change_time,
           recipientTimeZone,
+          emailChange,
           db: db
         };
 
@@ -195,6 +210,7 @@ router.post('/send', authenticateToken, requireRole(['admin']), async (req, res)
         await notificationQueueQueries.updateNotificationQueueStatus(db, notificationId, 'sent');
 
         sentCount++;
+        publishNotificationQueueUpdated(getTenantId(req)).catch(() => {});
       } catch (error) {
         console.error(`Failed to send notification ${notificationId}:`, error);
         errors.push(`Failed to send ${notificationId}: ${error.message}`);
@@ -230,6 +246,8 @@ router.delete('/', authenticateToken, requireRole(['admin']), async (req, res) =
     
     // MIGRATED: Delete notifications using sqlManager
     const result = await notificationQueueQueries.deleteNotificationQueueItems(db, notificationIds);
+
+    publishNotificationQueueUpdated(getTenantId(req)).catch(() => {});
 
     res.json({
       success: true,

--- a/server/routes/adminSystem.js
+++ b/server/routes/adminSystem.js
@@ -112,9 +112,12 @@ router.post('/jobs/cleanup', authenticateToken, requireRole(['admin']), async (r
 
 router.get('/system-info', authenticateToken, requireRole(['admin']), async (req, res) => {
   try {
-    // Host/container metrics are not tenant-scoped; hide in multi-tenant and demo deployments
+    // Host/container metrics are not tenant-scoped. Hidden in multi-tenant and demo
+    // unless the admin session sent the troubleshooting unlock header (TROUBLE).
     if (process.env.MULTI_TENANT === 'true' || process.env.DEMO_ENABLED === 'true') {
-      return res.status(404).json({ error: 'System metrics are not available in this deployment mode' });
+      if (String(req.get('x-agila-troubleshooting') || '') !== '1') {
+        return res.status(404).json({ error: 'System metrics are not available in this deployment mode' });
+      }
     }
 
     const db = getRequestDatabase(req);

--- a/server/routes/settings.js
+++ b/server/routes/settings.js
@@ -149,6 +149,8 @@ router.get('/', async (req, res, next) => {
       settingsObj[setting.key] = setting.value;
     });
     await applyEffectiveAiEnabledToSettings(db, settingsObj);
+    settingsObj.DEPLOY_MULTI_TENANT = process.env.MULTI_TENANT === 'true' ? 'true' : 'false';
+    settingsObj.DEPLOY_DEMO_ENABLED = process.env.DEMO_ENABLED === 'true' ? 'true' : 'false';
     // Per-tenant OAuth and site metadata must not be cached by browsers or intermediaries
     res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, private');
     res.json(settingsObj);
@@ -289,6 +291,8 @@ router.get('/', authenticateToken, requireRole(['admin']), async (req, res, next
     }
 
     await applyEffectiveAiEnabledToSettings(db, settingsObj);
+    settingsObj.DEPLOY_MULTI_TENANT = process.env.MULTI_TENANT === 'true' ? 'true' : 'false';
+    settingsObj.DEPLOY_DEMO_ENABLED = process.env.DEMO_ENABLED === 'true' ? 'true' : 'false';
     
     res.json(settingsObj);
   } catch (error) {

--- a/server/routes/taskRelations.js
+++ b/server/routes/taskRelations.js
@@ -3,7 +3,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
-import { authenticateToken } from '../middleware/auth.js';
+import { authenticateToken, userCanMutate } from '../middleware/auth.js';
 import { wrapQuery } from '../utils/queryLogger.js';
 import { logActivity, logTaskActivity } from '../services/activityLogger.js';
 import { TAG_ACTIONS } from '../constants/activityActions.js';
@@ -12,8 +12,8 @@ import notificationService from '../services/notificationService.js';
 import { updateStorageUsage } from '../utils/storageUtils.js';
 import { getLicenseManager } from '../config/license.js';
 import { getTenantId, getRequestDatabase } from '../middleware/tenantRouting.js';
-import { helpers, tasks as taskQueries, files as fileQueries, activity as activityQueries } from '../utils/sqlManager/index.js';
-import { getBilingualTranslation, getTranslatorForLanguage } from '../utils/i18n.js';
+import { helpers, tasks as taskQueries, files as fileQueries, activity as activityQueries, members as memberQueries } from '../utils/sqlManager/index.js';
+import { getBilingualTranslation, getTranslatorForLanguage, getTranslator } from '../utils/i18n.js';
 import { notifyCollaboratorAdded, notifyWatcherAdded } from '../services/taskEmailNotificationService.js';
 import { parseBody, taskAttachmentsBodySchema } from '../utils/requestValidation.js';
 
@@ -128,6 +128,15 @@ router.post('/:taskId/tags/:tagId', authenticateToken, async (req, res) => {
               authType: req.user?.authType,
               db: db,
               skipEmail: skipEmail === true,
+              emailChange: {
+                items: [
+                  {
+                    field: 'tags',
+                    added: [{ name: tag.tag, color: tag.color }],
+                    removed: [],
+                  },
+                ],
+              },
             }
           );
         } catch (error) {
@@ -350,7 +359,16 @@ router.delete('/:taskId/tags/:tagId', authenticateToken, async (req, res) => {
               boardId: normalizedTask.boardId,
               tenantId: getTenantId(req),
               authType: req.user?.authType,
-              db: db
+              db: db,
+              emailChange: {
+                items: [
+                  {
+                    field: 'tags',
+                    added: [],
+                    removed: [{ name: tag.tag, color: tag.color }],
+                  },
+                ],
+              },
             }
           );
         } catch (error) {
@@ -479,6 +497,13 @@ router.post('/:taskId/watchers/:memberId', authenticateToken, async (req, res) =
     req.body?.skipEmail === true;
   
   try {
+    if (!userCanMutate(req.user)) {
+      const tTranslator = await getTranslator(db);
+      const ownMember = await memberQueries.getMemberByUserId(db, userId);
+      if (!ownMember || ownMember.id !== memberId) {
+        return res.status(403).json({ error: tTranslator('errors.readOnly'), code: 'READ_ONLY' });
+      }
+    }
     // MIGRATED: Check if association already exists using sqlManager
     // Note: addWatcher uses ON CONFLICT DO NOTHING, so we check first
     const existingWatchers = await helpers.getWatchersForTask(db, taskId);
@@ -545,8 +570,16 @@ router.post('/:taskId/watchers/:memberId', authenticateToken, async (req, res) =
 router.delete('/:taskId/watchers/:memberId', authenticateToken, async (req, res) => {
   const { taskId, memberId } = req.params;
   const db = getRequestDatabase(req);
+  const userId = req.user?.id || 'system';
   
   try {
+    if (!userCanMutate(req.user)) {
+      const tTranslator = await getTranslator(db);
+      const ownMember = await memberQueries.getMemberByUserId(db, userId);
+      if (!ownMember || ownMember.id !== memberId) {
+        return res.status(403).json({ error: tTranslator('errors.readOnly'), code: 'READ_ONLY' });
+      }
+    }
     // MIGRATED: Remove watcher using sqlManager
     const result = await helpers.removeWatcher(db, taskId, memberId);
     

--- a/server/routes/taskWork.js
+++ b/server/routes/taskWork.js
@@ -289,17 +289,26 @@ router.put('/:taskId/work/control', authenticateToken, async (req, res) => {
           error: 'Task description is required before starting the agent'
         });
       }
-      updates.status = 'queued';
-      updates.control = 'resume';
       if (!workBefore.agent_owner_user_id && req.user?.id) {
         updates.agent_owner_user_id = req.user.id;
       }
-      // Clear prior automation apply state for a fresh re-run
-      if (workBefore.agent_mode === 'automation') {
-        updates.awaiting_apply = '';
-        updates.automation_pending_plan = '';
-        updates.automation_plan_hash = '';
-        updates.automation_apply_hash = '';
+      // Stop while waiting for Apply: keep the dry-run plan so Apply still works.
+      if (
+        workBefore.agent_mode === 'automation' &&
+        workBefore.automation_pending_plan
+      ) {
+        updates.status = 'waiting';
+        updates.control = 'none';
+        updates.awaiting_apply = 'true';
+      } else {
+        updates.status = 'queued';
+        updates.control = 'resume';
+        if (workBefore.agent_mode === 'automation') {
+          updates.awaiting_apply = '';
+          updates.automation_pending_plan = '';
+          updates.automation_plan_hash = '';
+          updates.automation_apply_hash = '';
+        }
       }
     } else if (control === 'stop') {
       updates.status = 'stopped';
@@ -336,7 +345,7 @@ router.put('/:taskId/work/control', authenticateToken, async (req, res) => {
     let work = await taskWorkQueries.getWorkMapByTaskId(db, req.params.taskId);
     await publishWork(req, req.params.taskId, work);
 
-    if (control === 'resume') {
+    if (control === 'resume' && work.status === 'queued') {
       const tenantId = getTenantId(req);
       try {
         await tryLaunchQueuedTasks(db, tenantId, dispatchCtx(req));

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -4,7 +4,7 @@ import { wrapQuery } from '../utils/queryLogger.js';
 import { logTaskActivity, generateTaskUpdateDetails, logBulkTaskFieldActivity } from '../services/activityLogger.js';
 import * as reportingLogger from '../services/reportingLogger.js';
 import { TASK_ACTIONS } from '../constants/activityActions.js';
-import { authenticateToken, requireRole } from '../middleware/auth.js';
+import { authenticateToken, requireRole, userCanMutate } from '../middleware/auth.js';
 import { checkTaskLimit } from '../middleware/licenseCheck.js';
 import notificationService from '../services/notificationService.js';
 import { getTranslator, t } from '../utils/i18n.js';
@@ -12,7 +12,7 @@ import { getRequestDatabase } from '../middleware/tenantRouting.js';
 import { serverDebug } from '../utils/serverDebug.js';
 import { dbTransaction } from '../utils/dbAsync.js';
 // MIGRATED: Import sqlManager
-import { tasks as taskQueries, boards as boardQueries, helpers, sprints as sprintQueries, taskWork as taskWorkQueries } from '../utils/sqlManager/index.js';
+import { tasks as taskQueries, boards as boardQueries, helpers, sprints as sprintQueries, taskWork as taskWorkQueries, members as memberQueries } from '../utils/sqlManager/index.js';
 import { AUTOMATION_CONFIG_KEYS } from '../constants/automation.js';
 import {
   purgeTaskCompletely,
@@ -605,6 +605,11 @@ router.post('/', authenticateToken, checkTaskLimit, async (req, res) => {
         priorityName = await helpers.getPriorityNameById(db, priorityId);
       }
     }
+
+    const tTranslator = await getTranslator(db);
+    if (task.memberId && (await memberQueries.isReadOnlyViewerMember(db, task.memberId))) {
+      return res.status(400).json({ error: tTranslator('errors.cannotAssignViewer') });
+    }
     
     // MIGRATED: Create the task using sqlManager
     await taskQueries.createTask(db, {
@@ -750,6 +755,11 @@ router.post('/add-at-top', authenticateToken, checkTaskLimit, async (req, res) =
       }
     }
     
+    const tTranslator = await getTranslator(db);
+    if (task.memberId && (await memberQueries.isReadOnlyViewerMember(db, task.memberId))) {
+      return res.status(400).json({ error: tTranslator('errors.cannotAssignViewer') });
+    }
+
     await dbTransaction(db, async () => {
       await taskQueries.incrementTaskPositions(db, task.columnId);
       await taskQueries.createTask(db, {
@@ -1253,10 +1263,9 @@ router.put('/:id', authenticateToken, async (req, res) => {
     // Check if sprint changed - handle separately like priority
     const currentSprintId = currentTask.sprint_id || currentTask.sprintId || null;
     const newSprintId = task.sprintId || null;
+    let oldSprintName = null;
+    let newSprintName = null;
     if (hasChanged(currentSprintId, newSprintId)) {
-      // Get sprint names for bilingual activity message
-      let oldSprintName = null;
-      let newSprintName = null;
       
       if (currentSprintId) {
         try {
@@ -1421,6 +1430,13 @@ router.put('/:id', authenticateToken, async (req, res) => {
     const nextBoardId = task.boardId ?? task.boardid ?? normalizedCurrentTask.boardId;
     const nextMemberId = task.memberId ?? task.memberid ?? normalizedCurrentTask.memberId;
     const nextRequesterId = task.requesterId ?? task.requesterid ?? normalizedCurrentTask.requesterId;
+    if (
+      nextMemberId &&
+      nextMemberId !== (normalizedCurrentTask.memberId || null) &&
+      (await memberQueries.isReadOnlyViewerMember(db, nextMemberId))
+    ) {
+      return res.status(400).json({ error: tTranslator('errors.cannotAssignViewer') });
+    }
     await taskQueries.updateTask(db, id, {
       title: task.title !== undefined ? task.title : currentTask.title,
       description: task.description !== undefined ? task.description : normalizedCurrentTask.description,
@@ -1491,10 +1507,63 @@ router.put('/:id', authenticateToken, async (req, res) => {
       let oldValue;
       let newValue;
       let changedField;
+      const emailItems = [];
+      if (priorityChanged) {
+        let oldPriorityColor = null;
+        let newPriorityColor = null;
+        try {
+          if (currentPriorityId) {
+            const oldPri = await helpers.getPriorityById(db, currentPriorityId);
+            oldPriorityColor = oldPri?.color || null;
+          }
+          if (priorityId) {
+            const newPri = await helpers.getPriorityById(db, priorityId);
+            newPriorityColor = newPri?.color || null;
+          }
+        } catch {
+          /* keep names without colors */
+        }
+        emailItems.push({
+          field: 'priorityId',
+          oldName: oldPriorityLabel,
+          newName: newPriorityLabel,
+          oldColor: oldPriorityColor,
+          newColor: newPriorityColor,
+        });
+      }
+      if (hasChanged(currentSprintId, newSprintId)) {
+        emailItems.push({
+          field: 'sprintId',
+          oldName: oldSprintName,
+          newName: newSprintName,
+        });
+      }
+      for (const field of fieldsToTrack) {
+        if (field === 'effort') continue;
+        if (!hasChanged(normalizedCurrentTask[field], task[field])) continue;
+        if (field === 'columnId' && columnMoveDisplayOld != null && columnMoveDisplayNew != null) {
+          emailItems.push({
+            field: 'columnId',
+            oldValue: columnMoveDisplayOld,
+            newValue: columnMoveDisplayNew,
+          });
+          continue;
+        }
+        emailItems.push({
+          field,
+          oldValue: normalizedCurrentTask[field],
+          newValue: task[field],
+        });
+      }
+
+      const skipEmailEffortOnly = emailItems.length === 0 && hasChanged(normalizedCurrentTask.effort, task.effort);
+
       if (changes.length === 1) {
         changedField = fieldsToTrack.find((field) =>
           hasChanged(normalizedCurrentTask[field], task[field])
         );
+        if (!changedField && priorityChanged) changedField = 'priorityId';
+        if (!changedField && hasChanged(currentSprintId, newSprintId)) changedField = 'sprintId';
         if (changedField) {
           if (
             changedField === 'columnId' &&
@@ -1503,15 +1572,23 @@ router.put('/:id', authenticateToken, async (req, res) => {
           ) {
             oldValue = columnMoveDisplayOld;
             newValue = columnMoveDisplayNew;
+          } else if (changedField === 'priorityId') {
+            oldValue = oldPriorityLabel;
+            newValue = newPriorityLabel;
+          } else if (changedField === 'sprintId') {
+            oldValue = oldSprintName;
+            newValue = newSprintName;
           } else {
             oldValue = normalizedCurrentTask[changedField];
             newValue = task[changedField];
           }
         }
+      } else if (emailItems.some((i) => i.field === 'memberId')) {
+        changedField = 'memberId';
+        oldValue = normalizedCurrentTask.memberId;
+        newValue = task.memberId;
       }
-      
-      // Fire-and-forget: Don't await activity logging to avoid blocking API response
-      // Activity logging can take 500-600ms on EFS, but we don't need to wait for it
+
       logTaskActivity(
         userId,
         TASK_ACTIONS.UPDATE,
@@ -1523,6 +1600,8 @@ router.put('/:id', authenticateToken, async (req, res) => {
           oldValue,
           newValue,
           changedField,
+          emailChange: { items: emailItems },
+          skipEmail: skipEmailEffortOnly,
           tenantId: getTenantId(req),
           authType: req.user?.authType,
           db: db
@@ -1713,6 +1792,16 @@ router.post('/batch-update', authenticateToken, async (req, res) => {
     
     if (missingTasks.length > 0) {
       return res.status(404).json({ error: tTranslator('errors.taskNotFound') + `: ${missingTasks.join(', ')}` });
+    }
+
+    for (const task of tasks) {
+      if (!task.memberId) continue;
+      const current = existingTaskMap.get(task.id);
+      const currentMemberId = current?.memberId || current?.memberid || null;
+      if (task.memberId === currentMemberId) continue;
+      if (await memberQueries.isReadOnlyViewerMember(db, task.memberId)) {
+        return res.status(400).json({ error: tTranslator('errors.cannotAssignViewer') });
+      }
     }
     
     // MIGRATED: Get all priorities for lookup
@@ -2810,6 +2899,12 @@ router.post('/:taskId/watchers/:memberId', authenticateToken, async (req, res) =
       req.body?.skipEmail === true;
     
     const tTranslator = await getTranslator(db);
+    if (!userCanMutate(req.user)) {
+      const ownMember = await memberQueries.getMemberByUserId(db, userId);
+      if (!ownMember || ownMember.id !== memberId) {
+        return res.status(403).json({ error: tTranslator('errors.readOnly'), code: 'READ_ONLY' });
+      }
+    }
     // MIGRATED: Get task's board ID for Redis publishing
     const boardId = await taskQueries.getTaskBoardId(db, taskId);
     if (!boardId) {
@@ -2860,11 +2955,18 @@ router.post('/:taskId/watchers/:memberId', authenticateToken, async (req, res) =
 });
 
 // Remove watcher from task
-router.delete('/:taskId/watchers/:memberId', async (req, res) => {
+router.delete('/:taskId/watchers/:memberId', authenticateToken, async (req, res) => {
   try {
     const db = getRequestDatabase(req);
     const tTranslator = await getTranslator(db);
     const { taskId, memberId } = req.params;
+    const userId = req.user?.id || 'system';
+    if (!userCanMutate(req.user)) {
+      const ownMember = await memberQueries.getMemberByUserId(db, userId);
+      if (!ownMember || ownMember.id !== memberId) {
+        return res.status(403).json({ error: tTranslator('errors.readOnly'), code: 'READ_ONLY' });
+      }
+    }
     
     // MIGRATED: Get task's board ID for Redis publishing
     const boardId = await taskQueries.getTaskBoardId(db, taskId);

--- a/server/services/activityLogger.js
+++ b/server/services/activityLogger.js
@@ -432,6 +432,8 @@ export const logTaskActivity = async (userId, action, taskId, details, additiona
           changedField: additionalData.changedField || null,
           projectIdentifier: additionalData.projectIdentifier || projectIdentifier || null,
           taskTicket: additionalData.taskTicket || taskTicket || null,
+          tagId: additionalData.tagId || null,
+          emailChange: additionalData.emailChange || null,
         },
         emailTenantId
       ).catch((notificationError) => {

--- a/server/services/automationTools.js
+++ b/server/services/automationTools.js
@@ -354,9 +354,10 @@ async function resolvePriority(ctx, fields) {
 
 async function searchTasksInternal(ctx, args = {}, allowedBoardIds) {
   const limit = Math.min(
-    Number(args.limit) || AUTOMATION_MAX_TASKS_PER_APPLY,
+    Math.max(1, Number(args.limit) || AUTOMATION_MAX_TASKS_PER_APPLY),
     AUTOMATION_MAX_TASKS_PER_APPLY
   );
+  const offset = Math.max(0, Number(args.offset) || 0);
 
   const conditions = [];
   const params = [];
@@ -367,7 +368,17 @@ async function searchTasksInternal(ctx, args = {}, allowedBoardIds) {
       ? [args.boardId]
       : allowedBoardIds;
 
-  if (!scopeIds.length) return { tasks: [], excludedLaunchTask: false };
+  if (!scopeIds.length) {
+    return {
+      tasks: [],
+      count: 0,
+      totalCount: 0,
+      offset,
+      limit,
+      hasMore: false,
+      excludedLaunchTask: false
+    };
+  }
 
   // Always exclude the automation recipe/launch task from discovery
   if (ctx.launchTaskId) {
@@ -414,39 +425,53 @@ async function searchTasksInternal(ctx, args = {}, allowedBoardIds) {
     idx += 1;
   }
 
-  params.push(limit);
+  const whereSql = conditions.join(' AND ');
+  const countStmt = wrapQuery(
+    ctx.db.prepare(`SELECT COUNT(*)::int AS n FROM tasks t WHERE ${whereSql}`),
+    'SELECT'
+  );
+  const countRow = await countStmt.get(...params);
+  const totalCount = countRow?.n || 0;
+
+  const listParams = [...params, limit, offset];
   const query = `
     SELECT t.id, t.ticket, t.title, t.boardid, t.columnid, t.sprint_id, t.memberid, t.priority, t.description,
            t.deleted_at, b.title AS board_title, c.title AS column_title
     FROM tasks t
     LEFT JOIN boards b ON b.id = t.boardid
     LEFT JOIN columns c ON c.id = t.columnid
-    WHERE ${conditions.join(' AND ')}
+    WHERE ${whereSql}
     ORDER BY t.updated_at DESC NULLS LAST, t.created_at DESC
-    LIMIT $${idx}
+    LIMIT $${idx} OFFSET $${idx + 1}
   `;
 
   const stmt = wrapQuery(ctx.db.prepare(query), 'SELECT');
-  let rows = await stmt.all(...params);
+  const rows = await stmt.all(...listParams);
 
-  if (args.text) {
-    const needle = String(args.text).trim().toLowerCase();
-    rows = rows.filter((row) => {
-      const hay = `${row.title || ''} ${stripHtml(row.description)}`.toLowerCase();
-      return hay.includes(needle);
-    });
-  }
-
-  // Include description previews by default so the model rarely needs N× get_task
-  const includeDescription = args.includeDescription !== false;
-  const tasks = rows.slice(0, limit).map((row) => compactTask(row, { includeDescription }));
+  // Previews are opt-in: default off so bulk assignee searches fit in the runner tool payload.
+  const includeDescription = args.includeDescription === true;
+  const tasks = rows.map((row) => compactTask(row, { includeDescription }));
+  const hasMore = offset + tasks.length < totalCount;
   return {
     tasks,
     count: tasks.length,
+    totalCount,
+    offset,
+    limit,
+    hasMore,
     excludedLaunchTask: Boolean(ctx.launchTaskId),
-    note: ctx.launchTaskId
-      ? 'The automation launch task itself is excluded from search results. Prefer boardTitle/columnTitle in human summaries.'
-      : 'Prefer boardTitle/columnTitle in human summaries; use boardId/columnId only in tool arguments.',
+    note: [
+      hasMore
+        ? `Paged results: ${offset + 1}–${offset + tasks.length} of ${totalCount}. Call search_tasks again with offset=${offset + tasks.length} until hasMore is false before planning bulk updates.`
+        : `Complete result set (${totalCount} match${totalCount === 1 ? '' : 'es'}).`,
+      ctx.launchTaskId
+        ? 'The automation launch task itself is excluded from search results.'
+        : null,
+      'Use assigneeId (from list_members) for “assigned to X”, not text search on the name.',
+      'Prefer boardTitle/columnTitle in human summaries; use boardId/columnId only in tool arguments.'
+    ]
+      .filter(Boolean)
+      .join(' '),
     trash: trashOnly ? 'only' : includeTrash ? 'include' : 'exclude'
   };
 }
@@ -614,9 +639,26 @@ async function toolUpdateTasks(ctx, args, { dryRun }, allowedBoardIds) {
       skippedLaunchTask: true
     };
   }
-  const { fields } = args || {};
-  if (!fields || typeof fields !== 'object') {
-    return { error: 'fields object is required' };
+  const rawFields =
+    args?.fields && typeof args.fields === 'object' && !Array.isArray(args.fields)
+      ? args.fields
+      : {};
+  const fields = { ...rawFields };
+  for (const key of [
+    'memberId',
+    'title',
+    'description',
+    'effort',
+    'startDate',
+    'dueDate',
+    'sprintId',
+    'priority',
+    'priorityId'
+  ]) {
+    if (args[key] !== undefined && fields[key] === undefined) fields[key] = args[key];
+  }
+  if (!Object.keys(fields).length) {
+    return { error: 'fields object is required (e.g. fields.memberId)' };
   }
 
   const updates = {};
@@ -639,6 +681,7 @@ async function toolUpdateTasks(ctx, args, { dryRun }, allowedBoardIds) {
   }
 
   const wouldAffect = [];
+  const snapshots = [];
   for (const taskId of taskIds) {
     const before = await taskQueries.getTaskById(ctx.db, taskId);
     if (!before) return { error: `Task not found: ${taskId}` };
@@ -649,15 +692,25 @@ async function toolUpdateTasks(ctx, args, { dryRun }, allowedBoardIds) {
         inTrash: true
       };
     }
-    wouldAffect.push({ taskId, before: taskSnapshot(before), after: { ...taskSnapshot(before), ...updates } });
+    snapshots.push({ taskId, before: taskSnapshot(before) });
+    wouldAffect.push({
+      taskId,
+      ticket: before.ticket,
+      fields: updates
+    });
   }
 
   if (dryRun) {
-    return { wouldAffect, dryRun: true, skippedLaunchTask: skippedLaunchTask || undefined };
+    return {
+      wouldAffect,
+      count: wouldAffect.length,
+      dryRun: true,
+      skippedLaunchTask: skippedLaunchTask || undefined
+    };
   }
 
   const updatedIds = [];
-  for (const item of wouldAffect) {
+  for (const item of snapshots) {
     await taskQueries.updateTask(ctx.db, item.taskId, updates);
     const after = await taskQueries.getTaskById(ctx.db, item.taskId);
     await journal(ctx, 'update_task', 'task', item.taskId, item.before, taskSnapshot(after));

--- a/server/services/emailTemplates.js
+++ b/server/services/emailTemplates.js
@@ -9,13 +9,17 @@ import {
 import { formatDateTimeLocal } from '../utils/dateFormatter.js';
 // recipientTimeZone: IANA tz from user_settings (browser-synced)
 import {
-  formatDetailsForEmail,
   stripHtmlForEmail,
   formatWordDiffHtml,
   formatWordDiffText,
   buildTaskEmailUrl,
   buildEmailSiteLogo,
 } from '../utils/emailContent.js';
+import {
+  contrastTextForHex,
+  priorityBadgeStyle,
+  shouldUseWordDiff,
+} from '../utils/taskEmailPayload.js';
 
 /**
  * Email language: explicit data.lang → recipient user pref → APP_LANGUAGE → en
@@ -69,10 +73,12 @@ function resolveActionMessageKey(actionType, changedField, notificationType) {
   if (notificationType === 'newTaskAssigned') return 'assigned';
   if (notificationType === 'addedAsCollaborator') return 'added_as_collaborator';
   if (notificationType === 'addedAsWatcher') return 'added_as_watcher';
+  if (actionType === 'delete_task') return 'deleted';
   if (changedField === 'memberId') return 'assignee_changed';
   if (changedField === 'requesterId') return 'requester_changed';
   if (changedField === 'columnId') return 'status_changed';
   if (changedField === 'isBlocked') return 'status_changed';
+  if (changedField === 'priorityId') return 'priority_changed';
   if (!actionType) return 'default';
   return ACTION_MESSAGE_KEY_MAP[actionType] || 'default';
 }
@@ -124,6 +130,18 @@ function escapeHtml(value) {
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;');
+}
+
+function emailPriorityChip(name, hex) {
+  const style = priorityBadgeStyle(hex);
+  return `<span style="display:inline-block;padding:3px 10px;border-radius:999px;font-size:12px;font-weight:600;background-color:${escapeHtml(style.backgroundColor)};color:${escapeHtml(style.color)};">${escapeHtml(name || '')}</span>`;
+}
+
+function emailTagChip(name, hex) {
+  const bg = hex || '#4F46E5';
+  const fg = contrastTextForHex(bg);
+  const border = fg === '#374151' ? 'border:1px solid #d1d5db;' : 'border:1px solid transparent;';
+  return `<span style="display:inline-block;padding:2px 8px;border-radius:999px;font-size:11px;font-weight:600;background-color:${escapeHtml(bg)};color:${escapeHtml(fg)};${border}margin:0 4px 0 0;vertical-align:middle;">${escapeHtml(name || '')}</span>`;
 }
 
 /**
@@ -302,9 +320,7 @@ ${t('emails.userInvite.body6', { siteName: brand })}`,
       user, 
       task, 
       board, 
-      project, 
       actionType, 
-      actionDetails, 
       taskUrl, 
       siteName,
       oldValue,
@@ -313,6 +329,8 @@ ${t('emails.userInvite.body6', { siteName: brand })}`,
       changedField = null,
       notificationType = null,
       recipientTimeZone = null,
+      emailChange = null,
+      isRecentAssignment = false,
       db,
       lang: langOverride,
     } = data;
@@ -324,106 +342,55 @@ ${t('emails.userInvite.body6', { siteName: brand })}`,
     });
     const firstName = displayFirstName(user);
     const boardName = displayBoardName(board);
-    const detailsText = formatDetailsForEmail(actionDetails, lang);
     const taskTitle = task?.title || 'Task';
     const taskHeading = formatTaskHeading(task);
+    const items = (emailChange?.items || []).filter((i) => i && i.field !== 'effort');
+    const showDescriptionAsDetails =
+      isRecentAssignment ||
+      notificationType === 'newTaskAssigned' ||
+      actionType === 'create_task';
+
+    const effectiveActionType =
+      actionType === 'delete_task' ? 'delete_task' : actionType;
+    const effectiveNotificationType =
+      showDescriptionAsDetails && notificationType !== 'requesterTaskCreated'
+        ? 'newTaskAssigned'
+        : notificationType;
 
     const getActionMessage = () => {
+      if (
+        items.filter((i) => i.field !== 'generic').length > 1 &&
+        effectiveActionType !== 'delete_task' &&
+        !showDescriptionAsDetails
+      ) {
+        return t('emails.taskNotification.common.actionMessage.consolidated_update');
+      }
       const actionKey = resolveActionMessageKey(
-        actionType,
+        effectiveActionType,
         changedField,
-        notificationType
+        effectiveNotificationType
       );
       return t(`emails.taskNotification.common.actionMessage.${actionKey}`);
     };
 
-    const getPeopleChangeDetails = () => {
-      const beforeRaw = stripHtmlForEmail(oldValue);
-      const afterRaw = stripHtmlForEmail(newValue);
-      if (!beforeRaw && !afterRaw) return '';
-      if (beforeRaw === afterRaw) return '';
-      // Never surface raw IDs in the people-change card
-      if (looksLikeId(beforeRaw) || looksLikeId(afterRaw)) return '';
-
-      const before =
-        beforeRaw || t('emails.taskNotification.common.unassigned');
-      const after = afterRaw || t('emails.taskNotification.common.unassigned');
-      const fieldLabel =
-        changedField === 'requesterId'
-          ? t('emails.taskNotification.common.fieldRequester')
-          : t('emails.taskNotification.common.fieldAssignee');
-
+    const fromToCard = (label, before, after, beforeHtml = null, afterHtml = null) => {
+      if (!before && !after) return '';
+      if (before === after && !beforeHtml && !afterHtml) return '';
       return `<div style="margin: 14px 0 0 0; background-color: #f9fafb; border: 1px solid #e5e7eb; border-radius: 6px; padding: 12px 14px;">
-          <div style="font-size: 11px; font-weight: 700; color: #4b5563; text-transform: uppercase; letter-spacing: 0.03em; margin-bottom: 10px;">${escapeHtml(fieldLabel)}</div>
+          <div style="font-size: 11px; font-weight: 700; color: #4b5563; text-transform: uppercase; letter-spacing: 0.03em; margin-bottom: 10px;">${escapeHtml(label)}</div>
           <table role="presentation" cellspacing="0" cellpadding="0" border="0" style="width:100%;">
             <tr>
-              <td style="padding: 8px 10px; background:#fef2f2; border-radius:4px; color:#7f1d1d; font-size:14px;">${escapeHtml(before)}</td>
+              <td style="padding: 8px 10px; background:#fef2f2; border-radius:4px; color:#7f1d1d; font-size:14px;">${beforeHtml || escapeHtml(before || '—')}</td>
               <td style="width:36px; text-align:center; color:#9ca3af; font-size:16px;">→</td>
-              <td style="padding: 8px 10px; background:#f0fdf4; border-radius:4px; color:#14532d; font-size:14px; font-weight:600;">${escapeHtml(after)}</td>
+              <td style="padding: 8px 10px; background:#f0fdf4; border-radius:4px; color:#14532d; font-size:14px; font-weight:600;">${afterHtml || escapeHtml(after || '—')}</td>
             </tr>
           </table>
         </div>`;
     };
 
-    const getChangeDetails = () => {
-      if (isPeopleField(changedField)) {
-        return getPeopleChangeDetails();
-      }
-
-      let before = stripHtmlForEmail(oldValue);
-      let after = stripHtmlForEmail(newValue);
-
-      // Localize boolean blocked flag for the recipient language
-      if (changedField === 'isBlocked') {
-        const toBlockedLabel = (value) => {
-          const blocked =
-            value === true ||
-            value === 1 ||
-            value === '1' ||
-            String(value).toLowerCase() === 'true';
-          return blocked ? t('activity.blocked') : t('activity.unblocked');
-        };
-        before = toBlockedLabel(oldValue);
-        after = toBlockedLabel(newValue);
-      }
-
-      if (!before && !after) return '';
-      if (before === after) return '';
-      // People-like short values without changedField (legacy queue rows)
-      if (
-        before.length < 80 &&
-        after.length < 80 &&
-        !before.includes('\n') &&
-        !after.includes('\n') &&
-        (looksLikeId(before) || looksLikeId(after))
-      ) {
-        return '';
-      }
-      if (
-        before.length < 80 &&
-        after.length < 80 &&
-        !before.includes('\n') &&
-        !after.includes('\n') &&
-        !before.includes('<') &&
-        !after.includes('<')
-      ) {
-        // Short non-prose change: From → To (dates, names, priorities, etc.)
-        return `<div style="margin: 14px 0 0 0; background-color: #f9fafb; border: 1px solid #e5e7eb; border-radius: 6px; padding: 12px 14px;">
-          <div style="font-size: 11px; font-weight: 700; color: #4b5563; text-transform: uppercase; letter-spacing: 0.03em; margin-bottom: 10px;">${t('emails.taskNotification.common.changed')}</div>
-          <table role="presentation" cellspacing="0" cellpadding="0" border="0" style="width:100%;">
-            <tr>
-              <td style="padding: 8px 10px; background:#fef2f2; border-radius:4px; color:#7f1d1d; font-size:14px;">${escapeHtml(before || '—')}</td>
-              <td style="width:36px; text-align:center; color:#9ca3af; font-size:16px;">→</td>
-              <td style="padding: 8px 10px; background:#f0fdf4; border-radius:4px; color:#14532d; font-size:14px; font-weight:600;">${escapeHtml(after || '—')}</td>
-            </tr>
-          </table>
-        </div>`;
-      }
-
+    const wordDiffCard = (before, after) => {
       const diffHtml = formatWordDiffHtml(before, after);
       if (!diffHtml) return '';
-
-      // Inline word diff: red strike = removed, green bold = added
       return `<div style="margin: 14px 0 0 0; background-color: #f9fafb; border: 1px solid #e5e7eb; border-radius: 6px; padding: 12px 14px;">
           <div style="font-size: 11px; font-weight: 700; color: #4b5563; text-transform: uppercase; letter-spacing: 0.03em; margin-bottom: 8px;">${t('emails.taskNotification.common.changed')}</div>
           <div style="font-size: 14px; line-height: 1.55; color: #374151;">${diffHtml}</div>
@@ -435,68 +402,203 @@ ${t('emails.userInvite.body6', { siteName: brand })}`,
         </div>`;
     };
 
-    // Format timestamp in the recipient's timezone when known
+    const valueChangeCard = (field, beforeRaw, afterRaw) => {
+      let before = stripHtmlForEmail(beforeRaw);
+      let after = stripHtmlForEmail(afterRaw);
+      if (field === 'isBlocked') {
+        const toBlockedLabel = (value) => {
+          const blocked =
+            value === true ||
+            value === 1 ||
+            value === '1' ||
+            String(value).toLowerCase() === 'true';
+          return blocked ? t('activity.blocked') : t('activity.unblocked');
+        };
+        before = toBlockedLabel(beforeRaw);
+        after = toBlockedLabel(afterRaw);
+      }
+      if (!before && !after) return '';
+      if (before === after) return '';
+      if (looksLikeId(before) || looksLikeId(after)) return '';
+      if (shouldUseWordDiff(before, after, field)) {
+        return wordDiffCard(before, after);
+      }
+      return fromToCard(t('emails.taskNotification.common.changed'), before, after);
+    };
+
+    const buildStructuredDetailsHtml = () => {
+      if (effectiveActionType === 'delete_task') {
+        return escapeHtml(
+          t('emails.taskNotification.common.detailsDeleted', {
+            taskTitle,
+            ticket: task?.ticket || '',
+          })
+        );
+      }
+      if (showDescriptionAsDetails) {
+        const desc = stripHtmlForEmail(task?.description || '');
+        return desc ? escapeHtml(desc) : '';
+      }
+
+      const lines = [];
+      for (const item of items) {
+        if (item.field === 'sprintId') {
+          const name = item.newName || item.oldName || '';
+          if (name) {
+            lines.push(
+              `${escapeHtml(t('emails.taskNotification.common.fieldSprint'))}: "${escapeHtml(name)}"`
+            );
+          }
+        } else if (item.field === 'startDate' || item.field === 'date') {
+          const from = item.oldValue || item.oldName || '';
+          const to = item.newValue || item.newName || '';
+          if (from || to) {
+            lines.push(
+              `${escapeHtml(t('emails.taskNotification.common.fieldDate'))}: ${escapeHtml(
+                t('emails.taskNotification.common.fromTo', {
+                  from: from || '—',
+                  to: to || '—',
+                })
+              )}`
+            );
+          }
+        } else if (item.field === 'tags') {
+          const added = item.added || [];
+          const removed = item.removed || [];
+          if (added.length) {
+            const key =
+              added.length > 1
+                ? 'emails.taskNotification.common.tagsAddedPlural'
+                : 'emails.taskNotification.common.tagsAdded';
+            lines.push(
+              `${escapeHtml(t(key))} ${added.map((tag) => emailTagChip(tag.name, tag.color)).join('')}`
+            );
+          }
+          if (removed.length) {
+            const key =
+              removed.length > 1
+                ? 'emails.taskNotification.common.tagsRemovedPlural'
+                : 'emails.taskNotification.common.tagsRemoved';
+            lines.push(
+              `${escapeHtml(t(key))} ${removed.map((tag) => emailTagChip(tag.name, tag.color)).join('')}`
+            );
+          }
+        } else if (item.field === 'priorityId') {
+          const oldChip = item.oldName
+            ? emailPriorityChip(item.oldName, item.oldColor)
+            : escapeHtml('—');
+          const newChip = item.newName
+            ? emailPriorityChip(item.newName, item.newColor)
+            : escapeHtml('—');
+          lines.push(
+            `${escapeHtml(t('emails.taskNotification.common.fieldPriority'))}: ${oldChip} → ${newChip}`
+          );
+        }
+      }
+      if (lines.length) return lines.join('<br>');
+      if (items.length) return '';
+      return '';
+    };
+
+    const getChangeDetails = () => {
+      if (showDescriptionAsDetails) return '';
+      if (effectiveActionType === 'delete_task') return '';
+
+      const parts = [];
+      if (items.length) {
+        for (const item of items) {
+          if (item.field === 'sprintId' || item.field === 'tags' || item.field === 'priorityId' || item.field === 'startDate' || item.field === 'delete') {
+            continue;
+          }
+          if (item.field === 'memberId' || item.field === 'requesterId') {
+            if (showDescriptionAsDetails) continue;
+            const before = item.oldName || item.oldValue || '';
+            const after = item.newName || item.newValue || '';
+            const label =
+              item.field === 'requesterId'
+                ? t('emails.taskNotification.common.fieldRequester')
+                : t('emails.taskNotification.common.fieldAssignee');
+            parts.push(fromToCard(label, before || t('emails.taskNotification.common.unassigned'), after || t('emails.taskNotification.common.unassigned')));
+            continue;
+          }
+          parts.push(valueChangeCard(item.field, item.oldValue, item.newValue));
+        }
+        return parts.join('');
+      }
+
+      if (isPeopleField(changedField) && !showDescriptionAsDetails) {
+        const beforeRaw = stripHtmlForEmail(oldValue);
+        const afterRaw = stripHtmlForEmail(newValue);
+        if (!beforeRaw && !afterRaw) return '';
+        if (looksLikeId(beforeRaw) || looksLikeId(afterRaw)) return '';
+        const label =
+          changedField === 'requesterId'
+            ? t('emails.taskNotification.common.fieldRequester')
+            : t('emails.taskNotification.common.fieldAssignee');
+        return fromToCard(
+          label,
+          beforeRaw || t('emails.taskNotification.common.unassigned'),
+          afterRaw || t('emails.taskNotification.common.unassigned')
+        );
+      }
+      return valueChangeCard(changedField, oldValue, newValue);
+    };
+
     const formattedTimestamp = formatDateTimeLocal(
       timestamp || new Date(),
       recipientTimeZone
     );
     
-    // Get task ticket for subject
     const taskTicket = task?.ticket || '';
     const ticketPrefix = taskTicket ? `[ ${taskTicket} ] ` : '';
     const actionMessage = getActionMessage();
-    const typeSpecificSubject =
-      notificationType === 'addedAsCollaborator' ||
-      notificationType === 'addedAsWatcher' ||
-      notificationType === 'newTaskAssigned' ||
-      notificationType === 'myTaskUpdated' ||
-      notificationType === 'watchedTaskUpdated' ||
-      notificationType === 'collaboratingTaskUpdated' ||
-      notificationType === 'requesterTaskCreated' ||
-      notificationType === 'requesterTaskUpdated'
-        ? t(`emails.taskNotification.${notificationType}.subject`, { taskTitle })
-        : null;
+    const knownTypes = [
+      'addedAsCollaborator',
+      'addedAsWatcher',
+      'newTaskAssigned',
+      'myTaskUpdated',
+      'watchedTaskUpdated',
+      'collaboratingTaskUpdated',
+      'requesterTaskCreated',
+      'requesterTaskUpdated',
+    ];
+    let subjectKey = knownTypes.includes(effectiveNotificationType)
+      ? `emails.taskNotification.${effectiveNotificationType}.subject`
+      : null;
+    if (effectiveActionType === 'delete_task') {
+      subjectKey = 'emails.taskNotification.common.subjectDeleted';
+    }
+    const typeSpecificSubject = subjectKey
+      ? t(subjectKey, { taskTitle })
+      : null;
     const emailSubject = typeSpecificSubject
       ? `${ticketPrefix}${typeSpecificSubject}`
       : `${ticketPrefix}${actionMessage} - ${taskTitle}`;
     const receivingReason =
-      notificationType === 'addedAsCollaborator' ||
-      notificationType === 'addedAsWatcher' ||
-      notificationType === 'newTaskAssigned' ||
-      notificationType === 'myTaskUpdated' ||
-      notificationType === 'watchedTaskUpdated' ||
-      notificationType === 'collaboratingTaskUpdated' ||
-      notificationType === 'requesterTaskCreated' ||
-      notificationType === 'requesterTaskUpdated'
-        ? t(`emails.taskNotification.${notificationType}.receivingReason`)
+      knownTypes.includes(effectiveNotificationType)
+        ? t(`emails.taskNotification.${effectiveNotificationType}.receivingReason`)
         : t('emails.taskNotification.common.receivingReason');
-    const beforeTextRaw = stripHtmlForEmail(oldValue);
-    const afterTextRaw = stripHtmlForEmail(newValue);
-    let beforeText = beforeTextRaw;
-    let afterText = afterTextRaw;
-    if (changedField === 'isBlocked') {
-      const toBlockedLabel = (value) => {
-        const blocked =
-          value === true ||
-          value === 1 ||
-          value === '1' ||
-          String(value).toLowerCase() === 'true';
-        return blocked ? t('activity.blocked') : t('activity.unblocked');
-      };
-      beforeText = toBlockedLabel(oldValue);
-      afterText = toBlockedLabel(newValue);
-    }
+
+    const detailsHtml = buildStructuredDetailsHtml();
+    const detailsTextPlain = detailsHtml
+      ? detailsHtml.replace(/<br\s*\/?>/gi, '\n').replace(/<[^>]+>/g, '').replace(/&quot;/g, '"').replace(/&amp;/g, '&')
+      : '';
+    const changeHtml = getChangeDetails();
     let textChangeBlock = '';
-    if (
-      beforeText !== afterText &&
-      (beforeText || afterText) &&
-      !looksLikeId(beforeText) &&
-      !looksLikeId(afterText)
-    ) {
-      if (isPeopleField(changedField) || (beforeText.length < 80 && afterText.length < 80)) {
-        textChangeBlock = `\n${t('emails.taskNotification.common.changed')} ${beforeText || '—'} → ${afterText || '—'}\n`;
-      } else {
-        textChangeBlock = `\n${t('emails.taskNotification.common.changed')} ${formatWordDiffText(beforeText, afterText)}\n`;
+    if (!showDescriptionAsDetails && effectiveActionType !== 'delete_task') {
+      const beforeText = stripHtmlForEmail(oldValue);
+      const afterText = stripHtmlForEmail(newValue);
+      if (
+        beforeText !== afterText &&
+        (beforeText || afterText) &&
+        !looksLikeId(beforeText) &&
+        !looksLikeId(afterText)
+      ) {
+        if (shouldUseWordDiff(beforeText, afterText, changedField)) {
+          textChangeBlock = `\n${t('emails.taskNotification.common.changed')} ${formatWordDiffText(beforeText, afterText)}\n`;
+        } else if (isPeopleField(changedField) || !shouldUseWordDiff(beforeText, afterText, changedField)) {
+          textChangeBlock = `\n${t('emails.taskNotification.common.changed')} ${beforeText || '—'} → ${afterText || '—'}\n`;
+        }
       }
     }
 
@@ -506,23 +608,19 @@ ${t('emails.userInvite.body6', { siteName: brand })}`,
 
 ${t('emails.taskNotification.common.actionInBoard', { actionMessage, boardName })}
 
-Task: ${taskHeading}
-${project ? `${t('emails.taskNotification.common.project')} ${project}` : ''}
-${t('emails.taskNotification.common.details')} ${detailsText}
+${taskHeading}
+${t('emails.taskNotification.common.project')} ${boardName}
+${t('emails.taskNotification.common.timestamp')} ${formattedTimestamp}
+${detailsTextPlain ? `${t('emails.taskNotification.common.details')}\n${detailsTextPlain}` : ''}
 ${textChangeBlock}
 ${t('emails.taskNotification.common.viewTask')}: ${taskUrl}
 
-Best regards,
 ${t('emails.taskNotification.common.teamSignature', { siteName: siteName || 'Agila' })}`,
       html: `
         <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
-          <div style="text-align: center; margin-bottom: 30px;">
-            <h1 style="color: #2563eb; margin: 0;">📋 ${t('emails.taskNotification.common.taskNotification')}</h1>
-          </div>
-          
           <div style="background-color: #f8fafc; padding: 20px; border-radius: 8px; margin-bottom: 20px;">
-            <h2 style="color: #374151; margin-top: 0;">${t('emails.taskNotification.common.hi', { firstName })}</h2>
-            <p style="color: #6b7280; line-height: 1.6; font-size: 16px;">
+            <p style="color: #374151; margin: 0 0 8px 0; font-size: 16px;">${t('emails.taskNotification.common.hi', { firstName })}</p>
+            <p style="color: #6b7280; line-height: 1.6; font-size: 16px; margin: 0;">
               ${t('emails.taskNotification.common.actionInBoard', {
                 actionMessage: escapeHtml(actionMessage),
                 boardName: `<strong>${escapeHtml(boardName)}</strong>`,
@@ -531,11 +629,11 @@ ${t('emails.taskNotification.common.teamSignature', { siteName: siteName || 'Agi
           </div>
 
           <div style="background-color: #fff; border: 1px solid #e5e7eb; padding: 20px; border-radius: 8px; margin-bottom: 20px;">
-            <h3 style="color: #1f2937; margin-top: 0; font-size: 18px;">📝 ${escapeHtml(taskHeading)}</h3>
-            ${project ? `<p style="color: #6b7280; margin: 5px 0;"><strong>${t('emails.taskNotification.common.project')}</strong> ${escapeHtml(project)}</p>` : ''}
+            <h3 style="color: #1f2937; margin-top: 0; font-size: 18px;">${escapeHtml(taskHeading)}</h3>
+            <p style="color: #6b7280; margin: 5px 0;"><strong>${t('emails.taskNotification.common.project')}</strong> ${escapeHtml(boardName)}</p>
             <p style="color: #6b7280; margin: 5px 0; font-size: 14px;"><strong>${t('emails.taskNotification.common.timestamp')}</strong> ${escapeHtml(formattedTimestamp)}</p>
-            <p style="color: #374151; margin: 10px 0;"><strong>${t('emails.taskNotification.common.details')}</strong> ${escapeHtml(detailsText)}</p>
-            ${getChangeDetails()}
+            ${detailsHtml ? `<div style="color: #374151; margin: 12px 0 0 0; line-height: 1.55;"><strong>${t('emails.taskNotification.common.details')}</strong><div style="margin-top:6px;">${detailsHtml}</div></div>` : ''}
+            ${changeHtml}
           </div>
           
           <div style="text-align: center; margin: 30px 0;">
@@ -543,7 +641,7 @@ ${t('emails.taskNotification.common.teamSignature', { siteName: siteName || 'Agi
               <tr>
                 <td align="center" style="border-radius: 6px; background-color: #2563eb;">
                   <a href="${taskUrl}" target="_blank" style="display: inline-block; padding: 12px 24px; color: #ffffff; text-decoration: none; border-radius: 6px; font-weight: bold;">
-                    👀 ${t('emails.taskNotification.common.viewTask')}
+                    ${t('emails.taskNotification.common.viewTask')}
                   </a>
                 </td>
               </tr>
@@ -630,10 +728,6 @@ ${t('emails.taskNotification.common.teamSignature', { siteName: siteName || 'Agi
       attachments: emailAttachments,
       html: `
         <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
-          <div style="text-align: center; margin-bottom: 30px;">
-            <h1 style="color: #2563eb; margin: 0;">💬 ${t('emails.commentNotification.title')}</h1>
-          </div>
-          
           <div style="background-color: #f8fafc; padding: 20px; border-radius: 8px; margin-bottom: 20px;">
             <h2 style="color: #374151; margin-top: 0;">${t('emails.taskNotification.common.hi', { firstName })}</h2>
             <p style="color: #6b7280; line-height: 1.6;">
@@ -643,7 +737,7 @@ ${t('emails.taskNotification.common.teamSignature', { siteName: siteName || 'Agi
 
           <div style="background-color: #fff; border: 1px solid #e5e7eb; padding: 20px; border-radius: 8px; margin-bottom: 20px;">
             <h3 style="color: #1f2937; margin-top: 0;">📝 ${escapeHtml(taskHeading)}</h3>
-            ${project ? `<p style="color: #6b7280; margin: 5px 0;"><strong>${t('emails.taskNotification.common.project')}</strong> ${escapeHtml(project)}</p>` : ''}
+            ${project ? `<p style="color: #6b7280; margin: 5px 0;"><strong>${t('emails.taskNotification.common.project')}</strong> ${escapeHtml(boardName)}</p>` : ''}
             <p style="color: #6b7280; margin: 5px 0;"><strong>${t('emails.taskNotification.common.board')}</strong> ${escapeHtml(boardName)}</p>
             <p style="color: #6b7280; margin: 5px 0; font-size: 14px;"><strong>${t('emails.taskNotification.common.timestamp')}</strong> ${escapeHtml(formattedTimestamp)}</p>
           </div>

--- a/server/services/notificationThrottler.js
+++ b/server/services/notificationThrottler.js
@@ -8,8 +8,16 @@ import {
   buildTaskEmailUrl,
 } from '../utils/emailContent.js';
 import { getUserTimeZone } from '../utils/dateFormatter.js';
-import { parseRetentionDays } from '../utils/retentionSettings.js';
-import { resolveCorrespondenceLanguage, getTranslatorForLanguage } from '../utils/i18n.js';
+import { publishNotificationQueueUpdated } from '../utils/publishNotificationQueueUpdated.js';
+import { resolveCorrespondenceLanguage } from '../utils/i18n.js';
+import {
+  refreshTaskSnapshot,
+  mergeEmailChange,
+  mergeEmailChangesFromActors,
+  emailChangeIsSilent,
+  isRecentlyCreatedTask,
+  ensureTagEmailChange,
+} from '../utils/taskEmailPayload.js';
 
 export { formatDetailsForEmail };
 
@@ -24,6 +32,10 @@ class NotificationThrottler {
   constructor(db, tenantId = null) {
     this.db = db;
     this.tenantId = tenantId;
+  }
+
+  notifyQueueChanged() {
+    publishNotificationQueueUpdated(this.tenantId).catch(() => {});
   }
 
   /**
@@ -64,6 +76,17 @@ class NotificationThrottler {
     }
     
     const delay = await this.getNotificationDelay();
+
+    const incomingChange = notificationData.actor?.emailChange;
+    if (
+      notificationData.action !== 'create_task' &&
+      notificationData.action !== 'delete_task' &&
+      notificationData.action !== 'restore_task' &&
+      notificationData.action !== 'copy_task' &&
+      emailChangeIsSilent(incomingChange)
+    ) {
+      return Promise.resolve();
+    }
     
     // If delay is 0, send immediately
     if (delay === 0) {
@@ -80,16 +103,35 @@ class NotificationThrottler {
           SELECT id, change_count, first_change_time, task_data, participants_data, actor_data
           FROM notification_queue
           WHERE user_id = ? AND task_id = ? AND status = 'pending'
+          ORDER BY created_at ASC
+          LIMIT 1
         `),
         'SELECT'
       ).get(userId, taskId);
 
       if (existing) {
-        // Update existing notification - accumulate changes
-        const taskData = JSON.parse(existing.task_data);
-        const participantsData = JSON.parse(existing.participants_data);
-        
-        // Merge changes (keep most recent actor and data)
+        const prevActor = JSON.parse(existing.actor_data || '{}');
+        const mergedChange = mergeEmailChange(
+          prevActor.emailChange,
+          notificationData.actor?.emailChange
+        );
+        if (
+          notificationData.action !== 'create_task' &&
+          notificationData.action !== 'delete_task' &&
+          notificationData.action !== 'restore_task' &&
+          notificationData.action !== 'copy_task' &&
+          emailChangeIsSilent(mergedChange) &&
+          emailChangeIsSilent(prevActor.emailChange)
+        ) {
+          return;
+        }
+        const mergedActor = {
+          ...notificationData.actor,
+          emailChange: mergedChange,
+        };
+        const nextAction =
+          notificationData.action === 'effort' ? existing.action : notificationData.action;
+
         await wrapQuery(
           this.db.prepare(`
             UPDATE notification_queue
@@ -109,25 +151,25 @@ class NotificationThrottler {
           `),
           'UPDATE'
         ).run(
-          notificationData.action,
+          nextAction,
           notificationData.details,
           notificationData.oldValue || null,
           notificationData.newValue || null,
           JSON.stringify(notificationData.task),
           JSON.stringify(notificationData.participants),
-          JSON.stringify(notificationData.actor),
+          JSON.stringify(mergedActor),
           now.toISOString(),
           scheduledSendTime.toISOString(),
           existing.id
         );
 
         console.log(`📧 [THROTTLER] Updated existing notification ${existing.id} for user ${userId}, task ${taskId}. Change count: ${existing.change_count + 1}`);
+        this.notifyQueueChanged();
       } else {
-        // Create new notification entry
         const notificationId = crypto.randomUUID();
-        
-        await wrapQuery(
-          this.db.prepare(`
+        try {
+          await wrapQuery(
+            this.db.prepare(`
             INSERT INTO notification_queue (
               id, user_id, task_id, notification_type, action, details,
               old_value, new_value, task_data, participants_data, actor_data,
@@ -135,27 +177,45 @@ class NotificationThrottler {
               change_count, created_at, updated_at
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
           `),
-          'INSERT'
-        ).run(
-          notificationId,
-          userId,
-          taskId,
-          notificationData.notificationType,
-          notificationData.action,
-          notificationData.details,
-          notificationData.oldValue || null,
-          notificationData.newValue || null,
-          JSON.stringify(notificationData.task),
-          JSON.stringify(notificationData.participants),
-          JSON.stringify(notificationData.actor),
-          'pending',
-          scheduledSendTime.toISOString(),
-          now.toISOString(),
-          now.toISOString(),
-          1
-        );
-
-        console.log(`📧 [THROTTLER] Created notification ${notificationId} for user ${userId}, task ${taskId}. Will send at ${scheduledSendTime.toISOString()}`);
+            'INSERT'
+          ).run(
+            notificationId,
+            userId,
+            taskId,
+            notificationData.notificationType,
+            notificationData.action,
+            notificationData.details,
+            notificationData.oldValue || null,
+            notificationData.newValue || null,
+            JSON.stringify(notificationData.task),
+            JSON.stringify(notificationData.participants),
+            JSON.stringify(notificationData.actor),
+            'pending',
+            scheduledSendTime.toISOString(),
+            now.toISOString(),
+            now.toISOString(),
+            1
+          );
+          console.log(`📧 [THROTTLER] Created notification ${notificationId} for user ${userId}, task ${taskId}. Will send at ${scheduledSendTime.toISOString()}`);
+          this.notifyQueueChanged();
+        } catch (insertErr) {
+          const isUnique =
+            insertErr?.code === '23505' ||
+            /unique|duplicate key/i.test(String(insertErr?.message || ''));
+          if (!isUnique) throw insertErr;
+          const raced = await wrapQuery(
+            this.db.prepare(`
+              SELECT id, change_count, first_change_time, task_data, participants_data, actor_data
+              FROM notification_queue
+              WHERE user_id = ? AND task_id = ? AND status = 'pending'
+              ORDER BY created_at DESC
+              LIMIT 1
+            `),
+            'SELECT'
+          ).get(userId, taskId);
+          if (!raced) throw insertErr;
+          await this.addNotification(userId, taskId, notificationData);
+        }
       }
     } catch (error) {
       console.error(`❌ [THROTTLER] Failed to queue notification for user ${userId}, task ${taskId}:`, error);
@@ -265,7 +325,23 @@ class NotificationThrottler {
       // Parse stored JSON data from the most recent notification
       const task = JSON.parse(baseNotification.task_data);
       const participants = JSON.parse(baseNotification.participants_data);
-      const actor = JSON.parse(baseNotification.actor_data);
+      const actors = [...notifications]
+        .sort(
+          (a, b) =>
+            new Date(a.last_change_time || a.first_change_time || 0).getTime() -
+            new Date(b.last_change_time || b.first_change_time || 0).getTime()
+        )
+        .map((row) => {
+        try {
+          return JSON.parse(row.actor_data || '{}');
+        } catch {
+          return {};
+        }
+      });
+      const actor = {
+        ...actors[actors.length - 1],
+        emailChange: mergeEmailChangesFromActors(actors),
+      };
 
       // Get recipient user info (alias both casings for template safety)
       const recipientUser = await wrapQuery(
@@ -337,14 +413,31 @@ class NotificationThrottler {
       // Recipient language: user pref → APP_LANGUAGE → en
       const recipientId = recipientUser.id || recipientUser.userId;
       const lang = await resolveCorrespondenceLanguage(this.db, recipientId);
-      const tLang = getTranslatorForLanguage(lang);
-      const actionType = notifications.length > 1 ? 'consolidated_update' : baseNotification.action;
-      const actionDetails =
-        notifications.length > 1
-          ? tLang('emails.taskNotification.common.consolidatedChanges', {
-              count: notifications.length,
-            })
-          : formatDetailsForEmail(baseNotification.details, lang);
+      const refreshedTask = await refreshTaskSnapshot(this.db, task);
+      const emailChange = await ensureTagEmailChange(
+        this.db,
+        baseNotification.action,
+        actor?.emailChange || null,
+        baseNotification.details,
+        actor?.tagId || null
+      );
+      const visibleItems = (emailChange?.items || []).filter(
+        (i) => i && i.field !== 'effort' && i.field !== 'generic'
+      );
+      const actionType =
+        visibleItems.length > 1 ? 'consolidated_update' : baseNotification.action;
+      const actionDetails = formatDetailsForEmail(baseNotification.details, lang);
+      const firstChangeTime =
+        [...notifications]
+          .map((n) => n.first_change_time || n.last_change_time)
+          .filter(Boolean)
+          .sort((a, b) => new Date(a).getTime() - new Date(b).getTime())[0] ||
+        baseNotification.last_change_time;
+      const assigneeUserId = emailChange?.newAssigneeUserId;
+      const isRecentAssignment =
+        Boolean(assigneeUserId) &&
+        String(assigneeUserId) === String(recipientId) &&
+        isRecentlyCreatedTask(refreshedTask, firstChangeTime);
 
       const boardTitle = boardInfo?.title || 'Board';
       const changedField = actor?.changedField || null;
@@ -356,7 +449,7 @@ class NotificationThrottler {
       // Create email template data
       const emailTemplateData = {
         user: recipientUser,
-        task: task,
+        task: refreshedTask,
         board: {
           id: boardInfo?.id || task.boardId || task.boardid,
           title: boardTitle,
@@ -374,6 +467,8 @@ class NotificationThrottler {
         timestamp: baseNotification.last_change_time,
         recipientTimeZone,
         lang,
+        emailChange,
+        isRecentAssignment,
         db: this.db
       };
 
@@ -403,6 +498,7 @@ class NotificationThrottler {
       ).run(...notificationIds);
 
       console.log(`✅ [THROTTLER] Grouped notification sent successfully (${notifications.length} change(s))`);
+      this.notifyQueueChanged();
 
     } catch (error) {
       console.error(`❌ [THROTTLER] Failed to send grouped notification:`, error);
@@ -483,14 +579,27 @@ class NotificationThrottler {
       // Recipient language: user pref → APP_LANGUAGE → en
       const recipientId = recipientUser.id || recipientUser.userId;
       const lang = await resolveCorrespondenceLanguage(this.db, recipientId);
-      const tLang = getTranslatorForLanguage(lang);
-      const actionType = queuedNotification.change_count > 1 ? 'consolidated_update' : queuedNotification.action;
-      const actionDetails =
-        queuedNotification.change_count > 1
-          ? tLang('emails.taskNotification.common.consolidatedChanges', {
-              count: queuedNotification.change_count,
-            })
-          : formatDetailsForEmail(queuedNotification.details, lang);
+      const refreshedTask = await refreshTaskSnapshot(this.db, task);
+      const emailChange = await ensureTagEmailChange(
+        this.db,
+        queuedNotification.action,
+        actor?.emailChange || null,
+        queuedNotification.details,
+        actor?.tagId || null
+      );
+      const visibleItems = (emailChange?.items || []).filter(
+        (i) => i && i.field !== 'effort' && i.field !== 'generic'
+      );
+      const actionType =
+        visibleItems.length > 1 ? 'consolidated_update' : queuedNotification.action;
+      const actionDetails = formatDetailsForEmail(queuedNotification.details, lang);
+      const firstChangeTime =
+        queuedNotification.first_change_time || queuedNotification.last_change_time;
+      const assigneeUserId = emailChange?.newAssigneeUserId;
+      const isRecentAssignment =
+        Boolean(assigneeUserId) &&
+        String(assigneeUserId) === String(recipientId) &&
+        isRecentlyCreatedTask(refreshedTask, firstChangeTime);
       const boardTitle = boardInfo?.title || 'Board';
       const changedField = actor?.changedField || null;
       const recipientTimeZone = await getUserTimeZone(
@@ -501,7 +610,7 @@ class NotificationThrottler {
       // Create email template data
       const emailTemplateData = {
         user: recipientUser,
-        task: task,
+        task: refreshedTask,
         board: {
           id: boardInfo?.id || task.boardId || task.boardid,
           title: boardTitle,
@@ -519,6 +628,8 @@ class NotificationThrottler {
         timestamp: queuedNotification.last_change_time,
         recipientTimeZone,
         lang,
+        emailChange,
+        isRecentAssignment,
         db: this.db
       };
 
@@ -545,6 +656,7 @@ class NotificationThrottler {
       ).run(queuedNotification.id);
 
       console.log(`✅ [THROTTLER] Notification ${queuedNotification.id} sent successfully (${queuedNotification.change_count} change(s))`);
+      this.notifyQueueChanged();
 
     } catch (error) {
       console.error(`❌ [THROTTLER] Failed to send notification ${queuedNotification.id}:`, error);

--- a/server/services/taskEmailNotificationService.js
+++ b/server/services/taskEmailNotificationService.js
@@ -3,6 +3,7 @@ import { EmailTemplates } from './emailTemplates.js';
 import { wrapQuery } from '../utils/queryLogger.js';
 import { getNotificationThrottlerForDb } from './notificationThrottler.js';
 import { activity as activityQueries, tasks as taskQueries, helpers } from '../utils/sqlManager/index.js';
+import { emailChangeIsSilent, refreshTaskSnapshot, ensureTagEmailChange } from '../utils/taskEmailPayload.js';
 import { buildTaskEmailUrl, buildEmailAuthorAvatar } from '../utils/emailContent.js';
 import { getUserTimeZone } from '../utils/dateFormatter.js';
 import { getTenantStoragePaths } from '../middleware/tenantRouting.js';
@@ -175,9 +176,12 @@ class TaskEmailNotificationService {
           memberId,
           requesterId,
           title: task.title,
+          description: task.description || '',
           ticket: task.ticket,
           boardId,
           projectId,
+          created_at: task.created_at || task.createdAt || null,
+          createdAt: task.created_at || task.createdAt || null,
         },
         projectId,
         boardTitle: board?.title || 'Board',
@@ -371,9 +375,12 @@ class TaskEmailNotificationService {
         changedField = null,
         projectIdentifier = null,
         taskTicket: activityTaskTicket = null,
+        emailChange: incomingEmailChange = null,
+        tagId = null,
       } = activityData;
       if (!userId || !taskId || !action) return;
       if (this.isDuplicateBurst(userId, action, taskId)) return;
+      if (changedField === 'effort' && !incomingEmailChange?.items?.length) return;
 
       const participants = await this.getTaskParticipants(taskId);
       if (!participants.task) return;
@@ -396,13 +403,86 @@ class TaskEmailNotificationService {
         newValue
       );
 
+      let emailChange = incomingEmailChange;
+      if (!emailChange) {
+        if (action === 'delete_task') {
+          emailChange = { items: [{ field: 'delete' }] };
+        } else if (changedField && changedField !== 'effort') {
+          emailChange = {
+            items: [
+              {
+                field: changedField,
+                oldValue: display.oldValue,
+                newValue: display.newValue,
+                oldName: display.oldValue,
+                newName: display.newValue,
+              },
+            ],
+            newAssigneeUserId: display.newAssigneeUserId,
+          };
+        } else if (action === 'associate_tag' || action === 'disassociate_tag') {
+          emailChange = { items: [] };
+        } else {
+          emailChange = { items: [{ field: 'generic' }] };
+        }
+      }
+      emailChange = await ensureTagEmailChange(
+        this.db,
+        action,
+        emailChange,
+        details,
+        tagId
+      );
+      if (
+        action !== 'create_task' &&
+        action !== 'delete_task' &&
+        action !== 'restore_task' &&
+        action !== 'copy_task' &&
+        emailChangeIsSilent(emailChange)
+      ) {
+        return;
+      }
+      emailChange = {
+        ...emailChange,
+        items: emailChange.items || [],
+        newAssigneeUserId:
+          emailChange.newAssigneeUserId || display.newAssigneeUserId || null,
+      };
+      const resolvedItems = [];
+      for (const item of emailChange.items) {
+        if (item.field === 'memberId' || item.field === 'requesterId') {
+          const names = await this.resolvePeopleDisplayValues(
+            item.field,
+            item.oldValue ?? item.oldName,
+            item.newValue ?? item.newName
+          );
+          resolvedItems.push({
+            ...item,
+            oldName: names.oldValue,
+            newName: names.newValue,
+            oldValue: names.oldValue,
+            newValue: names.newValue,
+          });
+          if (item.field === 'memberId' && names.newAssigneeUserId) {
+            emailChange.newAssigneeUserId = names.newAssigneeUserId;
+          }
+        } else {
+          resolvedItems.push(item);
+        }
+      }
+      emailChange.items = resolvedItems;
+
       const notifications = this.determineNotifications(
         action,
         participants,
         userId,
         {
-          changedField,
-          newAssigneeUserId: display.newAssigneeUserId,
+          changedField:
+            changedField ||
+            (emailChange.items || []).find((i) => i.field === 'memberId')?.field ||
+            null,
+          newAssigneeUserId:
+            emailChange.newAssigneeUserId || display.newAssigneeUserId,
         }
       );
       const throttler = getNotificationThrottlerForDb(this.db, this.tenantId);
@@ -414,6 +494,8 @@ class TaskEmailNotificationService {
       const actorWithMeta = {
         ...actor,
         changedField: changedField || null,
+        emailChange,
+        tagId: tagId || null,
       };
 
       for (const { recipientUserId, notificationType } of notifications) {
@@ -623,10 +705,11 @@ class TaskEmailNotificationService {
       const { getTranslatorForUser } = await import('../utils/i18n.js');
       const t = await getTranslatorForUser(this.db, recipientUserId);
       const actionDetails = `${t('emails.taskNotification.addedAsCollaborator.addedBy')} ${actorName}`;
+      const liveTask = await refreshTaskSnapshot(this.db, participants.task);
 
       const emailContent = await EmailTemplates.taskNotification({
         user: recipient,
-        task: participants.task,
+        task: liveTask,
         board: {
           id: participants.task.boardId,
           name: participants.boardTitle || 'Board',
@@ -716,10 +799,11 @@ class TaskEmailNotificationService {
       const { getTranslatorForUser } = await import('../utils/i18n.js');
       const t = await getTranslatorForUser(this.db, recipientUserId);
       const actionDetails = `${t('emails.taskNotification.addedAsWatcher.addedBy')} ${actorName}`;
+      const liveTask = await refreshTaskSnapshot(this.db, participants.task);
 
       const emailContent = await EmailTemplates.taskNotification({
         user: recipient,
-        task: participants.task,
+        task: liveTask,
         board: {
           id: participants.task.boardId,
           name: participants.boardTitle || 'Board',

--- a/server/services/websocketService.js
+++ b/server/services/websocketService.js
@@ -524,6 +524,14 @@ class WebSocketService {
       }
     });
 
+    postgresNotificationService.subscribeToAllTenants('notification-queue-updated', (data, tenantId) => {
+      if (tenantId) {
+        this.io?.to(`tenant-${tenantId}`).emit('notification-queue-updated', data);
+      } else {
+        this.io?.emit('notification-queue-updated', data);
+      }
+    });
+
     // Admin user management events - broadcast to tenant-specific clients
     postgresNotificationService.subscribeToAllTenants('user-created', (data, tenantId) => {
       if (tenantId) {

--- a/server/utils/i18n.js
+++ b/server/utils/i18n.js
@@ -76,7 +76,21 @@ export async function getAppLanguage(db) {
  */
 export function normalizeLanguage(value) {
   if (value == null) return null;
-  const v = String(value).trim().toLowerCase();
+  let raw = value;
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (
+      (trimmed.startsWith('"') && trimmed.endsWith('"')) ||
+      (trimmed.startsWith("'") && trimmed.endsWith("'"))
+    ) {
+      try {
+        raw = JSON.parse(trimmed);
+      } catch {
+        raw = trimmed.slice(1, -1);
+      }
+    }
+  }
+  const v = String(raw || '').trim().toLowerCase();
   if (!v) return null;
   if (v === 'fr' || v.startsWith('fr')) return 'fr';
   if (v === 'en' || v.startsWith('en')) return 'en';

--- a/server/utils/publishNotificationQueueUpdated.js
+++ b/server/utils/publishNotificationQueueUpdated.js
@@ -1,0 +1,13 @@
+import notificationService from '../services/notificationService.js';
+
+export async function publishNotificationQueueUpdated(tenantId = null) {
+  try {
+    await notificationService.publish(
+      'notification-queue-updated',
+      { timestamp: new Date().toISOString() },
+      tenantId
+    );
+  } catch (err) {
+    console.warn('Failed to publish notification-queue-updated:', err.message);
+  }
+}

--- a/server/utils/sqlManager/members.js
+++ b/server/utils/sqlManager/members.js
@@ -44,7 +44,13 @@ export async function getAllMembers(db, includeSystemOrOpts = false) {
       u.bio as "bio",
       u.avatar_path as "avatarPath", 
       u.auth_provider as "authProvider", 
-      u.google_avatar_url as "googleAvatarUrl"
+      u.google_avatar_url as "googleAvatarUrl",
+      COALESCE((
+        SELECT bool_or(r.name = 'viewer') AND NOT bool_or(r.name IN ('admin', 'user'))
+        FROM user_roles ur
+        JOIN roles r ON r.id = ur.role_id
+        WHERE ur.user_id = u.id
+      ), false) AS "isViewer"
     FROM members m
     LEFT JOIN users u ON m.user_id = u.id
     ${whereClause}
@@ -72,7 +78,8 @@ export async function getAllMembers(db, includeSystemOrOpts = false) {
     bio: member.bio || undefined,
     avatarUrl: member.avatarPath,
     authProvider: member.authProvider,
-    googleAvatarUrl: member.googleAvatarUrl
+    googleAvatarUrl: member.googleAvatarUrl,
+    isViewer: member.isViewer === true
   }));
 }
 
@@ -164,6 +171,26 @@ export async function getMemberByUserId(db, userId) {
     color: member.color,
     user_id: member.userId
   };
+}
+
+/**
+ * True when the member's linked user is a read-only viewer (no admin/user role).
+ */
+export async function isReadOnlyViewerMember(db, memberId) {
+  if (!memberId) return false;
+  const query = `
+    SELECT COALESCE(
+      bool_or(r.name = 'viewer') AND NOT bool_or(r.name IN ('admin', 'user')),
+      false
+    ) AS "isViewer"
+    FROM members m
+    JOIN user_roles ur ON ur.user_id = m.user_id
+    JOIN roles r ON r.id = ur.role_id
+    WHERE m.id = $1
+  `;
+  const stmt = wrapQuery(db.prepare(query), 'SELECT');
+  const row = await stmt.get(memberId);
+  return row?.isViewer === true;
 }
 
 /**

--- a/server/utils/taskEmailPayload.js
+++ b/server/utils/taskEmailPayload.js
@@ -1,0 +1,255 @@
+/**
+ * Shared helpers for task-change emails: silent fields, live snapshot, structured details.
+ */
+
+import { tasks as taskQueries } from './sqlManager/index.js';
+import { wrapQuery } from './queryLogger.js';
+
+export const PLACEHOLDER_TITLES = new Set([
+  'new task',
+  'nouvelle tâche',
+  'nouvelle tache',
+]);
+
+export function isPlaceholderTitle(title) {
+  return PLACEHOLDER_TITLES.has(String(title || '').trim().toLowerCase());
+}
+
+export function isSilentEmailField(field) {
+  return field === 'effort';
+}
+
+export function contrastTextForHex(hex) {
+  const raw = String(hex || '').replace('#', '');
+  if (raw.length < 6) return '#ffffff';
+  const r = parseInt(raw.slice(0, 2), 16);
+  const g = parseInt(raw.slice(2, 4), 16);
+  const b = parseInt(raw.slice(4, 6), 16);
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.62 ? '#374151' : '#ffffff';
+}
+
+export function priorityBadgeStyle(hex) {
+  const color = String(hex || '#6b7280');
+  const raw = color.replace('#', '');
+  let bg = 'rgba(107, 114, 128, 0.12)';
+  if (raw.length >= 6) {
+    const r = parseInt(raw.slice(0, 2), 16);
+    const g = parseInt(raw.slice(2, 4), 16);
+    const b = parseInt(raw.slice(4, 6), 16);
+    bg = `rgba(${r}, ${g}, ${b}, 0.12)`;
+  }
+  return { backgroundColor: bg, color };
+}
+
+export function mergeEmailChange(prev, next) {
+  const a = prev?.items || [];
+  const b = next?.items || [];
+  const byField = new Map();
+  for (const item of [...a, ...b]) {
+    if (!item?.field || isSilentEmailField(item.field)) continue;
+    if (item.field === 'generic') {
+      if (!byField.has('generic')) byField.set('generic', item);
+      continue;
+    }
+    if (item.field === 'tags') {
+      const existing = byField.get('tags') || { field: 'tags', added: [], removed: [] };
+      existing.added = [...(existing.added || []), ...(item.added || [])];
+      existing.removed = [...(existing.removed || []), ...(item.removed || [])];
+      byField.set('tags', existing);
+      continue;
+    }
+    const existing = byField.get(item.field);
+    if (existing) {
+      byField.set(item.field, {
+        ...item,
+        oldValue: existing.oldValue ?? existing.oldName ?? item.oldValue,
+        oldName: existing.oldName ?? existing.oldValue ?? item.oldName,
+        oldColor: existing.oldColor ?? item.oldColor,
+        newValue: item.newValue ?? item.newName ?? existing.newValue,
+        newName: item.newName ?? item.newValue ?? existing.newName,
+        newColor: item.newColor ?? existing.newColor,
+      });
+    } else {
+      byField.set(item.field, item);
+    }
+  }
+  if (byField.size > 1) byField.delete('generic');
+  const items = [...byField.values()];
+  if (items.some((i) => i.field === 'sprintId')) {
+    const filtered = items.filter((i) => i.field !== 'dueDate');
+    return {
+      items: filtered,
+      newAssigneeUserId: next?.newAssigneeUserId || prev?.newAssigneeUserId || null,
+    };
+  }
+  return {
+    items,
+    newAssigneeUserId: next?.newAssigneeUserId || prev?.newAssigneeUserId || null,
+  };
+}
+
+export function mergeEmailChangesFromActors(actors) {
+  return actors.reduce((acc, actor) => mergeEmailChange(acc, actor?.emailChange), {
+    items: [],
+    newAssigneeUserId: null,
+  });
+}
+
+export function emailChangeIsSilent(emailChange) {
+  const items = (emailChange?.items || []).filter((i) => !isSilentEmailField(i.field));
+  return items.length === 0;
+}
+
+function firstQuotedName(text) {
+  let source = text;
+  if (source && typeof source === 'object') {
+    source = source.fr || source.en || '';
+  } else if (typeof source === 'string') {
+    try {
+      const parsed = JSON.parse(source);
+      if (parsed && typeof parsed === 'object') {
+        source = parsed.fr || parsed.en || source;
+      }
+    } catch {
+      /* plain string */
+    }
+  }
+  const match = String(source || '').match(/"([^"]+)"/);
+  return match?.[1]?.trim() || '';
+}
+
+async function lookupTagColor(db, name) {
+  if (!db || !name) return '#4F46E5';
+  try {
+    const row = await wrapQuery(
+      db.prepare('SELECT color FROM tags WHERE tag = ?'),
+      'SELECT'
+    ).get(name);
+    return row?.color || '#4F46E5';
+  } catch {
+    return '#4F46E5';
+  }
+}
+
+/**
+ * Ensure associate/disassociate emails carry chip data (name + board color).
+ */
+export async function ensureTagEmailChange(db, action, emailChange, details, tagId = null) {
+  if (action !== 'associate_tag' && action !== 'disassociate_tag') {
+    return emailChange;
+  }
+
+  let items = [...(emailChange?.items || [])];
+  let tagItem = items.find((i) => i.field === 'tags');
+  if (!tagItem) {
+    let name = '';
+    let color = '#4F46E5';
+    if (tagId && db) {
+      try {
+        const row = await wrapQuery(
+          db.prepare('SELECT tag, color FROM tags WHERE id = ?'),
+          'SELECT'
+        ).get(tagId);
+        if (row) {
+          name = row.tag;
+          color = row.color || color;
+        }
+      } catch {
+        /* fall through */
+      }
+    }
+    if (!name) name = firstQuotedName(details);
+    if (name && color === '#4F46E5') color = await lookupTagColor(db, name);
+    const chip = { name, color };
+    tagItem = {
+      field: 'tags',
+      added: action === 'associate_tag' && name ? [chip] : [],
+      removed: action === 'disassociate_tag' && name ? [chip] : [],
+    };
+    items = [tagItem, ...items.filter((i) => i.field !== 'generic')];
+  } else {
+    const fill = async (chips) =>
+      Promise.all(
+        (chips || []).map(async (chip) => {
+          if (!chip?.name) return chip;
+          if (chip.color) return chip;
+          return { ...chip, color: await lookupTagColor(db, chip.name) };
+        })
+      );
+    tagItem = {
+      ...tagItem,
+      added: await fill(tagItem.added),
+      removed: await fill(tagItem.removed),
+    };
+    items = items.map((i) => (i.field === 'tags' ? tagItem : i));
+  }
+
+  return {
+    ...(emailChange || {}),
+    items,
+  };
+}
+
+export function isRecentlyCreatedTask(task, firstChangeTime, windowMs = 15 * 60 * 1000) {
+  const createdRaw = task?.created_at || task?.createdAt;
+  if (!createdRaw || !firstChangeTime) return false;
+  const created = new Date(createdRaw).getTime();
+  const first = new Date(firstChangeTime).getTime();
+  if (Number.isNaN(created) || Number.isNaN(first)) return false;
+  return first - created >= 0 && first - created < windowMs;
+}
+
+export function shouldUseWordDiff(before, after, field) {
+  if (field === 'description' || field === 'title') return true;
+  const a = String(before || '');
+  const b = String(after || '');
+  if (a.includes('\n') || b.includes('\n')) return true;
+  const words = (s) => s.trim().split(/\s+/).filter(Boolean).length;
+  if (words(a) > 6 || words(b) > 6) return true;
+  if (a.length >= 50 || b.length >= 50) return true;
+  return false;
+}
+
+/**
+ * Overlay live DB title/description/ticket so delayed emails don't ship "New Task".
+ */
+export async function refreshTaskSnapshot(db, task) {
+  if (!db || !task?.id) return task;
+  try {
+    const live = await taskQueries.getTaskById(db, task.id);
+    if (!live) return task;
+    const liveTitle = live.title || task.title;
+    const liveDescription =
+      live.description !== undefined && live.description !== null
+        ? live.description
+        : task.description;
+    return {
+      ...task,
+      title: liveTitle,
+      description: liveDescription,
+      ticket: live.ticket || task.ticket,
+      created_at: live.created_at || live.createdAt || task.created_at || task.createdAt,
+      createdAt: live.created_at || live.createdAt || task.createdAt || task.created_at,
+      memberId: live.memberid || live.memberId || task.memberId,
+      requesterId: live.requesterid || live.requesterId || task.requesterId,
+    };
+  } catch (err) {
+    console.warn('Failed to refresh task snapshot for email:', err.message);
+    return task;
+  }
+}
+
+export async function loadPriorityVisual(db, priorityId) {
+  if (!db || priorityId == null || priorityId === '') return null;
+  try {
+    const row = await wrapQuery(
+      db.prepare('SELECT priority, color FROM priorities WHERE id = ?'),
+      'SELECT'
+    ).get(priorityId);
+    if (!row) return null;
+    return { name: row.priority, color: row.color };
+  } catch {
+    return null;
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3047,7 +3047,7 @@ function AppContent() {
 
     const newTask: Task = {
       id: generateUUID(),
-      title: 'New Task',
+      title: t('taskCard.newTask', { ns: 'common' }),
       description: '',
       memberId: currentUserMember.id,
       startDate: taskStartDate,

--- a/src/api.ts
+++ b/src/api.ts
@@ -4,6 +4,10 @@ import { versionDetection } from './utils/versionDetection';
 import { handleAuthError } from './utils/authErrorHandler';
 import { feDebug } from './utils/clientDebug';
 import { clearMediaSession } from './utils/mediaSession';
+import {
+  readTroubleshootingUnlocked,
+  TROUBLESHOOTING_REQUEST_HEADER,
+} from './utils/troubleshootingAccess';
 
 function summarizeApiPayload(data: unknown, max = 400): string {
   if (data == null) return '';
@@ -962,7 +966,11 @@ export const getStorageInfo = async () => {
 
 // System information (admin only)
 export const getSystemInfo = async () => {
-  const { data } = await api.get('/admin/system-info');
+  const headers: Record<string, string> = {};
+  if (readTroubleshootingUnlocked()) {
+    headers[TROUBLESHOOTING_REQUEST_HEADER] = '1';
+  }
+  const { data } = await api.get('/admin/system-info', { headers });
   return data;
 };
 

--- a/src/components/ColumnBulkActionBar.tsx
+++ b/src/components/ColumnBulkActionBar.tsx
@@ -23,7 +23,7 @@ import { truncateMemberName } from '../utils/memberUtils';
 import AddTagModal from './AddTagModal';
 import MemberAvatar from './ui/MemberAvatar';
 import MemberSearchList from './ui/MemberSearchList';
-import { useFixedColumnFabPosition } from '../hooks/useFixedColumnFabPosition';
+import { layoutMemberDropdownFromElement } from '../utils/memberDropdownLayout';
 
 export type ColumnBulkActionBarProps = {
   columnId: string;
@@ -147,7 +147,9 @@ export default function ColumnBulkActionBar({
   const { t } = useTranslation(['tasks', 'common']);
   const rootRef = useRef<HTMLDivElement>(null);
   const [menu, setMenu] = useState<MenuKind>(null);
-  const [menuPos, setMenuPos] = useState<{ top: number; left: number } | null>(null);
+  const [menuPos, setMenuPos] = useState<
+    { top: number; left: number; width?: number; height?: number; columns?: 1 | 2 } | null
+  >(null);
   const [showAddTagModal, setShowAddTagModal] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState(false);
   const [permanentDeleteConfirm, setPermanentDeleteConfirm] = useState(false);
@@ -178,6 +180,18 @@ export default function ColumnBulkActionBar({
       return;
     }
     const rect = el.getBoundingClientRect();
+    if (kind === 'assignee' || kind === 'requester') {
+      const layout = layoutMemberDropdownFromElement(el, members || [], {
+        showAgent: kind === 'assignee',
+        excludeViewers: kind === 'assignee',
+        placement: 'beside',
+      });
+      setMenuPos(layout);
+      setMenu(kind);
+      setDeleteConfirm(false);
+      setBoardConfirm(null);
+      return;
+    }
     const menuWidth = kind === 'tag' ? 200 : isMemberMenu(kind) ? MEMBER_MENU_WIDTH : 192;
     const menuHeight = kind === 'tag' ? 400 : isMemberMenu(kind) ? 360 : 256;
     const preferredLeft = rect.right + 6;
@@ -303,14 +317,26 @@ export default function ColumnBulkActionBar({
             className={`fixed z-[9990] overflow-hidden rounded-md border border-gray-200 bg-white shadow-lg dark:border-gray-600 dark:bg-gray-800 ${
               menu === 'tag'
                 ? 'max-h-[400px] w-[200px] overflow-y-auto'
-                : isMemberMenu(menu)
-                  ? ''
-                  : 'max-h-64 w-48 overflow-y-auto py-1'
+                : menu === 'assignee' || menu === 'requester'
+                  ? 'flex flex-col'
+                  : isMemberMenu(menu)
+                    ? ''
+                    : 'max-h-64 w-48 overflow-y-auto py-1'
             }`}
             style={{
               top: menuPos.top,
               left: menuPos.left,
-              width: isMemberMenu(menu) ? MEMBER_MENU_WIDTH : undefined,
+              width: isMemberMenu(menu)
+                ? menuPos.width || MEMBER_MENU_WIDTH
+                : undefined,
+              height:
+                menu === 'assignee' || menu === 'requester'
+                  ? menuPos.height
+                  : undefined,
+              maxHeight:
+                menu === 'assignee' || menu === 'requester'
+                  ? menuPos.height
+                  : undefined,
             }}
             role="menu"
           >
@@ -418,6 +444,10 @@ export default function ColumnBulkActionBar({
               <MemberSearchList
                 members={members}
                 showAgentSection
+                excludeViewers
+                columns={menuPos.columns || 1}
+                maxHeightClassName="max-h-none"
+                className="min-h-0 flex-1"
                 onSelect={(memberId) => {
                   onAssignee(memberId);
                   closeMenu();
@@ -429,6 +459,9 @@ export default function ColumnBulkActionBar({
               <MemberSearchList
                 members={members}
                 showAgentSection={false}
+                columns={menuPos.columns || 1}
+                maxHeightClassName="max-h-none"
+                className="min-h-0 flex-1"
                 onSelect={(memberId) => {
                   onRequester(memberId);
                   closeMenu();

--- a/src/components/ListView.tsx
+++ b/src/components/ListView.tsx
@@ -10,13 +10,15 @@ import { getBoardColumns, addTagToTask, removeTagFromTask, createComment } from 
 import DOMPurify from 'dompurify';
 import { generateTaskUrl } from '../utils/routingUtils';
 import { mergeTaskTagsWithLiveData, getTagDisplayStyle } from '../utils/tagUtils';
-import { getAuthenticatedAvatarUrl, getAuthenticatedAttachmentUrl } from '../utils/authImageUrl';
+import { getAuthenticatedAttachmentUrl } from '../utils/authImageUrl';
 import { getLinkTarget, shouldOpenLinkInNewTab } from '../utils/linkUtils';
 import { truncateMemberName } from '../utils/memberUtils';
 import { commentTextToHtml } from '../utils/commentContent';
 import { generateUUID } from '../utils/uuid';
 import { truncateHtmlByChars } from '../utils/plainTextPreview';
 import MemberSearchList from './ui/MemberSearchList';
+import MemberAvatar from './ui/MemberAvatar';
+import { layoutMemberDropdownFromElement } from '../utils/memberDropdownLayout';
 import { CHROME_TOOLTIP_POPOVER_CLASS, CHROME_TOOLTIP_PANEL_SURFACE_CLASS, KanbanChromeTooltip } from './KanbanChromeTooltip';
 import AgentPanel from './AgentPanel';
 import type { AgentPanelView } from './AgentPanel';
@@ -26,9 +28,8 @@ import TextEditor from './TextEditor';
 import AddTagModal from './AddTagModal';
 import AddCommentModal from './AddCommentModal';
 import { putTaskWork, getTaskWork, setTaskWorkControl, type TaskWorkMap } from '../api';
-import { AGENT_MEMBER_ID, SYSTEM_MEMBER_ID } from '../constants/appConstants';
+import { AGENT_MEMBER_ID } from '../constants/appConstants';
 import {
-  getAgentAvatarSrc,
   isAgentMemberId,
   resolveTaskMember,
 } from '../utils/agentMemberUi';
@@ -670,7 +671,13 @@ export default function ListView({
   const [editValue, setEditValue] = useState<string>('');
   const [showDropdown, setShowDropdown] = useState<{taskId: string, field: string} | null>(null);
   const [dropdownPosition, setDropdownPosition] = useState<'above' | 'below'>('below');
-  const [assigneeDropdownCoords, setAssigneeDropdownCoords] = useState<{left: number; top: number; height?: number} | null>(null);
+  const [assigneeDropdownCoords, setAssigneeDropdownCoords] = useState<{
+    left: number;
+    top: number;
+    height?: number;
+    width?: number;
+    columns?: 1 | 2;
+  } | null>(null);
   const [priorityDropdownCoords, setPriorityDropdownCoords] = useState<{left: number; top: number} | null>(null);
   const [statusDropdownCoords, setStatusDropdownCoords] = useState<{left: number; top: number} | null>(null);
   const [tagsDropdownCoords, setTagsDropdownCoords] = useState<{left: number; top: number} | null>(null);
@@ -993,33 +1000,7 @@ export default function ListView({
     return (
       <div className="flex items-center gap-2">
         <div className="flex items-center gap-1">
-          {member.id === SYSTEM_MEMBER_ID ? (
-            <div 
-              className="w-5 h-5 rounded-full flex items-center justify-center text-xs"
-              style={{ backgroundColor: member.color }}
-            >
-              🤖
-            </div>
-          ) : isAgentMemberId(member.id) ? (
-            <img
-              src={getAgentAvatarSrc(member)}
-              alt={member.name}
-              className="w-5 h-5 rounded-full object-cover"
-            />
-          ) : member.googleAvatarUrl || member.avatarUrl ? (
-            <img
-              src={getAuthenticatedAvatarUrl(member.googleAvatarUrl || member.avatarUrl)}
-              alt={member.name}
-              className="w-5 h-5 rounded-full object-cover"
-            />
-          ) : (
-            <div 
-              className="w-5 h-5 rounded-full flex items-center justify-center text-xs font-medium text-white"
-              style={{ backgroundColor: member.color }}
-            >
-              {member.name.charAt(0).toUpperCase()}
-            </div>
-          )}
+          <MemberAvatar member={member} members={members} size="sm" />
           <span className="text-xs text-gray-900 truncate">{truncateMemberName(member.name)}</span>
         </div>
         
@@ -1407,23 +1388,15 @@ export default function ListView({
     
     switch (dropdownType) {
       case 'assignee':
-        dropdownWidth = 280;
         {
-          const searchHeaderHeight = 52;
-          const memberItemHeight = 40;
-          const availableSpaceBelow = window.innerHeight - rect.bottom - 20;
-          const availableSpaceAbove = rect.top - 20;
-          const maxAvailableSpace = Math.max(availableSpaceBelow, availableSpaceAbove);
-          const maxVisibleMembers = Math.floor(
-            Math.max(80, maxAvailableSpace - searchHeaderHeight) / memberItemHeight
-          );
-          const visibleMembers = Math.max(
-            3,
-            Math.min(10, maxVisibleMembers, members?.length || 3)
-          );
-          dropdownHeight = searchHeaderHeight + visibleMembers * memberItemHeight + 16;
+          const layout = layoutMemberDropdownFromElement(element, members || [], {
+            showAgent: true,
+            excludeViewers: true,
+            selectedId: allTasks.find((t) => t.id === showDropdown?.taskId)?.memberId || null,
+            placement: 'below',
+          });
+          return layout;
         }
-        break;
       case 'priority':
         dropdownWidth = 120;
         dropdownHeight = 120;
@@ -2678,7 +2651,7 @@ export default function ListView({
           style={{
             left: `${assigneeDropdownCoords.left}px`,
             top: `${assigneeDropdownCoords.top}px`,
-            width: '280px',
+            width: `${assigneeDropdownCoords.width || 280}px`,
             height: `${assigneeDropdownCoords.height || 280}px`,
             maxHeight: `${assigneeDropdownCoords.height || 280}px`,
           }}
@@ -2689,6 +2662,8 @@ export default function ListView({
               allTasks.find((t) => t.id === showDropdown.taskId)?.memberId || null
             }
             showAgentSection
+            excludeViewers
+            columns={assigneeDropdownCoords.columns || 1}
             onSelect={(memberId) => {
               handleDropdownSelect(showDropdown.taskId, 'memberId', memberId);
             }}

--- a/src/components/MiniTaskIcon.tsx
+++ b/src/components/MiniTaskIcon.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Task, TeamMember } from '../types';
-import { getAuthenticatedAvatarUrl } from '../utils/authImageUrl';
+import MemberAvatar from './ui/MemberAvatar';
 
 interface MiniTaskIconProps {
   task: Task;
@@ -19,13 +19,8 @@ const MiniTaskIcon: React.FC<MiniTaskIconProps> = ({ task, member, className = '
       `}
       title={task.title}
     >
-      {/* Task icon - show first letter of title or member avatar */}
-      {member?.avatarUrl ? (
-        <img 
-          src={getAuthenticatedAvatarUrl(member.avatarUrl)} 
-          alt={member.name}
-          className="w-6 h-6 rounded-full object-cover"
-        />
+      {member ? (
+        <MemberAvatar member={member} size="sm" />
       ) : (
         <span className="text-blue-600">
           {task.title.charAt(0).toUpperCase()}

--- a/src/components/TaskCardToolbar.tsx
+++ b/src/components/TaskCardToolbar.tsx
@@ -4,20 +4,16 @@ import { createPortal } from 'react-dom';
 import { Copy, Eye, UserPlus, GripVertical, TagIcon, Plus, Trash2, Link, Archive } from 'lucide-react';
 import { Task, TeamMember, Tag } from '../types';
 import { formatMembersTooltip } from '../utils/taskUtils';
-import { getAuthenticatedAvatarUrl } from '../utils/authImageUrl';
 import AddTagModal from './AddTagModal';
 import MemberSearchList from './ui/MemberSearchList';
+import MemberAvatar from './ui/MemberAvatar';
+import { layoutMemberDropdownFromElement } from '../utils/memberDropdownLayout';
 import { KanbanChromeTooltip } from './KanbanChromeTooltip';
 import AgentStatusButton from './AgentStatusButton';
 import {
   AGENT_MEMBER_ID,
-  SYSTEM_MEMBER_ID,
   AGENT_DRAG_BLOCKING_STATUSES,
 } from '../constants/appConstants';
-import {
-  getAgentAvatarSrc,
-  isAgentMemberId,
-} from '../utils/agentMemberUi';
 import type { TaskRelationshipSummary } from '../utils/taskRelationshipSummary';
 import { getTaskRelationshipSummary } from '../utils/taskRelationshipSummary';
 import { getArchivedColumnId, isArchivedColumnFlag } from '../utils/columnUtils';
@@ -291,35 +287,15 @@ export default function TaskCardToolbar({
   // Calculate member dropdown position for portal rendering
   const getMemberDropdownPosition = () => {
     if (memberButtonRef.current) {
-      const dropdownWidth = 280;
-      const rect = memberButtonRef.current.getBoundingClientRect();
-
-      // Search header (~52) + agent section padding + rows; cap to viewport
-      const searchHeaderHeight = 52;
-      const memberItemHeight = 40;
-      const availableSpaceBelow = window.innerHeight - rect.bottom - 20;
-      const availableSpaceAbove = rect.top - 20;
-      const maxAvailableSpace = Math.max(availableSpaceBelow, availableSpaceAbove);
-      const maxVisibleMembers = Math.floor(
-        Math.max(80, maxAvailableSpace - searchHeaderHeight) / memberItemHeight
-      );
-      const visibleMembers = Math.max(3, Math.min(10, maxVisibleMembers, members.length || 3));
-      const dropdownHeight = searchHeaderHeight + visibleMembers * memberItemHeight + 24;
-
-      let left = rect.right - dropdownWidth;
-      let top = rect.bottom + 5;
-
-      if (left < 20) left = 20;
-      if (left + dropdownWidth > window.innerWidth - 20) {
-        left = window.innerWidth - dropdownWidth - 20;
-      }
-      if (top + dropdownHeight > window.innerHeight - 20) {
-        top = rect.top - dropdownHeight - 5;
-      }
-
-      return { left, top, height: dropdownHeight, width: dropdownWidth };
+      return layoutMemberDropdownFromElement(memberButtonRef.current, members, {
+        showAgent: true,
+        excludeViewers: true,
+        selectedId: member.id,
+        placement: 'below',
+        extraChrome: 28,
+      });
     }
-    return { left: 0, top: 0, height: 280, width: 280 };
+    return { left: 0, top: 0, height: 280, width: 280, columns: 1 as const };
   };
 
   // Close quick tag dropdown when clicking outside
@@ -523,26 +499,7 @@ export default function TaskCardToolbar({
       ? 'pointer-events-auto opacity-100'
       : toolbarHoverVisibility;
 
-  const assigneeAvatar = isAgentMemberId(member.id) ? (
-    <img
-      src={getAgentAvatarSrc(member)}
-      alt={member.name}
-      className="w-8 h-8 rounded-full object-cover"
-    />
-  ) : member.googleAvatarUrl || member.avatarUrl ? (
-    <img
-      src={getAuthenticatedAvatarUrl(member.googleAvatarUrl || member.avatarUrl)}
-      alt={member.name}
-      className="w-8 h-8 rounded-full object-cover"
-    />
-  ) : (
-    <div
-      className="w-8 h-8 rounded-full flex items-center justify-center text-sm font-medium text-white"
-      style={{ backgroundColor: member.color }}
-    >
-      {member.id === SYSTEM_MEMBER_ID ? '🤖' : member.name.charAt(0).toUpperCase()}
-    </div>
-  );
+  const assigneeAvatar = <MemberAvatar member={member} members={members} size="lg" />;
 
   // Viewers: assignee avatar + watcher/collaborator counts only (no mutation controls).
   if (!canMutate) {
@@ -853,6 +810,8 @@ export default function TaskCardToolbar({
               members={members}
               selectedId={member.id}
               showAgentSection
+              excludeViewers
+              columns={position.columns}
               onSelect={(memberId) => {
                 onMemberChange(memberId);
                 onCloseMemberSelect();

--- a/src/components/TaskDetails.tsx
+++ b/src/components/TaskDetails.tsx
@@ -40,7 +40,7 @@ import { generateUUID } from '../utils/uuid';
 import { loadUserPreferences, updateUserPreference } from '../utils/userPreferences';
 import { generateTaskUrl } from '../utils/routingUtils';
 import { mergeTaskTagsWithLiveData, getTagDisplayStyle } from '../utils/tagUtils';
-import { getAuthenticatedAttachmentUrl, getAuthenticatedAvatarUrl } from '../utils/authImageUrl';
+import { getAuthenticatedAttachmentUrl } from '../utils/authImageUrl';
 import { truncateMemberName } from '../utils/memberUtils';
 import {
   isAgentMemberId,
@@ -49,6 +49,7 @@ import AddTagModal from './AddTagModal';
 import AgentPanel from './AgentPanel';
 import type { AgentPanelView } from './AgentPanel';
 import MemberPicker from './ui/MemberPicker';
+import WatchThisTaskButton from './ui/WatchThisTaskButton';
 import MemberAvatar from './ui/MemberAvatar';
 import AgentStatusButton from './AgentStatusButton';
 import {
@@ -59,6 +60,7 @@ import {
 import { feDebug } from '../utils/clientDebug';
 import { commentTextToHtml } from '../utils/commentContent';
 import { parseEffortUnit, isTaskSoftDeleted } from '../utils/taskUtils';
+import { userIsViewer } from '../utils/permissions';
 import websocketClient from '../services/websocketClient';
 
 function detailsLog(...args: unknown[]) {
@@ -192,6 +194,9 @@ export default function TaskDetails({
   const isWritersLocked = isAgentWorkActive || isReadOnlyMode || !canMutate;
   /** Comments allowed for viewers on live tasks; blocked in trash. */
   const commentsLocked = isReadOnlyMode;
+  const ownMember = members.find((m) => m.user_id === currentUser?.id);
+  const viewerWatchOk =
+    userIsViewer(currentUser) && !isReadOnlyMode && !isAgentWorkActive && Boolean(ownMember);
 
   useEffect(() => {
     if (!isAgentAssigned) {
@@ -1810,6 +1815,7 @@ export default function TaskDetails({
                   value={validMemberId}
                   onChange={(memberId) => handleUpdate({ memberId })}
                   mode="single"
+                  excludeViewers
                   disabled={isSubmitting || isWritersLocked}
                 />
               </div>
@@ -1843,7 +1849,7 @@ export default function TaskDetails({
                       >
                         <MemberAvatar memberId={watcher.id} members={members} size="xs" />
                         <span className="max-w-[7rem] truncate">{truncateMemberName(watcher.name)}</span>
-                        {!isWritersLocked && (
+                        {!isWritersLocked || (viewerWatchOk && ownMember?.id === watcher.id) ? (
                         <button
                           type="button"
                           disabled={isSubmitting}
@@ -1854,11 +1860,17 @@ export default function TaskDetails({
                         >
                           ×
                         </button>
-                        )}
+                        ) : null}
                       </span>
                     ))}
                   </div>
-                  {isWritersLocked ? (
+                  {viewerWatchOk && ownMember ? (
+                    <WatchThisTaskButton
+                      watching={taskWatchers.some((w) => w.id === ownMember.id)}
+                      disabled={isSubmitting}
+                      onClick={() => toggleWatcher(ownMember)}
+                    />
+                  ) : isWritersLocked ? (
                     taskWatchers.length === 0 && (
                       <div
                         className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm bg-white dark:bg-gray-700 text-gray-500 dark:text-gray-400 cursor-default"
@@ -2433,26 +2445,7 @@ export default function TaskDetails({
                 <div key={comment.id} className="border-b border-gray-200 pb-6">
                   <div className="flex items-center justify-between mb-2">
                     <div className="flex items-center gap-2">
-                      {author.googleAvatarUrl || author.avatarUrl ? (
-                        <img
-                          src={getAuthenticatedAvatarUrl(
-                            author.googleAvatarUrl || author.avatarUrl
-                          )}
-                          alt={author.name}
-                          className="w-7 h-7 rounded-full object-cover shrink-0"
-                        />
-                      ) : (
-                        <div
-                          className="w-7 h-7 rounded-full flex items-center justify-center text-xs font-medium text-white shrink-0"
-                          style={{ backgroundColor: author.color }}
-                        >
-                          {author.id === SYSTEM_MEMBER_ID
-                            ? '🤖'
-                            : author.id === AGENT_MEMBER_ID
-                              ? '✨'
-                              : author.name.charAt(0).toUpperCase()}
-                        </div>
-                      )}
+                      <MemberAvatar member={author} members={members} size="md" />
                       <span className="font-medium">{author.name}</span>
                       <span className="text-sm text-gray-500">
                         {formatToYYYYMMDDHHmmss(comment.createdAt)}

--- a/src/components/TaskPage.tsx
+++ b/src/components/TaskPage.tsx
@@ -15,15 +15,15 @@ import ModalManager from './layout/ModalManager';
 import Header from './layout/Header';
 import TaskFlowChart from './TaskFlowChart';
 import DOMPurify from 'dompurify';
-import { getAuthenticatedAttachmentUrl, getAuthenticatedAvatarUrl } from '../utils/authImageUrl';
+import { getAuthenticatedAttachmentUrl } from '../utils/authImageUrl';
 import { commentTextToHtml } from '../utils/commentContent';
 import { feDebug } from '../utils/clientDebug';
 import { parseEffortUnit, isTaskSoftDeleted } from '../utils/taskUtils';
-import { AGENT_MEMBER_ID, SYSTEM_MEMBER_ID } from '../constants/appConstants';
 import { mergeTaskTagsWithLiveData } from '../utils/tagUtils';
-import { userCanMutate } from '../utils/permissions';
+import { userCanMutate, userIsViewer } from '../utils/permissions';
 import MemberAvatar, { getPriorityPillStyle } from './ui/MemberAvatar';
 import MemberPicker from './ui/MemberPicker';
+import WatchThisTaskButton from './ui/WatchThisTaskButton';
 import TagPicker from './ui/TagPicker';
 import PriorityPicker from './ui/PriorityPicker';
 import SprintSelector from './SprintSelector';
@@ -953,6 +953,8 @@ export default function TaskPage({
   const canMutate = userCanMutate(currentUser);
   const fieldsLocked = isInTrash || !canMutate;
   const commentsLocked = isInTrash;
+  const ownMember = members.find((m) => m.user_id === currentUser?.id);
+  const viewerWatchOk = userIsViewer(currentUser) && !isInTrash && Boolean(ownMember);
 
   const toggleTaskTag = async (tag: Tag) => {
     if (fieldsLocked) return;
@@ -1261,26 +1263,7 @@ export default function TaskPage({
                     <div key={comment.id} className="border border-gray-200 dark:border-gray-600 rounded-md p-4 bg-white dark:bg-gray-900/40">
                       <div className="flex items-start justify-between mb-2">
                         <div className="flex items-center space-x-2">
-                          {author?.googleAvatarUrl || author?.avatarUrl ? (
-                            <img
-                              src={getAuthenticatedAvatarUrl(
-                                author.googleAvatarUrl || author.avatarUrl
-                              )}
-                              alt={author?.name || ''}
-                              className="h-6 w-6 rounded-full object-cover shrink-0"
-                            />
-                          ) : (
-                            <div
-                              className="h-6 w-6 rounded-full flex items-center justify-center text-xs font-medium text-white shrink-0"
-                              style={{ backgroundColor: author?.color || '#6b7280' }}
-                            >
-                              {author?.id === SYSTEM_MEMBER_ID
-                                ? '🤖'
-                                : author?.id === AGENT_MEMBER_ID
-                                  ? '✨'
-                                  : author?.name?.[0]?.toUpperCase() || 'U'}
-                            </div>
-                          )}
+                          <MemberAvatar member={author} members={members} size="sm" />
                           <span className="text-sm font-medium text-gray-900 dark:text-gray-100">{author?.name || 'Unknown'}</span>
                           <span className="text-xs text-gray-500 dark:text-gray-400">
                             {new Date(comment.createdAt).toLocaleDateString()} {new Date(comment.createdAt).toLocaleTimeString()}
@@ -1462,6 +1445,7 @@ export default function TaskPage({
                   value={editedTask.memberId}
                   onChange={(memberId) => handleTaskUpdate({ memberId })}
                   mode="single"
+                  excludeViewers
                   disabled={fieldsLocked}
                 />
 
@@ -1487,7 +1471,7 @@ export default function TaskPage({
                         >
                           <MemberAvatar memberId={watcher.id} members={members} size="xs" />
                           <span className="max-w-[7rem] truncate">{truncateMemberName(watcher.name)}</span>
-                          {!fieldsLocked && (
+                          {(!fieldsLocked || (viewerWatchOk && ownMember?.id === watcher.id)) && (
                           <button
                             type="button"
                             onClick={async () => {
@@ -1506,7 +1490,22 @@ export default function TaskPage({
                         </span>
                       ))}
                     </div>
-                    {fieldsLocked ? (
+                    {viewerWatchOk && ownMember ? (
+                      <WatchThisTaskButton
+                        watching={taskWatchers.some((w) => w.id === ownMember.id)}
+                        onClick={async () => {
+                          try {
+                            if (taskWatchers.some((w) => w.id === ownMember.id)) {
+                              await handleRemoveWatcher(ownMember.id);
+                            } else {
+                              await handleAddWatcher(ownMember.id);
+                            }
+                          } catch (error) {
+                            console.error('Error toggling watcher:', error);
+                          }
+                        }}
+                      />
+                    ) : fieldsLocked ? (
                       taskWatchers.length === 0 && (
                         <div
                           className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm text-sm bg-white dark:bg-gray-700 text-gray-500 dark:text-gray-400 cursor-default"

--- a/src/components/TeamMembers.tsx
+++ b/src/components/TeamMembers.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type MouseEvent, type PointerEvent as ReactPointerEvent } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type CSSProperties, type MouseEvent, type PointerEvent as ReactPointerEvent, type ReactElement } from 'react';
 import { createPortal } from 'react-dom';
-import { Copy, Check, Info, X, Minimize2, Maximize2, GripVertical } from 'lucide-react';
+import { Copy, Check, Info, X, Minimize2, Maximize2, GripVertical, Eye } from 'lucide-react';
 import {
   DndContext,
   PointerSensor,
@@ -25,6 +25,7 @@ import {
   isSystemMemberId,
   sortMembersAgentLast,
 } from '../utils/agentMemberUi';
+import { memberIsViewer } from '../utils/memberUtils';
 import {
   loadUserPreferences,
   loadUserPreferencesAsync,
@@ -221,42 +222,62 @@ function MemberContactTooltipBody({
   );
 }
 
-function memberAvatarNode(member: TeamMember, sizeClass: string, textClass = 'text-xs') {
+function memberAvatarNode(
+  member: TeamMember,
+  sizeClass: string,
+  textClass = 'text-xs',
+  viewerLabel?: string
+) {
+  let inner: ReactElement;
   if (isAgentMemberId(member.id)) {
-    return (
+    inner = (
       <img
         src={getAgentAvatarSrc(member)}
         alt=""
         className={`${sizeClass} rounded-full object-cover`}
       />
     );
-  }
-  if (member.googleAvatarUrl) {
-    return (
+  } else if (member.googleAvatarUrl) {
+    inner = (
       <img
         src={getAuthenticatedAvatarUrl(member.googleAvatarUrl)}
         alt=""
         className={`${sizeClass} rounded-full object-cover`}
       />
     );
-  }
-  if (member.avatarUrl) {
-    return (
+  } else if (member.avatarUrl) {
+    inner = (
       <img
         src={getAuthenticatedAvatarUrl(member.avatarUrl)}
         alt=""
         className={`${sizeClass} rounded-full object-cover`}
       />
     );
+  } else {
+    const initials = member.name.split(' ').map(n => n[0]).join('').toUpperCase();
+    inner = (
+      <div
+        className={`${sizeClass} rounded-full flex items-center justify-center ${textClass} font-bold text-white`}
+        style={{ backgroundColor: member.color }}
+      >
+        {initials}
+      </div>
+    );
   }
-  const initials = member.name.split(' ').map(n => n[0]).join('').toUpperCase();
+  if (!memberIsViewer(member)) return inner;
+  const compact = sizeClass.includes('w-7');
   return (
-    <div
-      className={`${sizeClass} rounded-full flex items-center justify-center ${textClass} font-bold text-white`}
-      style={{ backgroundColor: member.color }}
-    >
-      {initials}
-    </div>
+    <span className={`relative inline-flex ${sizeClass} shrink-0`} title={viewerLabel}>
+      {inner}
+      <span
+        className={`absolute -bottom-0.5 -right-0.5 flex items-center justify-center rounded-full bg-sky-100 text-sky-700 ring-2 ring-white dark:bg-sky-950 dark:text-sky-300 dark:ring-gray-800 ${
+          compact ? 'h-3.5 w-3.5' : 'h-5 w-5'
+        }`}
+        aria-label={viewerLabel}
+      >
+        <Eye size={compact ? 8 : 12} strokeWidth={2.5} aria-hidden />
+      </span>
+    </span>
   );
 }
 
@@ -331,7 +352,12 @@ function MeetTheTeamCard({
         }}
       >
         <div className="rounded-full bg-white dark:bg-gray-900 p-0.5">
-          {memberAvatarNode(member, showBios ? 'w-16 h-16' : 'w-12 h-12', showBios ? 'text-lg' : 'text-sm')}
+          {memberAvatarNode(
+            member,
+            showBios ? 'w-16 h-16' : 'w-12 h-12',
+            showBios ? 'text-lg' : 'text-sm',
+            t('messages.readOnlyBadge')
+          )}
         </div>
       </div>
       <div className="mt-2.5 text-sm font-semibold text-gray-900 dark:text-gray-50 break-words w-full pointer-events-none">
@@ -938,7 +964,7 @@ export default function TeamMembers({
                   }`}
                   onClick={() => onSelectMember(member.id)}
                 >
-                  {memberAvatarNode(member, 'w-7 h-7')}
+                  {memberAvatarNode(member, 'w-7 h-7', 'text-xs', t('messages.readOnlyBadge'))}
                 </button>
               </KanbanChromeTooltip>
             );
@@ -960,7 +986,7 @@ export default function TeamMembers({
                 }}
                 onClick={() => onSelectMember(member.id)}
               >
-                {memberAvatarNode(member, 'w-7 h-7')}
+                {memberAvatarNode(member, 'w-7 h-7', 'text-xs', t('messages.readOnlyBadge'))}
                 <span
                   className={`text-xs text-gray-800 dark:text-gray-100 ${
                     isSelected ? 'font-semibold' : 'font-medium'

--- a/src/components/admin/AdminAppSettingsTab.tsx
+++ b/src/components/admin/AdminAppSettingsTab.tsx
@@ -80,7 +80,7 @@ const AdminAppSettingsTab: React.FC<AdminAppSettingsTabProps> = ({
   onAutoSave,
 }) => {
   const { t } = useTranslation('admin');
-  const { updateSiteSettings } = useSettings();
+  const { updateSiteSettings, siteSettings } = useSettings();
   const [isSaving, setIsSaving] = useState(false);
   const [activeSubTab, setActiveSubTab] = useState<AppSettingsSubTab>(() =>
     typeof window !== 'undefined' ? subTabFromHash(window.location.hash) : 'ui'
@@ -101,7 +101,7 @@ const AdminAppSettingsTab: React.FC<AdminAppSettingsTabProps> = ({
     });
   }, [activeSubTab]);
 
-  const troubleshootingGated = isTroubleshootingGatedDeployment();
+  const troubleshootingGated = isTroubleshootingGatedDeployment(siteSettings);
   const [troubleshootingUnlocked, setTroubleshootingUnlocked] = useState(
     () => !troubleshootingGated || readTroubleshootingUnlocked()
   );

--- a/src/components/admin/AdminNotificationQueueTab.tsx
+++ b/src/components/admin/AdminNotificationQueueTab.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Send, Trash2, CheckSquare, Square, RefreshCw, ChevronDown, Search } from 'lucide-react';
+import { Send, Trash2, CheckSquare, Square, RefreshCw, ChevronDown, Search, Loader2 } from 'lucide-react';
 import { getNotificationQueue, sendNotificationsImmediately, deleteNotifications, updateSetting } from '../../api';
 import { toast } from '../../utils/toast';
 import { formatToYYYYMMDDHHmmss as formatDateTimeLocal } from '../../utils/dateUtils';
 import { ModernCheckbox } from '../ModernCheckbox';
 import { useSettings } from '../../contexts/SettingsContext';
+import websocketClient from '../../services/websocketClient';
 import {
   ADMIN_NUMERIC_INPUT_CLASS,
   ADMIN_TABLE_ROW_CLASS,
@@ -50,6 +51,12 @@ interface AdminNotificationQueueTabProps {
   discardNonce?: number;
 }
 
+function queueItemAgeMs(n: NotificationQueueItem): number {
+  const raw = n.firstChangeTime || n.createdAt || n.scheduledSendTime;
+  const t = raw ? Date.parse(raw) : NaN;
+  return Number.isFinite(t) ? t : 0;
+}
+
 /** Split `YYYY-MM-DD HH:MM:SS` into date / time for two-line table cells. */
 function splitDateTimeLocal(value: string | null | undefined): { date: string; time: string } | null {
   if (!value) return null;
@@ -74,6 +81,12 @@ const AdminNotificationQueueTab: React.FC<AdminNotificationQueueTabProps> = ({
   const [loading, setLoading] = useState(true);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [isSending, setIsSending] = useState(false);
+  const [sendProgress, setSendProgress] = useState<{
+    done: number;
+    total: number;
+    sent: number;
+    failed: number;
+  } | null>(null);
   const [isDeleting, setIsDeleting] = useState(false);
   const [displayLimit, setDisplayLimit] = useState(50);
   const [showDeleteMenu, setShowDeleteMenu] = useState(false);
@@ -94,21 +107,52 @@ const AdminNotificationQueueTab: React.FC<AdminNotificationQueueTabProps> = ({
     onLocalDirtyChange?.(retentionDirty);
   }, [retentionDirty, onLocalDirtyChange]);
 
-  const fetchNotifications = async () => {
+  const fetchNotifications = async (opts?: { silent?: boolean }) => {
     try {
-      setLoading(true);
+      if (!opts?.silent) setLoading(true);
       const data = await getNotificationQueue();
       setNotifications(data);
+      setSelectedIds((prev) => {
+        const valid = new Set(data.map((n: NotificationQueueItem) => n.id));
+        const next = new Set<string>();
+        prev.forEach((id) => {
+          if (valid.has(id)) next.add(id);
+        });
+        return next;
+      });
     } catch (error: any) {
       console.error('Failed to fetch notification queue:', error);
-      toast.error(t('notificationQueue.fetchError') || 'Failed to fetch notification queue', '');
+      if (!opts?.silent) {
+        toast.error(t('notificationQueue.fetchError') || 'Failed to fetch notification queue', '');
+      }
     } finally {
-      setLoading(false);
+      if (!opts?.silent) setLoading(false);
     }
   };
 
+  const liveFetchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const fetchNotificationsRef = useRef(fetchNotifications);
+  fetchNotificationsRef.current = fetchNotifications;
+
   useEffect(() => {
-    fetchNotifications();
+    void fetchNotifications();
+    const refreshSilent = () => {
+      if (liveFetchTimer.current) clearTimeout(liveFetchTimer.current);
+      liveFetchTimer.current = setTimeout(() => {
+        void fetchNotificationsRef.current({ silent: true });
+      }, 400);
+    };
+    websocketClient.onNotificationQueueUpdated(refreshSilent);
+    const poll = window.setInterval(() => {
+      if (document.visibilityState === 'visible') {
+        void fetchNotificationsRef.current({ silent: true });
+      }
+    }, 10000);
+    return () => {
+      websocketClient.offNotificationQueueUpdated(refreshSilent);
+      window.clearInterval(poll);
+      if (liveFetchTimer.current) clearTimeout(liveFetchTimer.current);
+    };
   }, []);
 
   const saveRetention = async () => {
@@ -247,7 +291,10 @@ const AdminNotificationQueueTab: React.FC<AdminNotificationQueueTabProps> = ({
 
     // Filter out sent notifications - only allow sending pending/failed notifications
     const selectedNotifications = filteredNotifications.filter(n => selectedIds.has(n.id));
-    const sendableNotifications = selectedNotifications.filter(n => n.status !== 'sent');
+    const sendableNotifications = selectedNotifications
+      .filter(n => n.status !== 'sent')
+      .slice()
+      .sort((a, b) => queueItemAgeMs(a) - queueItemAgeMs(b));
     
     if (sendableNotifications.length === 0) {
       toast.error(t('notificationQueue.noUnsentNotifications'));
@@ -266,23 +313,45 @@ const AdminNotificationQueueTab: React.FC<AdminNotificationQueueTabProps> = ({
 
     try {
       setIsSending(true);
-      const result = await sendNotificationsImmediately(sendableNotifications.map(n => n.id));
-      
-      if (result.errors && result.errors.length > 0) {
-        console.warn('Some notifications failed to send:', result.errors);
+      const ids = sendableNotifications.map((n) => n.id);
+      const progress = { done: 0, total: ids.length, sent: 0, failed: 0 };
+      setSendProgress({ ...progress });
+      const errors: string[] = [];
+
+      for (const id of ids) {
+        try {
+          const result = await sendNotificationsImmediately([id]);
+          progress.sent += result.sentCount || 0;
+          progress.failed += result.failedCount || 0;
+          if (result.errors?.length) errors.push(...result.errors);
+        } catch (error: any) {
+          const code = error?.response?.data?.code;
+          if (code === 'TASK_EMAIL_NOTIFICATIONS_PAUSED') {
+            toast.error(t('notificationQueue.sendPaused'));
+            break;
+          }
+          progress.failed += 1;
+          errors.push(error?.response?.data?.error || String(error));
+        }
+        progress.done += 1;
+        setSendProgress({ ...progress });
       }
 
-      if (result.sentCount > 0 && result.failedCount > 0) {
+      if (errors.length > 0) {
+        console.warn('Some notifications failed to send:', errors);
+      }
+
+      if (progress.sent > 0 && progress.failed > 0) {
         toast.warning(
           t('notificationQueue.sendPartial', {
-            sent: result.sentCount,
-            failed: result.failedCount,
+            sent: progress.sent,
+            failed: progress.failed,
           }),
           ''
         );
-      } else if (result.sentCount > 0) {
+      } else if (progress.sent > 0) {
         toast.success(
-          t('notificationQueue.sendSuccess', { count: result.sentCount }),
+          t('notificationQueue.sendSuccess', { count: progress.sent }),
           ''
         );
       } else {
@@ -290,7 +359,7 @@ const AdminNotificationQueueTab: React.FC<AdminNotificationQueueTabProps> = ({
       }
 
       setSelectedIds(new Set());
-      await fetchNotifications();
+      await fetchNotifications({ silent: true });
     } catch (error: any) {
       console.error('Failed to send notifications:', error);
       const code = error?.response?.data?.code;
@@ -302,6 +371,7 @@ const AdminNotificationQueueTab: React.FC<AdminNotificationQueueTabProps> = ({
       }
     } finally {
       setIsSending(false);
+      setSendProgress(null);
     }
   };
 
@@ -326,7 +396,7 @@ const AdminNotificationQueueTab: React.FC<AdminNotificationQueueTabProps> = ({
         );
         
         setSelectedIds(new Set());
-        await fetchNotifications();
+        await fetchNotifications({ silent: true });
       }
     } catch (error: any) {
       console.error('Failed to delete notifications:', error);
@@ -362,7 +432,7 @@ const AdminNotificationQueueTab: React.FC<AdminNotificationQueueTabProps> = ({
         );
         
         setSelectedIds(new Set());
-        await fetchNotifications();
+        await fetchNotifications({ silent: true });
       }
     } catch (error: any) {
       console.error('Failed to delete all sent notifications:', error);
@@ -397,11 +467,11 @@ const AdminNotificationQueueTab: React.FC<AdminNotificationQueueTabProps> = ({
     return translated;
   };
 
-  if (loading) {
+  if (loading && notifications.length === 0) {
     return (
       <div className="p-6 text-center">
         <div className="inline-block animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500"></div>
-        <p className="mt-2 text-gray-600 dark:text-gray-400">{t('notificationQueue.loading', 'Loading...')}</p>
+        <p className="mt-2 text-gray-600 dark:text-gray-400">{t('notificationQueue.loading')}</p>
       </div>
     );
   }
@@ -584,8 +654,15 @@ const AdminNotificationQueueTab: React.FC<AdminNotificationQueueTabProps> = ({
             title={!taskEmailSendingEnabled ? t('notificationQueue.sendPaused') : undefined}
             className="px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed flex items-center"
           >
-            <Send className="w-4 h-4 mr-2" />
-            {isSending ? t('notificationQueue.sending') : t('notificationQueue.sendNow')}
+            {isSending ? <Loader2 className="w-4 h-4 mr-2 animate-spin" /> : <Send className="w-4 h-4 mr-2" />}
+            {isSending && sendProgress
+              ? t('notificationQueue.sendingProgress', {
+                  done: sendProgress.done,
+                  total: sendProgress.total,
+                })
+              : isSending
+                ? t('notificationQueue.sending')
+                : t('notificationQueue.sendNow')}
           </button>
           <div className="relative">
             <button
@@ -634,16 +711,50 @@ const AdminNotificationQueueTab: React.FC<AdminNotificationQueueTabProps> = ({
             )}
           </div>
           <button
-            onClick={fetchNotifications}
+            onClick={() => void fetchNotifications()}
             disabled={loading || isSending || isDeleting}
             className="px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 rounded-md hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed flex items-center"
           >
             <RefreshCw className={`w-4 h-4 mr-2 ${loading ? 'animate-spin' : ''}`} />
-            {t('notificationQueue.refresh') || 'Refresh'}
+            {t('notificationQueue.refresh')}
           </button>
           </div>
         </div>
       </div>
+
+      {sendProgress && (
+        <div
+          className="mb-4 flex items-center gap-3 rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-100"
+          role="status"
+          aria-live="polite"
+        >
+          <Loader2 className="h-4 w-4 shrink-0 animate-spin" aria-hidden />
+          <div className="min-w-0 flex-1">
+            <p className="font-medium">
+              {t('notificationQueue.sendingProgress', {
+                done: sendProgress.done,
+                total: sendProgress.total,
+              })}
+            </p>
+            {sendProgress.done > 0 && (
+              <p className="mt-0.5 text-xs opacity-90">
+                {t('notificationQueue.sendPartial', {
+                  sent: sendProgress.sent,
+                  failed: sendProgress.failed,
+                })}
+              </p>
+            )}
+            <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-blue-200 dark:bg-blue-900">
+              <div
+                className="h-full bg-blue-600 transition-all dark:bg-blue-400"
+                style={{
+                  width: `${sendProgress.total ? Math.round((sendProgress.done / sendProgress.total) * 100) : 0}%`,
+                }}
+              />
+            </div>
+          </div>
+        </div>
+      )}
 
       {filteredNotifications.length === 0 ? (
         <div className="text-center py-12">

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -22,6 +22,10 @@ import {
   isPublicBrandAssetPath,
 } from '../../constants';
 import { userIsAdmin, userIsViewer } from '../../utils/permissions';
+import {
+  isSystemPanelAvailable as readSystemPanelAvailable,
+  TROUBLESHOOTING_VISIBILITY_EVENT,
+} from '../../utils/troubleshootingAccess';
 
 interface SystemInfo {
   memory: {
@@ -123,9 +127,16 @@ const Header: React.FC<HeaderProps> = ({
 }) => {
   const isDemoMode = process.env.DEMO_ENABLED === 'true';
   const { theme } = useTheme();
-  // Host-level metrics are misleading in multi-tenant; hide in demo mode as well.
-  const isSystemPanelAvailable =
-    process.env.MULTI_TENANT !== 'true' && process.env.DEMO_ENABLED !== 'true';
+  const [systemPanelUnlocked, setSystemPanelUnlocked] = useState(() =>
+    readSystemPanelAvailable(siteSettings)
+  );
+  useEffect(() => {
+    const sync = () => setSystemPanelUnlocked(readSystemPanelAvailable(siteSettings));
+    sync();
+    window.addEventListener(TROUBLESHOOTING_VISIBILITY_EVENT, sync);
+    return () => window.removeEventListener(TROUBLESHOOTING_VISIBILITY_EVENT, sync);
+  }, [siteSettings]);
+  const isSystemPanelAvailable = systemPanelUnlocked;
   // Extract all tasks from all boards for sprint counting
   const allTasks = useMemo(() => {
     const tasks: Array<{ id: string; sprintId?: string | null }> = [];

--- a/src/components/ui/MemberAvatar.tsx
+++ b/src/components/ui/MemberAvatar.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import { Eye } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 import type { TeamMember } from '../../types';
 import { SYSTEM_MEMBER_ID } from '../../constants/appConstants';
 import { getAuthenticatedAvatarUrl } from '../../utils/authImageUrl';
@@ -7,13 +9,29 @@ import {
   isAgentMemberId,
   resolveTaskMember,
 } from '../../utils/agentMemberUi';
+import { memberIsViewer } from '../../utils/memberUtils';
 
-type AvatarSize = 'xs' | 'sm' | 'md';
+type AvatarSize = 'xs' | 'sm' | 'md' | 'lg';
 
 const SIZE_CLASS: Record<AvatarSize, string> = {
   xs: 'w-4 h-4 text-[9px]',
   sm: 'w-5 h-5 text-[10px]',
   md: 'w-7 h-7 text-xs',
+  lg: 'w-8 h-8 text-sm',
+};
+
+const BADGE_CLASS: Record<AvatarSize, string> = {
+  xs: 'h-2.5 w-2.5 -bottom-0.5 -right-0.5',
+  sm: 'h-3 w-3 -bottom-0.5 -right-0.5',
+  md: 'h-3.5 w-3.5 -bottom-0.5 -right-0.5',
+  lg: 'h-4 w-4 -bottom-0.5 -right-0.5',
+};
+
+const EYE_PX: Record<AvatarSize, number> = {
+  xs: 7,
+  sm: 8,
+  md: 9,
+  lg: 10,
 };
 
 interface MemberAvatarProps {
@@ -23,6 +41,8 @@ interface MemberAvatarProps {
   size?: AvatarSize;
   className?: string;
   title?: string;
+  /** Viewer eye overlay (default on). */
+  showViewerBadge?: boolean;
 }
 
 /**
@@ -35,7 +55,9 @@ export default function MemberAvatar({
   size = 'md',
   className = '',
   title,
+  showViewerBadge = true,
 }: MemberAvatarProps) {
+  const { t } = useTranslation('common');
   const member =
     memberProp ||
     (memberId && members ? resolveTaskMember(members, memberId) : undefined);
@@ -51,10 +73,17 @@ export default function MemberAvatar({
   }
 
   const sizeClass = SIZE_CLASS[size];
-  const label = title || member.name;
+  const viewerHint = t('messages.readOnlyBadge');
+  const label =
+    title ||
+    (showViewerBadge && memberIsViewer(member)
+      ? `${member.name} (${viewerHint})`
+      : member.name);
+
+  let inner: React.ReactElement;
 
   if (member.id === SYSTEM_MEMBER_ID) {
-    return (
+    inner = (
       <div
         className={`${sizeClass} rounded-full flex items-center justify-center shrink-0 ${className}`}
         style={{ backgroundColor: member.color || '#1E40AF' }}
@@ -63,10 +92,8 @@ export default function MemberAvatar({
         🤖
       </div>
     );
-  }
-
-  if (isAgentMemberId(member.id)) {
-    return (
+  } else if (isAgentMemberId(member.id)) {
+    inner = (
       <img
         src={getAgentAvatarSrc(member)}
         alt={member.name}
@@ -74,28 +101,40 @@ export default function MemberAvatar({
         className={`${sizeClass} rounded-full object-cover shrink-0 ${className}`}
       />
     );
-  }
-
-  const avatarSrc = member.googleAvatarUrl || member.avatarUrl;
-  if (avatarSrc) {
-    return (
+  } else {
+    const avatarSrc = member.googleAvatarUrl || member.avatarUrl;
+    inner = avatarSrc ? (
       <img
         src={getAuthenticatedAvatarUrl(avatarSrc)}
         alt={member.name}
         title={label}
         className={`${sizeClass} rounded-full object-cover shrink-0 ${className}`}
       />
+    ) : (
+      <div
+        className={`${sizeClass} rounded-full flex items-center justify-center font-medium text-white shrink-0 ${className}`}
+        style={{ backgroundColor: member.color || '#6B7280' }}
+        title={label}
+      >
+        {(member.name || '?').charAt(0).toUpperCase()}
+      </div>
     );
   }
 
+  if (!showViewerBadge || !memberIsViewer(member)) {
+    return inner;
+  }
+
   return (
-    <div
-      className={`${sizeClass} rounded-full flex items-center justify-center font-medium text-white shrink-0 ${className}`}
-      style={{ backgroundColor: member.color || '#6B7280' }}
-      title={label}
-    >
-      {(member.name || '?').charAt(0).toUpperCase()}
-    </div>
+    <span className={`relative inline-flex ${sizeClass} shrink-0`} title={label}>
+      {inner}
+      <span
+        className={`absolute flex items-center justify-center rounded-full bg-sky-100 text-sky-700 ring-1 ring-white dark:bg-sky-950 dark:text-sky-300 dark:ring-gray-800 ${BADGE_CLASS[size]}`}
+        aria-label={viewerHint}
+      >
+        <Eye size={EYE_PX[size]} strokeWidth={2.5} aria-hidden />
+      </span>
+    </span>
   );
 }
 

--- a/src/components/ui/MemberPicker.tsx
+++ b/src/components/ui/MemberPicker.tsx
@@ -1,8 +1,10 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import { useTranslation } from 'react-i18next';
 import { ChevronDown } from 'lucide-react';
 import type { TeamMember } from '../../types';
 import { truncateMemberName } from '../../utils/memberUtils';
+import { layoutMemberDropdownFromElement, type MemberDropdownLayout } from '../../utils/memberDropdownLayout';
 import MemberAvatar from './MemberAvatar';
 import MemberSearchList from './MemberSearchList';
 
@@ -28,6 +30,8 @@ export interface MemberPickerProps {
   className?: string;
   /** Highlight agent in its own section (default true for single) */
   showAgentSection?: boolean;
+  /** Hide read-only viewers from assignee lists */
+  excludeViewers?: boolean;
 }
 
 /**
@@ -44,25 +48,54 @@ export default function MemberPicker({
   disabled = false,
   className = '',
   showAgentSection,
+  excludeViewers = false,
 }: MemberPickerProps) {
   const { t } = useTranslation('tasks');
   const [open, setOpen] = useState(false);
+  const [layout, setLayout] = useState<MemberDropdownLayout | null>(null);
   const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
   const preferAgentSection = showAgentSection ?? mode === 'single';
   const selected = value ? members.find((m) => m.id === value) : undefined;
 
   const close = () => setOpen(false);
 
+  const measure = () => {
+    const el = triggerRef.current;
+    if (!el) return;
+    setLayout(
+      layoutMemberDropdownFromElement(el, members, {
+        showAgent: preferAgentSection,
+        excludeViewers,
+        selectedId: mode === 'single' ? value : null,
+        placement: 'below',
+      })
+    );
+  };
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    measure();
+  }, [open, members, preferAgentSection, excludeViewers, value, mode]);
+
   useEffect(() => {
     if (!open) return;
     const onDoc = (e: MouseEvent) => {
-      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
-        close();
-      }
+      const target = e.target as Node;
+      if (rootRef.current?.contains(target) || panelRef.current?.contains(target)) return;
+      close();
     };
+    const onWin = () => measure();
     document.addEventListener('mousedown', onDoc);
-    return () => document.removeEventListener('mousedown', onDoc);
-  }, [open]);
+    window.addEventListener('resize', onWin);
+    window.addEventListener('scroll', onWin, true);
+    return () => {
+      document.removeEventListener('mousedown', onDoc);
+      window.removeEventListener('resize', onWin);
+      window.removeEventListener('scroll', onWin, true);
+    };
+  }, [open, members, preferAgentSection, excludeViewers, value, mode]);
 
   useEffect(() => {
     if (disabled) setOpen(false);
@@ -119,6 +152,7 @@ export default function MemberPicker({
         </label>
       )}
       <button
+        ref={triggerRef}
         type="button"
         onClick={() => {
           if (open) close();
@@ -147,19 +181,35 @@ export default function MemberPicker({
         />
       </button>
 
-      {open && (
-        <div className="absolute left-0 right-0 top-full mt-1 z-50 rounded-lg border border-gray-200 dark:border-gray-600 shadow-lg overflow-hidden max-h-80">
-          <MemberSearchList
-            members={members}
-            excludeIds={excludeIds}
-            selectedId={mode === 'single' ? value : null}
-            showAgentSection={preferAgentSection}
-            onSelect={pick}
-            onEscape={close}
-            maxHeightClassName="max-h-56"
-          />
-        </div>
-      )}
+      {open &&
+        layout &&
+        createPortal(
+          <div
+            ref={panelRef}
+            className="fixed z-[80] rounded-lg border border-gray-200 dark:border-gray-600 shadow-lg overflow-hidden flex flex-col bg-white dark:bg-gray-800"
+            style={{
+              left: layout.left,
+              top: layout.top,
+              width: layout.width,
+              height: layout.height,
+              maxHeight: layout.height,
+            }}
+          >
+            <MemberSearchList
+              members={members}
+              excludeIds={excludeIds}
+              selectedId={mode === 'single' ? value : null}
+              showAgentSection={preferAgentSection}
+              excludeViewers={excludeViewers}
+              columns={layout.columns}
+              onSelect={pick}
+              onEscape={close}
+              maxHeightClassName="max-h-none"
+              className="min-h-0 flex-1"
+            />
+          </div>,
+          document.body
+        )}
     </div>
   );
 }

--- a/src/components/ui/MemberSearchList.tsx
+++ b/src/components/ui/MemberSearchList.tsx
@@ -7,7 +7,7 @@ import {
   isAgentMemberId,
   sortMembersAgentLast,
 } from '../../utils/agentMemberUi';
-import { truncateMemberName } from '../../utils/memberUtils';
+import { truncateMemberName, memberIsViewer } from '../../utils/memberUtils';
 import MemberAvatar from './MemberAvatar';
 
 export interface MemberSearchListProps {
@@ -17,6 +17,8 @@ export interface MemberSearchListProps {
   excludeIds?: string[];
   /** Highlight currently selected id (assignee/requester single pick) */
   selectedId?: string | null;
+  /** Hide read-only viewers (assignee pickers). Still shows selectedId if it is a viewer. */
+  excludeViewers?: boolean;
   /** Highlight agent in its own section */
   showAgentSection?: boolean;
   /** Auto-focus search on mount */
@@ -25,6 +27,8 @@ export interface MemberSearchListProps {
   /** Called when Escape is pressed in the search field */
   onEscape?: () => void;
   maxHeightClassName?: string;
+  /** People grid; agent stays full-width under the list (no horizontal scroll). */
+  columns?: 1 | 2;
 }
 
 function memberMatchesQuery(member: TeamMember, query: string): boolean {
@@ -43,11 +47,13 @@ export default function MemberSearchList({
   onSelect,
   excludeIds = [],
   selectedId = null,
+  excludeViewers = false,
   showAgentSection = true,
   autoFocus = true,
   className = '',
   onEscape,
-  maxHeightClassName = 'max-h-64',
+  maxHeightClassName = 'max-h-[min(24rem,55vh)]',
+  columns = 1,
 }: MemberSearchListProps) {
   const { t } = useTranslation('tasks');
   const [searchTerm, setSearchTerm] = useState('');
@@ -55,9 +61,16 @@ export default function MemberSearchList({
 
   const exclude = new Set(excludeIds);
   const ordered = useMemo(
-    () => sortMembersAgentLast(members.filter((m) => !exclude.has(m.id))),
+    () =>
+      sortMembersAgentLast(
+        members.filter((m) => {
+          if (exclude.has(m.id)) return false;
+          if (excludeViewers && memberIsViewer(m) && m.id !== selectedId) return false;
+          return true;
+        })
+      ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [members, excludeIds.join('|')]
+    [members, excludeIds.join('|'), excludeViewers, selectedId]
   );
 
   const filtered = useMemo(
@@ -87,7 +100,7 @@ export default function MemberSearchList({
         key={m.id}
         type="button"
         onClick={() => pick(m.id)}
-        className={`w-full flex items-center gap-2 px-2.5 py-2 rounded-md text-left transition-colors ${
+        className={`w-full min-w-0 flex items-center gap-2 px-2.5 py-2 rounded-md text-left transition-colors ${
           m.id === SYSTEM_MEMBER_ID ? 'bg-yellow-50 dark:bg-yellow-900/20' : ''
         } ${
           isSelected
@@ -159,7 +172,7 @@ export default function MemberSearchList({
         </div>
       </div>
 
-      <div className={`overflow-y-auto flex-1 p-1.5 ${maxHeightClassName}`}>
+      <div className={`overflow-y-auto overflow-x-hidden flex-1 min-h-0 p-1.5 ${maxHeightClassName}`}>
         {!hasAnyResults ? (
           <div className="px-3 py-3 text-sm text-gray-500 text-center">
             {searchTerm.trim()
@@ -171,21 +184,28 @@ export default function MemberSearchList({
                 })}
           </div>
         ) : (
-          <>
+          <div
+            className={
+              columns === 2 && people.length > 0
+                ? 'grid grid-cols-2 gap-x-1'
+                : 'flex flex-col'
+            }
+          >
             {people.map(renderRow)}
-            {showAgentSection && agent && (
-              <>
-                <div className="my-1.5 border-t border-gray-200 dark:border-gray-600" />
-                <div className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500 px-2 mb-1">
-                  {t('toolbar.assignToAgentSection')}
-                </div>
-                {renderRow(agent)}
-              </>
+            {!showAgentSection && agent && (
+              <div className={columns === 2 ? 'col-span-2' : undefined}>{renderRow(agent)}</div>
             )}
-            {!showAgentSection && agent && renderRow(agent)}
-          </>
+          </div>
         )}
       </div>
+      {showAgentSection && agent && hasAnyResults && (
+        <div className="shrink-0 border-t border-gray-200 dark:border-gray-600 p-1.5 bg-white dark:bg-gray-800">
+          <div className="text-[10px] uppercase tracking-wide text-gray-400 dark:text-gray-500 px-2 mb-1">
+            {t('toolbar.assignToAgentSection')}
+          </div>
+          {renderRow(agent)}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/ui/WatchThisTaskButton.tsx
+++ b/src/components/ui/WatchThisTaskButton.tsx
@@ -1,0 +1,27 @@
+import { Eye, EyeOff } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+interface WatchThisTaskButtonProps {
+  watching: boolean;
+  onClick: () => void;
+  disabled?: boolean;
+}
+
+export default function WatchThisTaskButton({
+  watching,
+  onClick,
+  disabled = false,
+}: WatchThisTaskButtonProps) {
+  const { t } = useTranslation('tasks');
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className="inline-flex items-center gap-1.5 px-3 py-2 rounded-md border border-sky-200 dark:border-sky-800 bg-sky-50 dark:bg-sky-950/40 text-sm font-medium text-sky-800 dark:text-sky-200 hover:bg-sky-100 dark:hover:bg-sky-900/50 disabled:opacity-50"
+    >
+      {watching ? <EyeOff className="h-4 w-4 shrink-0" aria-hidden /> : <Eye className="h-4 w-4 shrink-0" aria-hidden />}
+      {watching ? t('taskPage.unwatchThisTask') : t('taskPage.watchThisTask')}
+    </button>
+  );
+}

--- a/src/contexts/TourContext.tsx
+++ b/src/contexts/TourContext.tsx
@@ -5,6 +5,11 @@ import { getTourSteps } from '../components/tour/TourSteps';
 import { parseTaskRoute } from '../utils/routingUtils';
 import { adminHashForTabId } from '../utils/adminNavigation';
 import { useTheme } from './ThemeContext';
+import { useSettings } from './SettingsContext';
+import {
+  isSystemPanelAvailable as readSystemPanelAvailable,
+  TROUBLESHOOTING_VISIBILITY_EVENT,
+} from '../utils/troubleshootingAccess';
 
 interface TourContextType {
   isRunning: boolean;
@@ -102,6 +107,7 @@ function ensureSystemUsagePanelVisible(): boolean {
 export const TourProvider: React.FC<TourProviderProps> = ({ children, currentUser, onViewModeChange, onPageChange }) => {
   const { t } = useTranslation('common');
   const { theme } = useTheme();
+  const { siteSettings } = useSettings();
   const [isRunning, setIsRunning] = useState(false);
   const [stepIndex, setStepIndex] = useState(0);
   const [isHelpModalOpen, setIsHelpModalOpen] = useState(false);
@@ -187,8 +193,15 @@ export const TourProvider: React.FC<TourProviderProps> = ({ children, currentUse
   const advancingRef = React.useRef(false);
 
   const isAdmin = currentUser?.roles?.includes('admin') || currentUser?.role === 'admin';
-  const isSystemPanelAvailable =
-    process.env.MULTI_TENANT !== 'true' && process.env.DEMO_ENABLED !== 'true';
+  const [isSystemPanelAvailable, setIsSystemPanelAvailable] = useState(() =>
+    readSystemPanelAvailable()
+  );
+  useEffect(() => {
+    const sync = () => setIsSystemPanelAvailable(readSystemPanelAvailable(siteSettings));
+    sync();
+    window.addEventListener(TROUBLESHOOTING_VISIBILITY_EVENT, sync);
+    return () => window.removeEventListener(TROUBLESHOOTING_VISIBILITY_EVENT, sync);
+  }, [siteSettings]);
   const steps = useMemo(() => {
     const { userSteps, adminSteps } = getTourSteps();
     const raw = isAdmin ? adminSteps : userSteps;

--- a/src/hooks/useTaskDetails.ts
+++ b/src/hooks/useTaskDetails.ts
@@ -156,6 +156,10 @@ export const useTaskDetails = ({
 
   const canMutateRef = useRef(canMutate);
   canMutateRef.current = canMutate;
+  const ownMemberIdRef = useRef<string | undefined>(undefined);
+  ownMemberIdRef.current = members.find((m) => m.user_id === currentUser?.id)?.id;
+  const canChangeOwnWatcher = (memberId: string) =>
+    canMutateRef.current || ownMemberIdRef.current === memberId;
 
   // Immediate save — always persist the latest editedTaskRef snapshot
   const saveImmediately = useCallback(async (taskToSave?: Task) => {
@@ -354,7 +358,7 @@ export const useTaskDetails = ({
 
   // Handle watcher operations
   const handleAddWatcher = useCallback(async (memberId: string) => {
-    if (!canMutateRef.current) return;
+    if (!canChangeOwnWatcher(memberId)) return;
     try {
       await addWatcherToTask(task.id, memberId);
       const member = members.find(m => m.id === memberId);
@@ -374,7 +378,7 @@ export const useTaskDetails = ({
   }, [task.id, members, taskWatchers, editedTask, onUpdate]);
 
   const handleRemoveWatcher = useCallback(async (memberId: string) => {
-    if (!canMutateRef.current) return;
+    if (!canChangeOwnWatcher(memberId)) return;
     try {
       await removeWatcherFromTask(task.id, memberId);
       const newWatchers = taskWatchers.filter(w => w.id !== memberId);

--- a/src/i18n/locales/en/admin.json
+++ b/src/i18n/locales/en/admin.json
@@ -1134,6 +1134,7 @@
     "someAlreadySent": "{{sendable}} of {{total}} selected notifications can be sent. Already sent notifications will be skipped.",
     "sendNow": "Send Now",
     "sending": "Sending...",
+    "sendingProgress": "Sending {{done}} of {{total}}",
     "sendSuccess": "Successfully sent {{count}} notification(s)",
     "sendPartial": "Sent {{sent}} notification(s); {{failed}} failed",
     "sendNone": "No notifications were sent. Check SMTP settings or the error details on each row.",

--- a/src/i18n/locales/en/tasks.json
+++ b/src/i18n/locales/en/tasks.json
@@ -466,6 +466,8 @@
     "assignment": "Assignment",
     "requestedBy": "Requested By",
     "addWatcher": "Add watcher...",
+    "watchThisTask": "Watch this task",
+    "unwatchThisTask": "Stop watching this task",
     "addCollaborator": "Add collaborator...",
     "noWatchers": "No watchers",
     "noCollaborators": "No collaborators",

--- a/src/i18n/locales/fr/admin.json
+++ b/src/i18n/locales/fr/admin.json
@@ -1137,6 +1137,7 @@
     "someAlreadySent": "{{sendable}} sur {{total}} notifications sélectionnées peuvent être envoyées. Les notifications déjà envoyées seront ignorées.",
     "sendNow": "Envoyer maintenant",
     "sending": "Envoi...",
+    "sendingProgress": "Envoi de {{done}} sur {{total}}",
     "sendSuccess": "{{count}} notification(s) envoyée(s) avec succès",
     "sendPartial": "{{sent}} notification(s) envoyée(s) ; {{failed}} en échec",
     "sendNone": "Aucune notification n'a été envoyée. Vérifiez les paramètres SMTP ou le détail d'erreur de chaque ligne.",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -1461,7 +1461,7 @@
     "clickToSelectAsParent": "Cliquer pour sélectionner comme tâche parent",
     "done": "TERMINÉ",
     "late": "RETARD",
-    "newTask": "Nouvelle tâche"
+    "newTask": "Nouvelle Tâche"
   },
   "tour": {
     "back": "Précédent",

--- a/src/i18n/locales/fr/tasks.json
+++ b/src/i18n/locales/fr/tasks.json
@@ -466,6 +466,8 @@
     "assignment": "Affectation",
     "requestedBy": "Demandé par",
     "addWatcher": "Ajouter un observateur...",
+    "watchThisTask": "Observer cette tâche",
+    "unwatchThisTask": "Ne plus observer cette tâche",
     "addCollaborator": "Ajouter un collaborateur...",
     "noWatchers": "Aucun observateur",
     "noCollaborators": "Aucun collaborateur",

--- a/src/services/websocketClient.ts
+++ b/src/services/websocketClient.ts
@@ -477,6 +477,10 @@ class WebSocketClient {
     this.addEventListener('activity-updated', callback);
   }
 
+  onNotificationQueueUpdated(callback: (data: any) => void) {
+    this.addEventListener('notification-queue-updated', callback);
+  }
+
   onMemberCreated(callback: (data: any) => void) {
     this.addEventListener('member-created', callback);
   }
@@ -626,6 +630,10 @@ class WebSocketClient {
 
   offActivityUpdated(callback?: (data: any) => void) {
     this.removeEventListener('activity-updated', callback);
+  }
+
+  offNotificationQueueUpdated(callback?: (data: any) => void) {
+    this.removeEventListener('notification-queue-updated', callback);
   }
 
   offMemberCreated(callback?: (data: any) => void) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,8 @@ export interface TeamMember {
   bio?: string;
   /** false when linked user is inactive; omitted/true otherwise (Agent stubs, etc.) */
   isActive?: boolean;
+  /** Linked user is a read-only viewer (no admin/user role). */
+  isViewer?: boolean;
   avatarUrl?: string;
   authProvider?: 'local' | 'google';
   googleAvatarUrl?: string;

--- a/src/utils/memberDropdownLayout.ts
+++ b/src/utils/memberDropdownLayout.ts
@@ -1,0 +1,110 @@
+import type { TeamMember } from '../types';
+import { isAgentMemberId } from './agentMemberUi';
+import { memberIsViewer } from './memberUtils';
+
+const MARGIN = 12;
+const SEARCH_H = 56;
+const AGENT_H = 76;
+const ROW_H = 40;
+const COL1_W = 280;
+const COL2_W = 520;
+
+export type MemberDropdownLayout = {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+  columns: 1 | 2;
+};
+
+export function countAssigneePeople(
+  members: TeamMember[],
+  opts?: { excludeViewers?: boolean; selectedId?: string | null }
+): number {
+  return members.filter((m) => {
+    if (isAgentMemberId(m.id)) return false;
+    if (opts?.excludeViewers && memberIsViewer(m) && m.id !== opts.selectedId) return false;
+    return true;
+  }).length;
+}
+
+/**
+ * Viewport-aware assignee menu: grow vertically first, then two columns.
+ * Overflow is always vertical — never horizontal scroll.
+ */
+export function layoutMemberDropdown(opts: {
+  anchor: DOMRect;
+  peopleCount: number;
+  showAgent: boolean;
+  /** Card/list: below the trigger. Bulk bar: beside. */
+  placement?: 'below' | 'beside';
+  extraChrome?: number;
+}): MemberDropdownLayout {
+  const vw = window.innerWidth;
+  const vh = window.innerHeight;
+  const extra = opts.extraChrome ?? 0;
+  const chrome = SEARCH_H + extra + (opts.showAgent ? AGENT_H : 0);
+  const content1 = chrome + Math.max(opts.peopleCount, 1) * ROW_H;
+
+  const spaceBelow = vh - opts.anchor.bottom - MARGIN;
+  const spaceAbove = opts.anchor.top - MARGIN;
+  const openDown = opts.placement !== 'beside' && (spaceBelow >= 240 || spaceBelow >= spaceAbove);
+  const maxH =
+    opts.placement === 'beside'
+      ? Math.max(220, vh - 2 * MARGIN)
+      : Math.max(200, openDown ? spaceBelow : spaceAbove);
+
+  const canFitTwoCols = vw >= COL2_W + 2 * MARGIN;
+  const heightTight = maxH < content1 - 8;
+  const manyPeople = opts.peopleCount >= 5;
+  const columns: 1 | 2 = canFitTwoCols && heightTight && manyPeople ? 2 : 1;
+
+  const width = columns === 2 ? Math.min(COL2_W, vw - 2 * MARGIN) : COL1_W;
+  const rows = columns === 2 ? Math.ceil(opts.peopleCount / 2) : opts.peopleCount;
+  const desired = chrome + Math.min(Math.max(rows, 4), 14) * ROW_H;
+  const height = Math.min(maxH, Math.max(220, desired));
+
+  let left: number;
+  let top: number;
+
+  if (opts.placement === 'beside') {
+    const preferredLeft = opts.anchor.right + 6;
+    left =
+      preferredLeft + width <= vw - MARGIN
+        ? preferredLeft
+        : Math.max(MARGIN, opts.anchor.left - width - 6);
+    top = Math.max(MARGIN, Math.min(opts.anchor.top, vh - height - MARGIN));
+  } else {
+    left = opts.anchor.left;
+    if (left + width > vw - MARGIN) left = Math.max(MARGIN, vw - width - MARGIN);
+    if (left < MARGIN) left = MARGIN;
+    top = openDown ? opts.anchor.bottom + 4 : opts.anchor.top - height - 4;
+    if (top < MARGIN) top = MARGIN;
+    if (top + height > vh - MARGIN) top = Math.max(MARGIN, vh - height - MARGIN);
+  }
+
+  return { left, top, width, height, columns };
+}
+
+export function layoutMemberDropdownFromElement(
+  el: HTMLElement,
+  members: TeamMember[],
+  opts?: {
+    showAgent?: boolean;
+    excludeViewers?: boolean;
+    selectedId?: string | null;
+    placement?: 'below' | 'beside';
+    extraChrome?: number;
+  }
+): MemberDropdownLayout {
+  return layoutMemberDropdown({
+    anchor: el.getBoundingClientRect(),
+    peopleCount: countAssigneePeople(members, {
+      excludeViewers: opts?.excludeViewers,
+      selectedId: opts?.selectedId,
+    }),
+    showAgent: opts?.showAgent !== false,
+    placement: opts?.placement,
+    extraChrome: opts?.extraChrome,
+  });
+}

--- a/src/utils/memberUtils.ts
+++ b/src/utils/memberUtils.ts
@@ -9,3 +9,7 @@ export const truncateMemberName = (name: string, maxLength: number = 30): string
   return name.substring(0, maxLength) + '...';
 };
 
+export function memberIsViewer(member?: { isViewer?: boolean } | null): boolean {
+  return Boolean(member?.isViewer);
+}
+

--- a/src/utils/troubleshootingAccess.ts
+++ b/src/utils/troubleshootingAccess.ts
@@ -8,9 +8,19 @@ export const TROUBLESHOOTING_UNLOCK_KEY = 'adminTroubleshootingUnlocked';
 /** Type this in ALL CAPS while Admin → App Settings is focused (not in an input). */
 export const TROUBLESHOOTING_UNLOCK_SEQUENCE = 'TROUBLE';
 
-export function isTroubleshootingGatedDeployment(): boolean {
+/** Sent on system-info when the session is unlocked (gated deployments). */
+export const TROUBLESHOOTING_REQUEST_HEADER = 'X-Agila-Troubleshooting';
+
+type SettingsLike = { [key: string]: string | undefined } | null | undefined;
+
+function flagTrue(envVal: string | undefined, settingVal: string | undefined): boolean {
+  return envVal === 'true' || settingVal === 'true';
+}
+
+export function isTroubleshootingGatedDeployment(siteSettings?: SettingsLike): boolean {
   return (
-    process.env.MULTI_TENANT === 'true' || process.env.DEMO_ENABLED === 'true'
+    flagTrue(process.env.MULTI_TENANT, siteSettings?.DEPLOY_MULTI_TENANT) ||
+    flagTrue(process.env.DEMO_ENABLED, siteSettings?.DEPLOY_DEMO_ENABLED)
   );
 }
 
@@ -23,9 +33,29 @@ export function readTroubleshootingUnlocked(): boolean {
 }
 
 /** Whether the Troubleshooting Admin tab (and matching Help section) should show. */
-export function isTroubleshootingVisible(): boolean {
-  if (!isTroubleshootingGatedDeployment()) return true;
+export function isTroubleshootingVisible(siteSettings?: SettingsLike): boolean {
+  if (!isTroubleshootingGatedDeployment(siteSettings)) return true;
   return readTroubleshootingUnlocked();
+}
+
+/**
+ * Host/pod metrics in the header: always on single-tenant (non-demo);
+ * on MULTI_TENANT / DEMO only after TROUBLE unlock.
+ * Until public settings include DEPLOY_* flags, stay hidden so k8s clients
+ * built without MULTI_TENANT do not poll /admin/system-info (404).
+ */
+export function isSystemPanelAvailable(siteSettings?: SettingsLike): boolean {
+  const deployKnown =
+    siteSettings?.DEPLOY_MULTI_TENANT !== undefined ||
+    siteSettings?.DEPLOY_DEMO_ENABLED !== undefined;
+  if (
+    !deployKnown &&
+    process.env.MULTI_TENANT !== 'true' &&
+    process.env.DEMO_ENABLED !== 'true'
+  ) {
+    return false;
+  }
+  return isTroubleshootingVisible(siteSettings);
 }
 
 /** Same-tab listeners (sessionStorage does not fire `storage` in the writing tab). */


### PR DESCRIPTION
## Summary
- Viewer role: eye badge on avatars, omit from assignee pickers, Watch this task (self-only).
- Assignee menus use more viewport height, optional two columns, Agent pinned; no horizontal scroll.
- Automation: paged compact search, drop btree on `task_work.value`, keep dry-run plan after stop, clearer runner tool logs.

## Test plan
- [ ] Viewer cannot be assigned; can watch/unwatch own membership
- [ ] Assignee dropdown shows Agent and scrolls vertically
- [ ] Automation bulk reassign >30 tasks: plan saves, Apply persists

Made with [Cursor](https://cursor.com)