### PR TITLE
fix: stop Google SSO redirecting to the wrong tenant

### DIFF
--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -427,18 +427,30 @@ function debugLog(settingsObj, ...args) {
 async function getOAuthSettings(db, tenantId) {
   const cached = getCachedOAuthEntry(tenantId);
   if (cached && !cached.invalidated && cached.settings) {
-    console.log('🔄 [GOOGLE SSO] Using cached OAuth settings');
+    console.log(`🔄 [GOOGLE SSO] Using cached OAuth settings (tenant=${tenantId || 'default'})`);
     return cached.settings;
   }
 
   const settingsObj = await authQueries.getOAuthSettings(db);
+  if (
+    tenantId &&
+    settingsObj.GOOGLE_CALLBACK_URL &&
+    !String(settingsObj.GOOGLE_CALLBACK_URL).includes(`${tenantId}.`)
+  ) {
+    console.error(
+      `🔐 [GOOGLE SSO] Loaded callback URL does not match tenant "${tenantId}" (schema=${db?.schema || '?'}): ${settingsObj.GOOGLE_CALLBACK_URL}`
+    );
+  }
   setCachedOAuthSettings(tenantId, settingsObj);
   
   // Always log basic OAuth config status, detailed logs only if debug enabled
   const oauthKeys = ['GOOGLE_CLIENT_ID', 'GOOGLE_CLIENT_SECRET', 'GOOGLE_CALLBACK_URL'];
   console.log(
     '🔄 [GOOGLE SSO] OAuth settings loaded:',
+    `tenant=${tenantId || 'default'}`,
+    `schema=${db?.schema || '?'}`,
     oauthKeys.map((k) => `${k}: ${settingsObj[k] ? '✓' : '✗'}`).join(', '),
+    `callback=${settingsObj.GOOGLE_CALLBACK_URL || 'NOT_SET'}`,
     `[DEBUG: ${isGoogleSsoDebugEnabled(settingsObj) ? 'ON' : 'OFF'}]`
   );
   debugLog(settingsObj, '🔄 [GOOGLE SSO] OAuth settings details:', {

--- a/server/utils/oauthConfigCache.js
+++ b/server/utils/oauthConfigCache.js
@@ -1,5 +1,7 @@
 /** Per-tenant in-memory OAuth settings cache (Google SSO). */
 
+import { getTenantDomain } from './tenantDomain.js';
+
 function tenantKey(tenantId) {
   return tenantId || 'default';
 }
@@ -11,13 +13,49 @@ function cacheMap() {
   return global.oauthConfigCacheByTenant;
 }
 
+/**
+ * True when GOOGLE_CALLBACK_URL (if set) matches this tenant's host.
+ * Rejects cross-tenant cache pollution (wrong redirect_uri after SSO).
+ */
+export function oauthSettingsMatchTenant(tenantId, settings) {
+  if (!tenantId || !settings) return true;
+  const callback = String(settings.GOOGLE_CALLBACK_URL || '').trim();
+  if (!callback) return true;
+  try {
+    const host = new URL(callback).hostname.toLowerCase();
+    const expected = `${String(tenantId).toLowerCase()}.${getTenantDomain().toLowerCase()}`;
+    return host === expected;
+  } catch {
+    return false;
+  }
+}
+
 export function getCachedOAuthEntry(tenantId) {
-  return cacheMap()[tenantKey(tenantId)] || null;
+  const entry = cacheMap()[tenantKey(tenantId)] || null;
+  if (!entry || entry.invalidated || !entry.settings) {
+    return entry;
+  }
+  if (!oauthSettingsMatchTenant(tenantId, entry.settings)) {
+    console.error(
+      `🔐 [GOOGLE SSO] Rejecting cached OAuth settings for tenant "${tenantId}" — callback URL does not match tenant (got ${entry.settings.GOOGLE_CALLBACK_URL})`
+    );
+    entry.invalidated = true;
+    entry.settings = null;
+  }
+  return entry;
 }
 
 export function setCachedOAuthSettings(tenantId, settings) {
+  if (!oauthSettingsMatchTenant(tenantId, settings)) {
+    console.error(
+      `🔐 [GOOGLE SSO] Refusing to cache OAuth settings for tenant "${tenantId}" — callback URL does not match tenant (got ${settings?.GOOGLE_CALLBACK_URL})`
+    );
+    return;
+  }
+  // Clone so later decrypt/mutation cannot cross tenants via shared object refs.
   cacheMap()[tenantKey(tenantId)] = {
-    settings,
+    settings: { ...settings },
+    tenantId: tenantId || null,
     invalidated: false,
     timestamp: Date.now(),
   };
@@ -29,6 +67,7 @@ export function invalidateOAuthConfigCache(tenantId) {
   const key = tenantKey(tenantId);
   if (map[key]) {
     map[key].invalidated = true;
+    map[key].settings = null;
   } else {
     map[key] = { settings: null, invalidated: true, timestamp: Date.now() };
   }

--- a/server/utils/sqlManager/auth.js
+++ b/server/utils/sqlManager/auth.js
@@ -403,9 +403,16 @@ export async function getSetting(db, key) {
  * @returns {Promise<Object>} Settings with GOOGLE_CLIENT_*, SERVER_DEBUG_GOOGLE_SSO (legacy GOOGLE_SSO_DEBUG merged in)
  */
 export async function getOAuthSettings(db) {
+  // Schema-qualify settings: unqualified FROM settings + pooled search_path has
+  // leaked another tenant's GOOGLE_CALLBACK_URL into the OAuth cache (SSO redirect
+  // to the wrong host, e.g. drenlia → qa1).
+  const table =
+    db?.schema && typeof db.schema === 'string' && db.schema !== 'public'
+      ? `"${db.schema.replace(/"/g, '""')}".settings`
+      : 'settings';
   const query = `
     SELECT key, value 
-    FROM settings 
+    FROM ${table}
     WHERE key IN ($1, $2, $3, $4, $5)
   `;
   


### PR DESCRIPTION
Schema-qualify OAuth settings reads and reject cached callback URLs that do not match the request tenant so shared Client IDs cannot leak GOOGLE_CALLBACK_URL across tenants (e.g. drenlia → qa1).