### PR TITLE
Enforce compact field length limits in the UI and API

### DIFF
--- a/server/constants/fieldLimits.js
+++ b/server/constants/fieldLimits.js
@@ -1,0 +1,24 @@
+/** Keep in sync with src/constants/appConstants.ts */
+
+/** Task card / list / email subject titles — keep scannable. */
+export const TASK_TITLE_MAX_LENGTH = 200;
+
+/** Stored HTML for task descriptions (TipTap). */
+export const TASK_DESCRIPTION_MAX_LENGTH = 100_000;
+
+/** Comment body (HTML or plain). */
+export const COMMENT_MAX_LENGTH = 10_000;
+
+export const BOARD_TITLE_MAX_LENGTH = 200;
+export const COLUMN_TITLE_MAX_LENGTH = 200;
+export const COLUMN_POLICY_MAX_LENGTH = 500;
+
+export const TAG_NAME_MAX_LENGTH = 30;
+export const TAG_DESCRIPTION_MAX_LENGTH = 2000;
+
+export const BLOCKED_REASON_MAX_LENGTH = 500;
+
+export const FILTER_NAME_MAX_LENGTH = 100;
+export const SPRINT_NAME_MAX_LENGTH = 30;
+export const SPRINT_DESCRIPTION_MAX_LENGTH = 5000;
+export const PRIORITY_NAME_MAX_LENGTH = 30;

--- a/server/services/automationTools.js
+++ b/server/services/automationTools.js
@@ -26,6 +26,7 @@ import {
   AUTOMATION_CAPABILITIES
 } from '../constants/automation.js';
 import { AGENT_MEMBER_ID } from '../constants/agentIdentity.js';
+import { TASK_TITLE_MAX_LENGTH, TASK_DESCRIPTION_MAX_LENGTH } from '../constants/fieldLimits.js';
 import notificationService from './notificationService.js';
 import { getDefaultBoardColumns } from '../utils/defaultBoardColumns.js';
 import { updateStorageUsage } from '../utils/storageUtils.js';
@@ -574,6 +575,12 @@ async function toolCreateTask(ctx, args, { dryRun }, allowedBoardIds) {
   if (!title || !boardId || !columnId) {
     return { error: 'title, boardId, and columnId are required' };
   }
+  if (String(title).length > TASK_TITLE_MAX_LENGTH) {
+    return { error: `title must be at most ${TASK_TITLE_MAX_LENGTH} characters` };
+  }
+  if (description != null && String(description).length > TASK_DESCRIPTION_MAX_LENGTH) {
+    return { error: `description must be at most ${TASK_DESCRIPTION_MAX_LENGTH} characters` };
+  }
   assertBoardInScope(boardId, allowedBoardIds);
 
   const column = await helpers.getColumnById(ctx.db, columnId);
@@ -662,8 +669,18 @@ async function toolUpdateTasks(ctx, args, { dryRun }, allowedBoardIds) {
   }
 
   const updates = {};
-  if (fields.title !== undefined) updates.title = fields.title;
-  if (fields.description !== undefined) updates.description = fields.description;
+  if (fields.title !== undefined) {
+    if (String(fields.title).length > TASK_TITLE_MAX_LENGTH) {
+      return { error: `title must be at most ${TASK_TITLE_MAX_LENGTH} characters` };
+    }
+    updates.title = fields.title;
+  }
+  if (fields.description !== undefined) {
+    if (fields.description != null && String(fields.description).length > TASK_DESCRIPTION_MAX_LENGTH) {
+      return { error: `description must be at most ${TASK_DESCRIPTION_MAX_LENGTH} characters` };
+    }
+    updates.description = fields.description;
+  }
   if (fields.effort !== undefined) updates.effort = fields.effort;
   if (fields.startDate !== undefined) updates.startDate = fields.startDate;
   if (fields.dueDate !== undefined) updates.dueDate = fields.dueDate;

--- a/server/utils/requestValidation.js
+++ b/server/utils/requestValidation.js
@@ -1,4 +1,19 @@
 import { z } from 'zod';
+import {
+  TASK_TITLE_MAX_LENGTH,
+  TASK_DESCRIPTION_MAX_LENGTH,
+  COMMENT_MAX_LENGTH,
+  BOARD_TITLE_MAX_LENGTH,
+  COLUMN_TITLE_MAX_LENGTH,
+  COLUMN_POLICY_MAX_LENGTH,
+  TAG_NAME_MAX_LENGTH,
+  TAG_DESCRIPTION_MAX_LENGTH,
+  BLOCKED_REASON_MAX_LENGTH,
+  FILTER_NAME_MAX_LENGTH,
+  SPRINT_NAME_MAX_LENGTH,
+  SPRINT_DESCRIPTION_MAX_LENGTH,
+  PRIORITY_NAME_MAX_LENGTH
+} from '../constants/fieldLimits.js';
 
 /**
  * Parse req.body with a Zod schema. Returns { success, data } or { success: false, error }.
@@ -60,13 +75,13 @@ const attachmentSchema = z.object({
 export const createCommentBodySchema = z.object({
   id: z.string().min(1).max(128),
   taskId: z.string().min(1).max(128),
-  text: z.string().min(1, 'Comment cannot be empty').max(10000, 'Comment must be less than 10000 characters'),
+  text: z.string().min(1, 'Comment cannot be empty').max(COMMENT_MAX_LENGTH, `Comment must be less than ${COMMENT_MAX_LENGTH} characters`),
   createdAt: z.union([z.string().min(1), z.number()]).optional(),
   attachments: z.array(attachmentSchema).max(50).optional()
 }).passthrough();
 
 export const updateCommentBodySchema = z.object({
-  text: z.string().min(1, 'Comment cannot be empty').max(10000, 'Comment must be less than 10000 characters')
+  text: z.string().min(1, 'Comment cannot be empty').max(COMMENT_MAX_LENGTH, `Comment must be less than ${COMMENT_MAX_LENGTH} characters`)
 });
 
 export const loginBodySchema = z.object({
@@ -86,14 +101,14 @@ export const passwordResetCompleteBodySchema = z.object({
 /** Task create / add-at-top — core fields required; extras passthrough for FE compatibility. */
 export const createTaskBodySchema = z.object({
   id: idSchema,
-  title: z.string().min(1, 'Title is required').max(500),
-  description: z.string().max(500_000).optional(),
+  title: z.string().min(1, 'Title is required').max(TASK_TITLE_MAX_LENGTH),
+  description: z.string().max(TASK_DESCRIPTION_MAX_LENGTH).optional(),
   memberId: optionalNullableId,
   requesterId: optionalNullableId,
   startDate: optionalDate,
   dueDate: optionalDate,
   effort: effortSchema,
-  priority: z.union([z.string().max(100), z.null()]).optional(),
+  priority: z.union([z.string().max(PRIORITY_NAME_MAX_LENGTH), z.null()]).optional(),
   priorityId: optionalNullableId,
   columnId: idSchema,
   boardId: idSchema,
@@ -104,21 +119,21 @@ export const createTaskBodySchema = z.object({
 /** Task update — partial; known fields constrained; unknown keys allowed. */
 export const updateTaskBodySchema = z.object({
   id: idSchema.optional(),
-  title: z.string().min(1).max(500).optional(),
-  description: z.union([z.string().max(500_000), z.null()]).optional(),
+  title: z.string().min(1).max(TASK_TITLE_MAX_LENGTH).optional(),
+  description: z.union([z.string().max(TASK_DESCRIPTION_MAX_LENGTH), z.null()]).optional(),
   memberId: optionalNullableId,
   requesterId: optionalNullableId,
   startDate: optionalDate,
   dueDate: optionalDate,
   effort: effortSchema,
-  priority: z.union([z.string().max(100), z.null()]).optional(),
+  priority: z.union([z.string().max(PRIORITY_NAME_MAX_LENGTH), z.null()]).optional(),
   priorityId: optionalNullableId,
   columnId: z.preprocess((v) => (v === '' ? undefined : v), idSchema.optional()),
   boardId: z.preprocess((v) => (v === '' ? undefined : v), idSchema.optional()),
   position: z.union([z.number(), z.string().max(32), z.null()]).optional(),
   sprintId: optionalNullableId,
   isBlocked: booleanish,
-  blockedReason: z.union([z.string().max(2000), z.null()]).optional(),
+  blockedReason: z.union([z.string().max(BLOCKED_REASON_MAX_LENGTH), z.null()]).optional(),
   skipActivity: z.boolean().optional()
 }).passthrough();
 
@@ -224,11 +239,11 @@ export const adminUpdateUserRoleBodySchema = z.union([
 
 export const createBoardBodySchema = z.object({
   id: idSchema,
-  title: z.string().min(1, 'Board title is required').max(200)
+  title: z.string().min(1, 'Board title is required').max(BOARD_TITLE_MAX_LENGTH)
 }).passthrough();
 
 export const updateBoardBodySchema = z.object({
-  title: z.string().min(1, 'Board title is required').max(200),
+  title: z.string().min(1, 'Board title is required').max(BOARD_TITLE_MAX_LENGTH),
   wip_limit: z.union([z.number(), z.string().max(32), z.null()]).optional()
 }).passthrough();
 
@@ -239,17 +254,17 @@ export const reorderBoardBodySchema = z.object({
 
 export const createColumnBodySchema = z.object({
   id: idSchema,
-  title: z.string().min(1, 'Column title is required').max(200),
+  title: z.string().min(1, 'Column title is required').max(COLUMN_TITLE_MAX_LENGTH),
   boardId: idSchema,
   position: z.union([z.number(), z.string().max(32), z.null()]).optional()
 }).passthrough();
 
 export const updateColumnBodySchema = z.object({
-  title: z.string().min(1, 'Column title is required').max(200),
+  title: z.string().min(1, 'Column title is required').max(COLUMN_TITLE_MAX_LENGTH),
   is_finished: booleanish,
   is_archived: booleanish,
   wip_limit: z.union([z.number(), z.string().max(32), z.null()]).optional(),
-  policy_text: z.union([z.string().max(2000), z.null()]).optional()
+  policy_text: z.union([z.string().max(COLUMN_POLICY_MAX_LENGTH), z.null()]).optional()
 }).passthrough();
 
 export const reorderColumnBodySchema = z.object({
@@ -295,15 +310,15 @@ export const updateAppUrlBodySchema = z.object({
 // —— Tags / priorities / sprints / members ——
 
 export const createTagBodySchema = z.object({
-  tag: z.string().min(1, 'Tag name is required').max(100),
-  description: z.string().max(2000).optional(),
+  tag: z.string().min(1, 'Tag name is required').max(TAG_NAME_MAX_LENGTH),
+  description: z.string().max(TAG_DESCRIPTION_MAX_LENGTH).optional(),
   color: z.string().max(32).optional()
 }).passthrough();
 
 export const updateTagBodySchema = createTagBodySchema;
 
 export const createPriorityBodySchema = z.object({
-  priority: z.string().min(1, 'Priority name is required').max(100),
+  priority: z.string().min(1, 'Priority name is required').max(PRIORITY_NAME_MAX_LENGTH),
   color: z.string().min(1, 'Color is required').max(32)
 }).passthrough();
 
@@ -323,11 +338,11 @@ export const reorderPrioritiesBodySchema = z.object({
 });
 
 export const createSprintBodySchema = z.object({
-  name: z.string().min(1, 'Sprint name is required').max(200),
+  name: z.string().min(1, 'Sprint name is required').max(SPRINT_NAME_MAX_LENGTH),
   start_date: z.string().min(1, 'Start date is required').max(64),
   end_date: z.string().min(1, 'End date is required').max(64),
   is_active: booleanish,
-  description: z.union([z.string().max(5000), z.null()]).optional()
+  description: z.union([z.string().max(SPRINT_DESCRIPTION_MAX_LENGTH), z.null()]).optional()
 }).passthrough();
 
 export const updateSprintBodySchema = createSprintBodySchema;
@@ -410,13 +425,13 @@ export const viewFiltersSchema = z
   .passthrough();
 
 export const createViewBodySchema = z.object({
-  filterName: z.string().trim().min(1, 'Filter name is required').max(200),
+  filterName: z.string().trim().min(1, 'Filter name is required').max(FILTER_NAME_MAX_LENGTH),
   filters: viewFiltersSchema,
   shared: booleanish
 }).passthrough();
 
 export const updateViewBodySchema = z.object({
-  filterName: z.string().trim().min(1).max(200).optional(),
+  filterName: z.string().trim().min(1).max(FILTER_NAME_MAX_LENGTH).optional(),
   filters: viewFiltersSchema.optional(),
   shared: booleanish
 }).passthrough();
@@ -572,7 +587,7 @@ export const agentMoveTaskBodySchema = z.object({
 }).passthrough();
 
 export const agentCommentBodySchema = z.object({
-  text: z.string().min(1).max(10000),
+  text: z.string().min(1).max(COMMENT_MAX_LENGTH),
   id: idSchema.optional(),
   markWaiting: booleanish
 }).passthrough();
@@ -594,7 +609,7 @@ export const agentAttachmentsBodySchema = z.object({
 
 export const agentPatchTaskBodySchema = z
   .object({
-    priority: z.union([z.string().max(100), z.null()]).optional(),
+    priority: z.union([z.string().max(PRIORITY_NAME_MAX_LENGTH), z.null()]).optional(),
     priorityId: optionalNullableId,
     priority_id: optionalNullableId,
     effort: effortSchema,
@@ -606,8 +621,8 @@ export const agentPatchTaskBodySchema = z
     columnid: idSchema.optional(),
     sprintId: optionalNullableId,
     sprint_id: optionalNullableId,
-    title: z.any().optional(),
-    description: z.any().optional()
+    title: z.string().max(TASK_TITLE_MAX_LENGTH).optional(),
+    description: z.union([z.string().max(TASK_DESCRIPTION_MAX_LENGTH), z.null()]).optional()
   })
   .passthrough();
 
@@ -637,7 +652,7 @@ export const agentRunnerCallbackBodySchema = z
     jobId: z.string().max(128).optional(),
     progress: z.union([z.number(), z.string().max(32)]).optional(),
     log: z.string().max(100_000).optional(),
-    comment: z.string().max(10000).optional(),
+    comment: z.string().max(COMMENT_MAX_LENGTH).optional(),
     status: z.string().max(64).optional(),
     prUrl: z.string().max(2048).optional(),
     branch: z.string().max(256).optional(),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3047,7 +3047,7 @@ function AppContent() {
 
     const newTask: Task = {
       id: generateUUID(),
-      title: t('taskCard.newTask', { ns: 'common' }),
+      title: t('taskCard.newTask'),
       description: '',
       memberId: currentUserMember.id,
       startDate: taskStartDate,

--- a/src/components/AddCommentModal.tsx
+++ b/src/components/AddCommentModal.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { createPortal } from 'react-dom';
 import { X, Send } from 'lucide-react';
 import { useEscapeDismiss } from '../hooks/useEscapeDismiss';
+import { COMMENT_MAX_LENGTH } from '../constants/appConstants';
 
 interface AddCommentModalProps {
   isOpen: boolean;
@@ -128,6 +129,7 @@ export default function AddCommentModal({
             onChange={(e) => setCommentText(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder={t('addCommentModal.typeYourCommentHere')}
+            maxLength={COMMENT_MAX_LENGTH}
             className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder:text-gray-400 dark:placeholder:text-gray-500"
             rows={4}
             disabled={isSubmitting}

--- a/src/components/AddTagModal.tsx
+++ b/src/components/AddTagModal.tsx
@@ -2,6 +2,7 @@ import React, { useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { X } from 'lucide-react';
 import { useEscapeDismiss } from '../hooks/useEscapeDismiss';
+import { TAG_NAME_MAX_LENGTH } from '../constants/appConstants';
 
 interface AddTagModalProps {
   onClose: () => void;
@@ -145,6 +146,7 @@ export default function AddTagModal({ onClose, onTagCreated }: AddTagModalProps)
               onKeyDown={handleInputKeyDown}
               className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white"
               placeholder={t('addTagModal.enterTagName')}
+              maxLength={TAG_NAME_MAX_LENGTH}
               autoFocus
               disabled={isSubmitting}
             />

--- a/src/components/AssignToAgentModal.tsx
+++ b/src/components/AssignToAgentModal.tsx
@@ -12,6 +12,7 @@ import {
   looksLikeNonCodingRequest,
 } from '../utils/agentTaskHints';
 import TextEditor from './TextEditor';
+import { TASK_DESCRIPTION_MAX_LENGTH } from '../constants/appConstants';
 import { ModernCheckbox } from './ModernCheckbox';
 import DOMPurify from 'dompurify';
 
@@ -686,6 +687,7 @@ const AssignToAgentModal: React.FC<AssignToAgentModalProps> = ({
                   compact
                   minHeight="96px"
                   placeholder={t('agent.taskDescriptionPlaceholder')}
+                  maxLength={TASK_DESCRIPTION_MAX_LENGTH}
                   allowImagePaste={false}
                   allowImageDelete={false}
                   className="w-full border border-gray-200 dark:border-gray-600 rounded-md overflow-hidden bg-gray-50/50 dark:bg-gray-900/20"

--- a/src/components/BoardTabs.tsx
+++ b/src/components/BoardTabs.tsx
@@ -13,6 +13,7 @@ import {
   getBoardTabDropClasses 
 } from '../utils/crossBoardDragUtils';
 import { KanbanChromeTooltip } from './KanbanChromeTooltip';
+import { BOARD_TITLE_MAX_LENGTH } from '../constants/appConstants';
 import { useEscapeDismiss } from '../hooks/useEscapeDismiss';
 import {
   TASK_COUNT_PILL_BASE,
@@ -1004,6 +1005,7 @@ export default function BoardTabs({
             editingTitleRef.current = e.target.value;
           }}
           className="w-full rounded-md border border-gray-300 bg-white px-2 py-1.5 text-sm text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100"
+          maxLength={BOARD_TITLE_MAX_LENGTH}
           autoFocus
           disabled={isSubmitting}
           aria-label={t('boardTabs.boardTitle')}

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -15,6 +15,7 @@ import { TASK_COUNT_PILL_BASE, taskCountPillToneClass, taskCountPillWeightClass 
 import { sumTaskEffort, formatEffortDisplay, parseEffortUnit } from '../utils/taskUtils';
 import { showColumnEffort, showColumnTaskCounts } from '../utils/kanbanChromeVisibility';
 import { KanbanChromeTooltip } from './KanbanChromeTooltip';
+import { COLUMN_TITLE_MAX_LENGTH, COLUMN_POLICY_MAX_LENGTH } from '../constants/appConstants';
 import { resolveTaskMember } from '../utils/agentMemberUi';
 import {
   shouldShowColumnBulkFab,
@@ -1049,6 +1050,7 @@ export default function KanbanColumn({
                 type="text"
                 value={title}
                 onChange={e => setTitle(e.target.value)}
+                maxLength={COLUMN_TITLE_MAX_LENGTH}
                 className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                 autoFocus
                 disabled={isSubmitting}
@@ -1196,7 +1198,7 @@ export default function KanbanColumn({
                   value={policyText}
                   onChange={(e) => setPolicyText(e.target.value)}
                   rows={2}
-                  maxLength={500}
+                  maxLength={COLUMN_POLICY_MAX_LENGTH}
                   placeholder={t('column.policyTextPlaceholder')}
                   className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm resize-y"
                   disabled={isSubmitting}

--- a/src/components/ListView.tsx
+++ b/src/components/ListView.tsx
@@ -28,7 +28,7 @@ import TextEditor from './TextEditor';
 import AddTagModal from './AddTagModal';
 import AddCommentModal from './AddCommentModal';
 import { putTaskWork, getTaskWork, setTaskWorkControl, type TaskWorkMap } from '../api';
-import { AGENT_MEMBER_ID } from '../constants/appConstants';
+import { AGENT_MEMBER_ID, TASK_TITLE_MAX_LENGTH, TASK_DESCRIPTION_MAX_LENGTH } from '../constants/appConstants';
 import {
   isAgentMemberId,
   resolveTaskMember,
@@ -2010,6 +2010,7 @@ export default function ListView({
                               onKeyDown={handleKeyDown}
                               className="text-sm font-medium text-gray-900 dark:text-gray-100 bg-white dark:bg-gray-700 border border-blue-400 rounded px-1 py-0.5 outline-none focus:border-blue-500 w-full"
                               onClick={(e) => e.stopPropagation()}
+                              maxLength={TASK_TITLE_MAX_LENGTH}
                             />
                           ) : (
                             <div 
@@ -2061,6 +2062,7 @@ export default function ListView({
                                   onChange={(content) => setEditValue(content)}
                                   initialContent={editValue}
                                   placeholder={t('listView.enterTaskDescription')}
+                                  maxLength={TASK_DESCRIPTION_MAX_LENGTH}
                                   compact={true}
                                   showSubmitButtons={false}
                                   resizable={false}

--- a/src/components/ManageFiltersModal.tsx
+++ b/src/components/ManageFiltersModal.tsx
@@ -3,6 +3,7 @@ import { X, Edit2, Trash2, Save, XCircle, Globe, Lock } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { SavedFilterView, updateSavedFilterView, deleteSavedFilterView } from '../api';
 import { useEscapeDismiss } from '../hooks/useEscapeDismiss';
+import { FILTER_NAME_MAX_LENGTH } from '../constants/appConstants';
 
 interface ManageFiltersModalProps {
   isOpen: boolean;
@@ -199,6 +200,7 @@ export default function ManageFiltersModal({
                         onChange={(e) => setEditName(e.target.value)}
                         className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100"
                         placeholder={t('manageFiltersModal.filterNamePlaceholder')}
+                        maxLength={FILTER_NAME_MAX_LENGTH}
                         onKeyDown={(e) => {
                           if (e.key === 'Enter' && editName.trim()) {
                             handleSaveEdit();

--- a/src/components/RenameModal.tsx
+++ b/src/components/RenameModal.tsx
@@ -2,19 +2,22 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { X } from 'lucide-react';
 import { useEscapeDismiss } from '../hooks/useEscapeDismiss';
+import { BOARD_TITLE_MAX_LENGTH } from '../constants/appConstants';
 
 interface RenameModalProps {
   title: string;
   currentName: string;
   onSubmit: (newName: string) => void;
   onClose: () => void;
+  maxLength?: number;
 }
 
 export default function RenameModal({
   title,
   currentName,
   onSubmit,
-  onClose
+  onClose,
+  maxLength = BOARD_TITLE_MAX_LENGTH
 }: RenameModalProps) {
   const { t } = useTranslation('common');
   const [name, setName] = React.useState(currentName);
@@ -57,6 +60,7 @@ export default function RenameModal({
               onChange={(e) => setName(e.target.value)}
               className="w-full px-3 py-2 border rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
               placeholder={t('renameModal.enterName')}
+              maxLength={maxLength}
               autoFocus
             />
           </div>

--- a/src/components/SearchInterface.tsx
+++ b/src/components/SearchInterface.tsx
@@ -8,6 +8,7 @@ import ManageFiltersModal from './ManageFiltersModal';
 import ColumnFilterDropdown from './ColumnFilterDropdown';
 import { getAgentAvatarSrc } from '../utils/agentMemberUi';
 import { useEscapeDismiss } from '../hooks/useEscapeDismiss';
+import { FILTER_NAME_MAX_LENGTH } from '../constants/appConstants';
 
 interface SearchFilters {
   text: string;
@@ -949,6 +950,7 @@ export default function SearchInterface({
                   value={newFilterName}
                   onChange={(e) => setNewFilterName(e.target.value)}
                   placeholder={t('searchInterface.enterFilterName')}
+                  maxLength={FILTER_NAME_MAX_LENGTH}
                   className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-blue-500 bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 placeholder-gray-400 dark:placeholder-gray-500"
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' && newFilterName.trim()) {

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -45,6 +45,8 @@ import {
   AGENT_MEMBER_ID,
   SYSTEM_MEMBER_ID,
   AGENT_DRAG_BLOCKING_STATUSES,
+  TASK_TITLE_MAX_LENGTH,
+  TASK_DESCRIPTION_MAX_LENGTH,
 } from '../constants/appConstants';
 import AgentPanel from './AgentPanel';
 import type { AgentPanelView } from './AgentPanel';
@@ -2054,6 +2056,7 @@ const TaskCard = React.memo(function TaskCard({
                 className="font-medium text-gray-800 dark:text-gray-100 bg-white dark:bg-gray-700 border border-blue-400 rounded px-1 py-0.5 outline-none focus:border-blue-500 w-full text-sm"
                 onClick={(e) => e.stopPropagation()}
                 autoFocus
+                maxLength={TASK_TITLE_MAX_LENGTH}
               />
             </div>
           ) : (
@@ -2155,6 +2158,7 @@ const TaskCard = React.memo(function TaskCard({
                   }}
                   initialContent={editedDescription}
                   placeholder={t('taskCard.enterTaskDescription')}
+                  maxLength={TASK_DESCRIPTION_MAX_LENGTH}
                   compact={true}
                   showSubmitButtons={false}
                   resizable={true}

--- a/src/components/TaskDetails.tsx
+++ b/src/components/TaskDetails.tsx
@@ -56,6 +56,10 @@ import {
   AGENT_MEMBER_ID,
   SYSTEM_MEMBER_ID,
   AGENT_DRAG_BLOCKING_STATUSES,
+  TASK_TITLE_MAX_LENGTH,
+  TASK_DESCRIPTION_MAX_LENGTH,
+  COMMENT_MAX_LENGTH,
+  BLOCKED_REASON_MAX_LENGTH,
 } from '../constants/appConstants';
 import { feDebug } from '../utils/clientDebug';
 import { commentTextToHtml } from '../utils/commentContent';
@@ -1653,6 +1657,7 @@ export default function TaskDetails({
                         : 'bg-gray-50 dark:bg-gray-700'
                     }`}
                     disabled={isSubmitting || isWritersLocked}
+                    maxLength={TASK_TITLE_MAX_LENGTH}
                     readOnly={isReadOnlyMode}
                     title={
                       isWritersLocked
@@ -1773,6 +1778,7 @@ export default function TaskDetails({
                 onImageRemovalNeeded={isWritersLocked ? undefined : handleImageRemoval}
                 initialContent={editedTask.description}
                 placeholder={t('placeholders.enterDescription')}
+                maxLength={TASK_DESCRIPTION_MAX_LENGTH}
                 minHeight="120px"
                 showSubmitButtons={false}
                 showAttachments={true}
@@ -2082,6 +2088,7 @@ export default function TaskDetails({
                       });
                     }}
                     placeholder={t('labels.blockedReasonPlaceholder')}
+                    maxLength={BLOCKED_REASON_MAX_LENGTH}
                     className="mt-2 w-full px-3 py-2 border rounded-md bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100 text-sm"
                     disabled={isSubmitting || isWritersLocked}
                   />
@@ -2393,6 +2400,7 @@ export default function TaskDetails({
                 // No additional action needed here
               }}
               placeholder={t('comments.addComment')}
+              maxLength={COMMENT_MAX_LENGTH}
               showAttachments={true}
               submitButtonText={t('actions.addComment')}
               cancelButtonText={t('buttons.cancel', { ns: 'common' })}
@@ -2481,6 +2489,7 @@ export default function TaskDetails({
                       }}
                       onCancel={handleCancelEditComment}
                       placeholder={t('comments.editComment')}
+                      maxLength={COMMENT_MAX_LENGTH}
                       showAttachments={true}
                       submitButtonText={t('comments.saveChanges')}
                       cancelButtonText={t('buttons.cancel', { ns: 'common' })}

--- a/src/components/TaskPage.tsx
+++ b/src/components/TaskPage.tsx
@@ -19,6 +19,7 @@ import { getAuthenticatedAttachmentUrl } from '../utils/authImageUrl';
 import { commentTextToHtml } from '../utils/commentContent';
 import { feDebug } from '../utils/clientDebug';
 import { parseEffortUnit, isTaskSoftDeleted } from '../utils/taskUtils';
+import { TASK_TITLE_MAX_LENGTH, TASK_DESCRIPTION_MAX_LENGTH, COMMENT_MAX_LENGTH, BLOCKED_REASON_MAX_LENGTH } from '../constants/appConstants';
 import { mergeTaskTagsWithLiveData } from '../utils/tagUtils';
 import { userCanMutate, userIsViewer } from '../utils/permissions';
 import MemberAvatar, { getPriorityPillStyle } from './ui/MemberAvatar';
@@ -1095,6 +1096,7 @@ export default function TaskPage({
                     : 'bg-white dark:bg-gray-700'
                 }`}
                 placeholder={t('placeholders.enterTitle')}
+                maxLength={TASK_TITLE_MAX_LENGTH}
               />
             </div>
 
@@ -1112,6 +1114,7 @@ export default function TaskPage({
                 onImageRemovalNeeded={fieldsLocked ? undefined : handleImageRemoval}
                 initialContent={editedTask.description || ''}
                 placeholder={t('placeholders.enterDescription')}
+                maxLength={TASK_DESCRIPTION_MAX_LENGTH}
                 minHeight="120px"
                 showSubmitButtons={false}
                 showAttachments={!fieldsLocked}
@@ -1218,6 +1221,7 @@ export default function TaskPage({
                     // No additional action needed here
                   }}
                   placeholder={t('taskPage.addCommentPlaceholder')}
+                  maxLength={COMMENT_MAX_LENGTH}
                   showAttachments={true}
                   submitButtonText={t('taskPage.addComment')}
                   cancelButtonText={t('buttons.cancel', { ns: 'common' })}
@@ -1294,6 +1298,7 @@ export default function TaskPage({
                           onSubmit={handleSaveEditComment}
                           onCancel={handleCancelEditComment}
                           placeholder={t('taskPage.editCommentPlaceholder')}
+                          maxLength={COMMENT_MAX_LENGTH}
                           minHeight="80px"
                           showToolbar={true}
                           showSubmitButtons={true}
@@ -1782,6 +1787,7 @@ export default function TaskPage({
                         window.setTimeout(() => saveImmediately(), 0);
                       }}
                       placeholder={t('labels.blockedReasonPlaceholder')}
+                      maxLength={BLOCKED_REASON_MAX_LENGTH}
                       className={`mt-2 w-full px-3 py-2 border rounded-md bg-white dark:bg-gray-700 border-gray-300 dark:border-gray-600 text-gray-900 dark:text-gray-100 text-sm ${
                         fieldsLocked ? 'cursor-default' : ''
                       }`}

--- a/src/components/TextEditor.tsx
+++ b/src/components/TextEditor.tsx
@@ -94,6 +94,8 @@ interface TextEditorProps {
   imageDisplayMode?: 'full' | 'compact'; // Image display size (default: 'full')
   /** When false, TipTap content is not editable (e.g. soft-deleted task details). Default true. */
   editable?: boolean;
+  /** When set, extra typing/paste that would exceed this HTML length is undone. */
+  maxLength?: number;
 }
 
 const defaultToolbarOptions: ToolbarOptions = {
@@ -174,6 +176,7 @@ export default function TextEditor({
   allowImageResize = true,
   imageDisplayMode = 'full',
   editable = true,
+  maxLength,
 }: TextEditorProps) {
   const { t } = useTranslation('common');
   const { siteSettings } = useSettings();
@@ -217,6 +220,8 @@ export default function TextEditor({
   const tableDropdownRef = React.useRef<HTMLDivElement>(null);
   // TipTap HTML after last programmatic setContent / create — used to ignore non-user updates
   const contentBaselineRef = React.useRef<string | null>(null);
+  const maxLengthRef = React.useRef<number | undefined>(maxLength);
+  maxLengthRef.current = maxLength;
 
   // Track previous existingAttachments to prevent infinite updates
   const prevExistingAttachmentsRef = React.useRef<string>('');
@@ -671,7 +676,12 @@ export default function TextEditor({
       contentBaselineRef.current = content;
       onChange(content);
     },
-    onUpdate: ({ editor }) => {
+    onUpdate: ({ editor, transaction }) => {
+      const max = maxLengthRef.current;
+      if (max && transaction.docChanged && editor.getHTML().length > max) {
+        editor.commands.undo();
+        return;
+      }
       if (!onChange) return;
       const content = editor.getHTML();
       // Ignore updates that don't change content relative to the last programmatic baseline
@@ -1183,6 +1193,9 @@ export default function TextEditor({
     if (!editor) return;
     
     const content = editor.getHTML();
+    if (maxLength && content.length > maxLength) {
+      return;
+    }
     const isEmptyContent = !content || content.replace(/<[^>]*>/g, '').trim() === '';
     
     if (!isEmptyContent || (showAttachments && newAttachments.length > 0)) {

--- a/src/components/admin/AdminDefaultBoardColumnsTable.tsx
+++ b/src/components/admin/AdminDefaultBoardColumnsTable.tsx
@@ -21,6 +21,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { toast } from '../../utils/toast';
 import { useEscapeDismiss } from '../../hooks/useEscapeDismiss';
 import { ADMIN_TABLE_ROW_CLASS } from '../../utils/adminFieldLimits';
+import { COLUMN_TITLE_MAX_LENGTH } from '../../constants/appConstants';
 import { adminInputClass } from './AdminSection';
 import {
   type DefaultBoardColumnRow,
@@ -162,6 +163,7 @@ const SortableDefaultColumnRow: React.FC<{
               }}
               className={`w-full max-w-[12rem] ${adminInputClass}`}
               placeholder="To Do"
+              maxLength={COLUMN_TITLE_MAX_LENGTH}
             />
           ) : (
             <span className="text-sm font-medium text-slate-900 dark:text-slate-100">
@@ -184,7 +186,8 @@ const SortableDefaultColumnRow: React.FC<{
               }
             }}
             className={`w-full max-w-[12rem] ${adminInputClass}`}
-            placeholder="À faire"
+              placeholder="À faire"
+              maxLength={COLUMN_TITLE_MAX_LENGTH}
           />
         ) : (
           <span className="text-sm font-medium text-slate-900 dark:text-slate-100">

--- a/src/components/admin/AdminPrioritiesTab.tsx
+++ b/src/components/admin/AdminPrioritiesTab.tsx
@@ -8,6 +8,7 @@ import { useSortable } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { useEscapeDismiss } from '../../hooks/useEscapeDismiss';
 import { ADMIN_TABLE_ROW_CLASS } from '../../utils/adminFieldLimits';
+import { PRIORITY_NAME_MAX_LENGTH } from '../../constants/appConstants';
 
 interface Priority {
   id: string;
@@ -510,6 +511,7 @@ const AdminPrioritiesTab: React.FC<AdminPrioritiesTabProps> = ({
                       onChange={(e) => setNewPriority(prev => ({ ...prev, priority: e.target.value }))}
                       className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                       placeholder={t('priorities.enterPriorityName')}
+                      maxLength={PRIORITY_NAME_MAX_LENGTH}
                     />
                   </div>
                   
@@ -566,6 +568,7 @@ const AdminPrioritiesTab: React.FC<AdminPrioritiesTabProps> = ({
                       onChange={(e) => setEditingPriority(prev => prev ? { ...prev, priority: e.target.value } : null)}
                       className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
                       placeholder={t('priorities.enterPriorityName')}
+                      maxLength={PRIORITY_NAME_MAX_LENGTH}
                     />
                   </div>
                   

--- a/src/components/admin/AdminProjectSettingsTab.tsx
+++ b/src/components/admin/AdminProjectSettingsTab.tsx
@@ -22,6 +22,7 @@ import {
   uniqueNewFinishedKeywords,
   type DefaultBoardColumnRow,
 } from '../../utils/defaultBoardColumns';
+import { COLUMN_TITLE_MAX_LENGTH } from '../../constants/appConstants';
 
 interface AdminProjectSettingsTabProps {
   settings: { [key: string]: string | undefined };
@@ -242,6 +243,7 @@ const AdminProjectSettingsTab: React.FC<AdminProjectSettingsTabProps> = ({
               onKeyDown={handleFinishedNameKeyDown}
               placeholder={t('enterColumnName')}
               className={`flex-1 ${adminInputClass}`}
+              maxLength={COLUMN_TITLE_MAX_LENGTH}
             />
             <button
               onClick={addFinishedColumnName}

--- a/src/components/admin/AdminSprintSettingsTab.tsx
+++ b/src/components/admin/AdminSprintSettingsTab.tsx
@@ -7,6 +7,7 @@ import { getSprintUsage, deleteSprint } from '../../api';
 import { ModernCheckbox } from '../ModernCheckbox';
 import { useEscapeDismiss } from '../../hooks/useEscapeDismiss';
 import { ADMIN_TABLE_ROW_CLASS } from '../../utils/adminFieldLimits';
+import { SPRINT_NAME_MAX_LENGTH, SPRINT_DESCRIPTION_MAX_LENGTH } from '../../constants/appConstants';
 
 interface PlanningPeriod {
   id: string;
@@ -416,6 +417,7 @@ const AdminSprintSettingsTab: React.FC = () => {
                 value={formData.name}
                 onChange={(e) => setFormData({ ...formData, name: e.target.value })}
                 placeholder="e.g., Sprint 1, Q1 2025"
+                maxLength={SPRINT_NAME_MAX_LENGTH}
                 className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400"
               />
             </div>
@@ -452,6 +454,7 @@ const AdminSprintSettingsTab: React.FC = () => {
                 value={formData.description}
                 onChange={(e) => setFormData({ ...formData, description: e.target.value })}
                 placeholder={t('sprintSettings.optionalDescription')}
+                maxLength={SPRINT_DESCRIPTION_MAX_LENGTH}
                 rows={2}
                 className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white placeholder-gray-400"
               />

--- a/src/components/admin/AdminTagsTab.tsx
+++ b/src/components/admin/AdminTagsTab.tsx
@@ -4,6 +4,7 @@ import { createPortal } from 'react-dom';
 import { Edit, Trash2 } from 'lucide-react';
 import { useEscapeDismiss } from '../../hooks/useEscapeDismiss';
 import { ADMIN_TABLE_ROW_CLASS } from '../../utils/adminFieldLimits';
+import { TAG_NAME_MAX_LENGTH, TAG_DESCRIPTION_MAX_LENGTH } from '../../constants/appConstants';
 
 interface Tag {
   id: number;
@@ -335,6 +336,7 @@ const AdminTagsTab: React.FC<AdminTagsTabProps> = ({
                     onChange={(e) => setNewTag(prev => ({ ...prev, tag: e.target.value }))}
                     className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                     placeholder={t('tags.enterTagName')}
+                    maxLength={TAG_NAME_MAX_LENGTH}
                     required
                   />
                 </div>
@@ -345,6 +347,7 @@ const AdminTagsTab: React.FC<AdminTagsTabProps> = ({
                     onChange={(e) => setNewTag(prev => ({ ...prev, description: e.target.value }))}
                     className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500"
                     placeholder={t('tags.enterTagDescription')}
+                    maxLength={TAG_DESCRIPTION_MAX_LENGTH}
                     rows={3}
                   />
                 </div>
@@ -397,6 +400,7 @@ const AdminTagsTab: React.FC<AdminTagsTabProps> = ({
                     onChange={(e) => setEditingTag(prev => prev ? { ...prev, tag: e.target.value } : null)}
                     className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
                     placeholder={t('tags.enterTagName')}
+                    maxLength={TAG_NAME_MAX_LENGTH}
                     required
                   />
                 </div>
@@ -407,6 +411,7 @@ const AdminTagsTab: React.FC<AdminTagsTabProps> = ({
                     onChange={(e) => setEditingTag(prev => prev ? { ...prev, description: e.target.value } : null)}
                     className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
                     placeholder={t('tags.enterTagDescription')}
+                    maxLength={TAG_DESCRIPTION_MAX_LENGTH}
                     rows={3}
                   />
                 </div>

--- a/src/constants/appConstants.ts
+++ b/src/constants/appConstants.ts
@@ -11,6 +11,21 @@ export const AGENT_MEMBER_ID = '00000000-0000-0000-0000-000000000011';
 export const AGENT_DEFAULT_NAME = 'Agent';
 export const AGENT_DEFAULT_COLOR = '#0F766E';
 
+/** Keep in sync with server/constants/fieldLimits.js */
+export const TASK_TITLE_MAX_LENGTH = 200;
+export const TASK_DESCRIPTION_MAX_LENGTH = 100_000;
+export const COMMENT_MAX_LENGTH = 10_000;
+export const BOARD_TITLE_MAX_LENGTH = 200;
+export const COLUMN_TITLE_MAX_LENGTH = 200;
+export const COLUMN_POLICY_MAX_LENGTH = 500;
+export const TAG_NAME_MAX_LENGTH = 30;
+export const TAG_DESCRIPTION_MAX_LENGTH = 2000;
+export const BLOCKED_REASON_MAX_LENGTH = 500;
+export const FILTER_NAME_MAX_LENGTH = 100;
+export const SPRINT_NAME_MAX_LENGTH = 30;
+export const SPRINT_DESCRIPTION_MAX_LENGTH = 5000;
+export const PRIORITY_NAME_MAX_LENGTH = 30;
+
 /** task_work.status values for agent automation */
 export const AGENT_WORK_STATUSES = {
   queued: 'queued',

--- a/src/i18n/locales/en/tasks.json
+++ b/src/i18n/locales/en/tasks.json
@@ -388,6 +388,7 @@
     "clickToAdd": "Click to add tags"
   },
   "taskCard": {
+    "newTask": "New Task",
     "directLinkTo": "Direct link to {{ticket}}",
     "editTitle": "Edit title",
     "editDescription": "Edit description",

--- a/src/i18n/locales/fr/tasks.json
+++ b/src/i18n/locales/fr/tasks.json
@@ -388,6 +388,7 @@
     "clickToAdd": "Cliquer pour ajouter"
   },
   "taskCard": {
+    "newTask": "Nouvelle tâche",
     "directLinkTo": "Lien direct vers {{ticket}}",
     "editTitle": "Modifier le titre",
     "editDescription": "Modifier la description",

--- a/src/validation/schemas.ts
+++ b/src/validation/schemas.ts
@@ -1,8 +1,9 @@
 import { z } from 'zod';
+import { TASK_TITLE_MAX_LENGTH } from '../constants/appConstants';
 
 export const TaskSchema = z.object({
   id: z.string().uuid(),
-  title: z.string().min(1, "Title is required").max(200, "Title must be less than 200 characters"),
+  title: z.string().min(1, "Title is required").max(TASK_TITLE_MAX_LENGTH, "Title must be less than 200 characters"),
   description: z.string().max(5000, "Description must be less than 5000 characters"),
   columnId: z.string(),
   memberId: z.string().optional(),


### PR DESCRIPTION
## Summary
- Shared max lengths for titles, descriptions, comments, tags, priorities, sprints, filters, blocked reason, and column policy
- UI `maxLength` / TipTap caps match Zod and automation tools
- Shorter labels (priority/tag/sprint 30) so they stay usable on cards

## Test plan
- [ ] New task title stops at 200
- [ ] Priority and tag create/edit stop at 30
- [ ] Blocked reason 500, column policy 500, filter names 100, sprint names 30
- [ ] Oversized paste in description/comment is rejected in the editor


Made with [Cursor](https://cursor.com)