### PR TITLE
Improve related-link UX and bidirectional unlink

### DIFF
--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -3313,6 +3313,11 @@ router.delete('/:taskId/relationships/:relationshipId', authenticateToken, async
       if (inverseRel) {
         await taskQueries.deleteTaskRelationship(db, inverseRel.id);
       }
+    } else if (relationship.relationship === 'related') {
+      const inverseRel = await taskQueries.getTaskRelationship(db, relationship.to_task_id, 'related', relationship.task_id);
+      if (inverseRel) {
+        await taskQueries.deleteTaskRelationship(db, inverseRel.id);
+      }
     }
     
     // MIGRATED: Get the board ID for the source task to publish the update

--- a/server/services/automationTools.js
+++ b/server/services/automationTools.js
@@ -1385,6 +1385,9 @@ async function toolUnlinkTasks(ctx, args, { dryRun }, allowedBoardIds) {
   } else if (relationship === 'child') {
     const inverse = await taskQueries.getTaskRelationship(ctx.db, toTaskId, 'parent', taskId);
     if (inverse) await taskQueries.deleteTaskRelationship(ctx.db, inverse.id);
+  } else if (relationship === 'related') {
+    const inverse = await taskQueries.getTaskRelationship(ctx.db, toTaskId, 'related', taskId);
+    if (inverse) await taskQueries.deleteTaskRelationship(ctx.db, inverse.id);
   }
 
   await journal(ctx, 'unlink_task', 'task_rel', rel.id, before, null);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1807,12 +1807,18 @@ function AppContent() {
   };
 
   // Task linking handlers
-  const handleStartLinking = (task: Task, startPosition: {x: number, y: number}) => {
+  const handleStartLinking = (
+    task: Task,
+    startPosition: { x: number; y: number },
+    options?: { shiftKey?: boolean }
+  ) => {
     if (feDebug('FE_DEBUG_TASK_LINKING')) console.log('🔗 handleStartLinking called:', {
       taskTicket: task.ticket,
       taskId: task.id,
-      startPosition
+      startPosition,
+      shiftKey: options?.shiftKey,
     });
+    taskLinking.setLinkingWantRelated(Boolean(options?.shiftKey));
     taskLinking.setIsLinkingMode(true);
     taskLinking.setLinkingSourceTask(task);
     // For fixed overlay, coordinates should be viewport-relative (clientX/clientY)
@@ -1852,6 +1858,7 @@ function AppContent() {
     taskLinking.setIsLinkingMode(false);
     taskLinking.setLinkingSourceTask(null);
     taskLinking.setLinkingLine(null);
+    taskLinking.setLinkingWantRelated(false);
   };
 
   const handleFinishLinking = async (
@@ -5806,6 +5813,8 @@ function AppContent() {
         linkingLine={taskLinking.linkingLine}
         onUpdateLinkingLine={handleUpdateLinkingLine}
         onCancelLinking={handleCancelLinking}
+        wantRelated={taskLinking.linkingWantRelated}
+        onWantRelatedChange={taskLinking.setLinkingWantRelated}
       />
       </div>
       

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -91,7 +91,11 @@ interface KanbanColumnProps {
   // Task linking props
   isLinkingMode?: boolean;
   linkingSourceTask?: Task | null;
-  onStartLinking?: (task: Task, startPosition: {x: number, y: number}) => void;
+  onStartLinking?: (
+    task: Task,
+    startPosition: { x: number; y: number },
+    options?: { shiftKey?: boolean }
+  ) => void;
   onFinishLinking?: (targetTask: Task | null, relationshipType?: 'parent' | 'child' | 'related') => Promise<void>;
   
   // Hover highlighting props

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -103,7 +103,11 @@ interface TaskCardProps {
   // Task linking props
   isLinkingMode?: boolean;
   linkingSourceTask?: Task | null;
-  onStartLinking?: (task: Task, startPosition: {x: number, y: number}) => void;
+  onStartLinking?: (
+    task: Task,
+    startPosition: { x: number; y: number },
+    options?: { shiftKey?: boolean }
+  ) => void;
   onFinishLinking?: (targetTask: Task | null, relationshipType?: 'parent' | 'child' | 'related') => Promise<void>;
   
   // Hover highlighting props

--- a/src/components/TaskCardToolbar.tsx
+++ b/src/components/TaskCardToolbar.tsx
@@ -47,7 +47,11 @@ interface TaskCardToolbarProps {
   // Task linking props
   isLinkingMode?: boolean;
   linkingSourceTask?: Task | null;
-  onStartLinking?: (task: Task, startPosition: {x: number, y: number}) => void;
+  onStartLinking?: (
+    task: Task,
+    startPosition: { x: number; y: number },
+    options?: { shiftKey?: boolean }
+  ) => void;
   
   // Hover highlighting props
   hoveredLinkTask?: Task | null;
@@ -140,6 +144,7 @@ export default function TaskCardToolbar({
   // State for drag-to-link logic
   const [isDragPrepared, setIsDragPrepared] = useState(false);
   const [dragStartPosition, setDragStartPosition] = useState<{x: number, y: number} | null>(null);
+  const linkGestureHandledRef = useRef(false);
   const dragThreshold = 5; // Minimum pixels to consider it a drag
 
   const handleLinkPointerDown = (e: React.PointerEvent) => {
@@ -150,6 +155,7 @@ export default function TaskCardToolbar({
     // Use the actual mouse position when clicking, not the button center
     // This prevents false drag detection when clicking the button
     const startPos = { x: e.clientX, y: e.clientY };
+    linkGestureHandledRef.current = false;
     
     // Prepare for potential drag, but don't start linking yet
     setIsDragPrepared(true);
@@ -162,12 +168,33 @@ export default function TaskCardToolbar({
     e.stopPropagation();
     
     const startPos = { x: e.clientX, y: e.clientY };
+    linkGestureHandledRef.current = false;
     setIsDragPrepared(true);
     setDragStartPosition(startPos);
   };
   
   // Handle global mouse/pointer move to detect drag while holding down
   useEffect(() => {
+    const beginLinkingDrag = (shiftKey: boolean) => {
+      if (!dragStartPosition || !onStartLinking) return;
+      linkGestureHandledRef.current = true;
+      setIsDragPrepared(false);
+      onStartLinking(task, dragStartPosition, { shiftKey });
+      setDragStartPosition(null);
+    };
+
+    const tryFinishLinkClick = (clientX: number, clientY: number, shiftKey: boolean) => {
+      if (!isDragPrepared || !dragStartPosition || !onStartLinking) return false;
+      const deltaX = Math.abs(clientX - dragStartPosition.x);
+      const deltaY = Math.abs(clientY - dragStartPosition.y);
+      const isClick = deltaX <= dragThreshold && deltaY <= dragThreshold;
+      if (isClick && shiftKey) {
+        beginLinkingDrag(true);
+        return true;
+      }
+      return false;
+    };
+
     const handleGlobalMouseMove = (e: MouseEvent) => {
       if (isDragPrepared && dragStartPosition && onStartLinking) {
         const currentX = e.clientX;
@@ -175,43 +202,37 @@ export default function TaskCardToolbar({
         const deltaX = Math.abs(currentX - dragStartPosition.x);
         const deltaY = Math.abs(currentY - dragStartPosition.y);
         
-        // If moved beyond threshold, start linking mode
+        // If moved beyond threshold, start linking mode (Shift = related)
         if (deltaX > dragThreshold || deltaY > dragThreshold) {
-          setIsDragPrepared(false);
-          onStartLinking(task, dragStartPosition);
-          setDragStartPosition(null);
+          beginLinkingDrag(e.shiftKey);
         }
       }
     };
 
     const handleGlobalPointerMove = (e: PointerEvent) => {
-      // Also handle pointer events for better cross-device support
       if (isDragPrepared && dragStartPosition && onStartLinking) {
         const currentX = e.clientX;
         const currentY = e.clientY;
         const deltaX = Math.abs(currentX - dragStartPosition.x);
         const deltaY = Math.abs(currentY - dragStartPosition.y);
         
-        // If moved beyond threshold, start linking mode
         if (deltaX > dragThreshold || deltaY > dragThreshold) {
-          setIsDragPrepared(false);
-          onStartLinking(task, dragStartPosition);
-          setDragStartPosition(null);
+          beginLinkingDrag(e.shiftKey);
         }
       }
     };
 
-    const handleGlobalMouseUp = (_e: MouseEvent) => {
+    const handleGlobalMouseUp = (e: MouseEvent) => {
+      if (tryFinishLinkClick(e.clientX, e.clientY, e.shiftKey)) return;
       if (isDragPrepared) {
-        // Released without dragging - cancel linking
         setIsDragPrepared(false);
         setDragStartPosition(null);
       }
     };
 
-    const handleGlobalPointerUp = (_e: PointerEvent) => {
+    const handleGlobalPointerUp = (e: PointerEvent) => {
+      if (tryFinishLinkClick(e.clientX, e.clientY, e.shiftKey)) return;
       if (isDragPrepared) {
-        // Released without dragging - cancel linking
         setIsDragPrepared(false);
         setDragStartPosition(null);
       }
@@ -406,19 +427,31 @@ export default function TaskCardToolbar({
       >
         <button
           data-no-dnd="true"
+          data-kanban-mod-allow="shift link"
           disabled={agentBlocking}
           onPointerDown={(e) => {
             if (agentBlocking) return;
+            e.stopPropagation();
             handleLinkPointerDown(e);
           }}
           onMouseDown={(e) => {
             if (agentBlocking) return;
+            e.stopPropagation();
             handleLinkMouseDown(e);
           }}
           onClick={(e) => {
             e.preventDefault();
             e.stopPropagation();
-            // Unlink is handled on pointerdown to avoid a second DELETE after success
+            if (
+              !agentBlocking &&
+              e.shiftKey &&
+              onStartLinking &&
+              !isLinkingMode &&
+              !linkGestureHandledRef.current
+            ) {
+              linkGestureHandledRef.current = true;
+              onStartLinking(task, { x: e.clientX, y: e.clientY }, { shiftKey: true });
+            }
           }}
           onMouseEnter={(e) => {
             if (agentBlocking) return;

--- a/src/components/TaskLinkingOverlay.tsx
+++ b/src/components/TaskLinkingOverlay.tsx
@@ -8,6 +8,8 @@ interface TaskLinkingOverlayProps {
   linkingLine: { startX: number; startY: number; endX: number; endY: number } | null;
   onUpdateLinkingLine: (endPosition: { x: number; y: number }) => void;
   onCancelLinking: () => void;
+  wantRelated?: boolean;
+  onWantRelatedChange?: (wantRelated: boolean) => void;
 }
 
 const TaskLinkingOverlay: React.FC<TaskLinkingOverlayProps> = ({
@@ -16,6 +18,8 @@ const TaskLinkingOverlay: React.FC<TaskLinkingOverlayProps> = ({
   linkingLine,
   onUpdateLinkingLine,
   onCancelLinking,
+  wantRelated = false,
+  onWantRelatedChange,
 }) => {
   const { t } = useTranslation('tasks');
   const overlayRef = useRef<HTMLDivElement>(null);
@@ -24,6 +28,17 @@ const TaskLinkingOverlay: React.FC<TaskLinkingOverlayProps> = ({
   const edgeScrollZone = 50;
   const scrollSpeed = 10;
   const [shiftHeld, setShiftHeld] = useState(false);
+
+  useEffect(() => {
+    if (isLinkingMode) {
+      setShiftHeld(wantRelated);
+    }
+  }, [isLinkingMode, linkingSourceTask?.id, wantRelated]);
+
+  const updateWantRelated = (next: boolean) => {
+    setShiftHeld(next);
+    onWantRelatedChange?.(next);
+  };
 
   const findScrollableContainer = (): HTMLElement | null => {
     return document.querySelector('.kanban-scrollable-container') as HTMLElement | null;
@@ -87,7 +102,6 @@ const TaskLinkingOverlay: React.FC<TaskLinkingOverlayProps> = ({
 
   useEffect(() => {
     if (!isLinkingMode || !linkingLine) {
-      setShiftHeld(false);
       return;
     }
 
@@ -110,7 +124,7 @@ const TaskLinkingOverlay: React.FC<TaskLinkingOverlayProps> = ({
     };
 
     const handlePointerMove = (event: PointerEvent) => {
-      setShiftHeld(event.shiftKey);
+      updateWantRelated(event.shiftKey);
       updateLineFromClientPoint(event.clientX, event.clientY);
     };
 
@@ -128,13 +142,13 @@ const TaskLinkingOverlay: React.FC<TaskLinkingOverlayProps> = ({
         return;
       }
       if (event.key === 'Shift') {
-        setShiftHeld(true);
+        updateWantRelated(true);
       }
     };
 
     const handleKeyUp = (event: KeyboardEvent) => {
       if (event.key === 'Shift') {
-        setShiftHeld(false);
+        updateWantRelated(false);
       }
     };
 
@@ -156,7 +170,7 @@ const TaskLinkingOverlay: React.FC<TaskLinkingOverlayProps> = ({
 
       currentMousePositionRef.current = null;
     };
-  }, [isLinkingMode, linkingLine, onUpdateLinkingLine, onCancelLinking]);
+  }, [isLinkingMode, linkingLine, onUpdateLinkingLine, onCancelLinking, onWantRelatedChange]);
 
   if (!isLinkingMode || !linkingLine || !linkingSourceTask) {
     return null;

--- a/src/components/layout/KanbanPage.tsx
+++ b/src/components/layout/KanbanPage.tsx
@@ -180,7 +180,11 @@ interface KanbanPageProps {
   isLinkingMode?: boolean;
   linkingSourceTask?: Task | null;
   linkingLine?: {startX: number, startY: number, endX: number, endY: number} | null;
-  onStartLinking?: (task: Task, startPosition: {x: number, y: number}) => void;
+  onStartLinking?: (
+    task: Task,
+    startPosition: { x: number; y: number },
+    options?: { shiftKey?: boolean }
+  ) => void;
   onUpdateLinkingLine?: (endPosition: {x: number, y: number}) => void;
   onFinishLinking?: (targetTask: Task | null, relationshipType?: 'parent' | 'child' | 'related') => Promise<void>;
   onCancelLinking?: () => void;

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -154,7 +154,11 @@ interface MainLayoutProps {
   isLinkingMode?: boolean;
   linkingSourceTask?: Task | null;
   linkingLine?: {startX: number, startY: number, endX: number, endY: number} | null;
-  onStartLinking?: (task: Task, startPosition: {x: number, y: number}) => void;
+  onStartLinking?: (
+    task: Task,
+    startPosition: { x: number; y: number },
+    options?: { shiftKey?: boolean }
+  ) => void;
   onUpdateLinkingLine?: (endPosition: {x: number, y: number}) => void;
   onFinishLinking?: (targetTask: Task | null, relationshipType?: 'parent' | 'child' | 'related') => Promise<void>;
   onCancelLinking?: () => void;

--- a/src/hooks/useKanbanModifierKeys.ts
+++ b/src/hooks/useKanbanModifierKeys.ts
@@ -16,7 +16,7 @@ function applyKanbanModifierClasses(ctrl: boolean, shift: boolean): void {
 /**
  * While Ctrl/Cmd or Shift is held (and the user is not typing), mark <body>
  * so card chrome buttons cannot steal the click. Ctrl = multi-select;
- * Shift = range-select (delete remains clickable via data-kanban-mod-allow).
+ * Shift = range-select (delete + link reserve Shift via data-kanban-mod-allow).
  */
 export function useKanbanModifierKeys(): void {
   useEffect(() => {

--- a/src/hooks/useTaskLinking.ts
+++ b/src/hooks/useTaskLinking.ts
@@ -13,6 +13,9 @@ export interface UseTaskLinkingReturn {
   setLinkingSourceTask: (task: Task | null) => void;
   linkingLine: { startX: number; startY: number; endX: number; endY: number } | null;
   setLinkingLine: (line: { startX: number; startY: number; endX: number; endY: number } | null) => void;
+  /** True while linking if Shift selects a related link (live during drag). */
+  linkingWantRelated: boolean;
+  setLinkingWantRelated: (wantRelated: boolean) => void;
 
   // Hover highlighting
   hoveredLinkTask: Task | null;
@@ -34,6 +37,7 @@ export const useTaskLinking = (): UseTaskLinkingReturn => {
     endX: number;
     endY: number;
   } | null>(null);
+  const [linkingWantRelated, setLinkingWantRelated] = useState(false);
 
   const [hoveredLinkTask, setHoveredLinkTask] = useState<Task | null>(null);
   const [taskRelationships, setTaskRelationships] = useState<{ [taskId: string]: any[] }>({});
@@ -46,6 +50,8 @@ export const useTaskLinking = (): UseTaskLinkingReturn => {
     setLinkingSourceTask,
     linkingLine,
     setLinkingLine,
+    linkingWantRelated,
+    setLinkingWantRelated,
     hoveredLinkTask,
     setHoveredLinkTask,
     taskRelationships,

--- a/src/index.css
+++ b/src/index.css
@@ -565,7 +565,7 @@ body {
 
 /*
  * Ctrl/Cmd = card multi-select, Shift = range select. Disable card chrome so
- * archive/copy/link cannot steal the click. Delete stays clickable on Shift.
+ * archive/copy cannot steal the click. Delete and link stay clickable on Shift.
  */
 body.kanban-mod-ctrl .task-card button:not([data-kanban-mod-allow~="ctrl"]),
 body.kanban-mod-ctrl .task-card a {


### PR DESCRIPTION
## Summary
- Deleting a related link removes both directed rows so neither card keeps a stale relationship.
- Shift+click or shift-drag from the link icon starts related linking mode immediately; releasing Shift while dragging reverts to parent→child.
- Link button reserves Shift+click from card range-select via `data-kanban-mod-allow`.

## Test plan
- [ ] Create related link between two tasks, unlink from either card — both cards lose the link badge
- [ ] Shift+click link icon — yellow related mode starts without range-selecting the card
- [ ] Shift+drag from link icon — related mode; release Shift mid-drag — blue parent mode
- [ ] Shift+click card body (not link icon) — still range-selects as before


Made with [Cursor](https://cursor.com)