### PR TITLE
Fix trash restore sync and Kanban scroll UX

### DIFF
--- a/server/config/helpUiIndex.generated.json
+++ b/server/config/helpUiIndex.generated.json
@@ -1588,8 +1588,8 @@
       "value": "board-trash-bulk-purge-confirm",
       "en": "Permanently delete all {{count}} task(s) in trash? This cannot be undone.",
       "fr": "Supprimer définitivement les {{count}} tâche(s) de la corbeille ? Cette action est irréversible.",
-      "searchEn": "Permanently delete all {{count}} task(s) in trash? This cannot be undone. Permanently delete all {{count}} task(s) in trash? This cannot be undone. Permanently delete {{count}} selected task(s)? This cannot be undone. Cancel Empty trash Delete selected trash deleted board-trash-bulk-purge-confirm",
-      "searchFr": "Supprimer définitivement les {{count}} tâche(s) de la corbeille ? Cette action est irréversible. Supprimer définitivement les {{count}} tâche(s) de la corbeille ? Cette action est irréversible. Supprimer définitivement {{count}} tâche(s) sélectionnée(s) ? Cette action est irréversible. Annuler Vider la corbeille Supprimer la sélection corbeille supprimees supprimes board-trash-bulk-purge-confirm",
+      "searchEn": "Permanently delete all {{count}} task(s) in trash? This cannot be undone. Permanently delete all {{count}} task(s) in trash? This cannot be undone. Permanently delete {{count}} selected task(s)? This cannot be undone. Cancel Empty trash Delete selected Loading trash… trash deleted board-trash-bulk-purge-confirm",
+      "searchFr": "Supprimer définitivement les {{count}} tâche(s) de la corbeille ? Cette action est irréversible. Supprimer définitivement les {{count}} tâche(s) de la corbeille ? Cette action est irréversible. Supprimer définitivement {{count}} tâche(s) sélectionnée(s) ? Cette action est irréversible. Annuler Vider la corbeille Supprimer la sélection Chargement de la corbeille… corbeille supprimees supprimes board-trash-bulk-purge-confirm",
       "kind": "view",
       "mode": "kanban",
       "highlights": [
@@ -1707,8 +1707,8 @@
       "value": "board-trash-view",
       "en": "Trash",
       "fr": "Corbeille",
-      "searchEn": "Trash Trash trash deleted board-trash-view",
-      "searchFr": "Corbeille Corbeille corbeille supprimees supprimes board-trash-view",
+      "searchEn": "Trash Trash Trash is empty Soft-deleted tasks from this board appear here. trash deleted board-trash-view",
+      "searchFr": "Corbeille Corbeille La corbeille est vide Les tâches en suppression récupérable de ce tableau apparaissent ici. corbeille supprimees supprimes board-trash-view",
       "kind": "view",
       "mode": "kanban",
       "highlights": [
@@ -1843,8 +1843,8 @@
       "value": "kanban-columns",
       "en": "This is your Kanban board! Tasks are organized in columns. You can drag and drop tasks between columns to update their status.",
       "fr": "C'est votre tableau Kanban ! Les tâches sont organisées en colonnes. Vous pouvez faire glisser et déposer les tâches entre les colonnes pour mettre à jour leur statut.",
-      "searchEn": "This is your Kanban board! Tasks are organized in columns. You can drag and drop tasks between columns to update their status. Click or hold to scroll right kanban-columns",
-      "searchFr": "C'est votre tableau Kanban ! Les tâches sont organisées en colonnes. Vous pouvez faire glisser et déposer les tâches entre les colonnes pour mettre à jour leur statut. Cliquer ou maintenir pour défiler vers la droite kanban-columns",
+      "searchEn": "This is your Kanban board! Tasks are organized in columns. You can drag and drop tasks between columns to update their status. Back to top kanban-columns",
+      "searchFr": "C'est votre tableau Kanban ! Les tâches sont organisées en colonnes. Vous pouvez faire glisser et déposer les tâches entre les colonnes pour mettre à jour leur statut. Retour en haut kanban-columns",
       "kind": "view",
       "mode": "kanban",
       "highlights": [

--- a/server/routes/adminLifecycle.js
+++ b/server/routes/adminLifecycle.js
@@ -143,7 +143,7 @@ router.post('/tasks/restore-batch', async (req, res) => {
               boardId,
               updates: shifted.map((row) => ({
                 taskId: row.id,
-                position: row.position,
+                position: typeof row.position === 'number' ? row.position : parseFloat(row.position) || 0,
                 columnId: row.columnId || columnId,
               })),
               timestamp: new Date().toISOString(),

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -2070,6 +2070,9 @@ router.post('/:id/restore', authenticateToken, async (req, res) => {
     restored.boardId = boardId;
 
     const tenantId = getTenantId(req);
+
+    // Only publish shifted siblings (usually small). Full-column snapshots blow past
+    // PostgreSQL NOTIFY's 8KB limit on large boards and the event becomes a useless stub.
     if (shifted.length > 0) {
       await notificationService.publish(
         'tasks-positions-updated',
@@ -2077,7 +2080,7 @@ router.post('/:id/restore', authenticateToken, async (req, res) => {
           boardId,
           updates: shifted.map((row) => ({
             taskId: row.id,
-            position: row.position,
+            position: typeof row.position === 'number' ? row.position : parseFloat(row.position) || 0,
             columnId: row.columnId || columnId,
           })),
           timestamp: new Date().toISOString(),
@@ -2115,6 +2118,7 @@ router.post('/:id/restore', authenticateToken, async (req, res) => {
       console.error('Background activity logging failed:', error);
     });
 
+    // Keep NOTIFY lean: no positionUpdates array (8KB limit). Peers bump locally / apply shifted WS.
     await notificationService.publish(
       'task-restored',
       {

--- a/server/services/automationTools.js
+++ b/server/services/automationTools.js
@@ -931,7 +931,14 @@ async function toolRestoreTasks(ctx, args, { dryRun }, allowedBoardIds) {
       'task-restored',
       {
         boardId: item.boardId,
-        task: restored,
+        task: {
+          ...restored,
+          position,
+          columnId: item.columnId,
+          boardId: item.boardId,
+          deletedAt: null,
+          deletedBy: null,
+        },
         timestamp: new Date().toISOString()
       },
       ctx.tenantId || null

--- a/server/services/postgresNotificationService.js
+++ b/server/services/postgresNotificationService.js
@@ -235,11 +235,14 @@ class PostgresNotificationService {
             message: 'Activity feed updated - fetch latest from API'
           });
         } else if (
-          (channel === 'task-updated' || channel === 'task-created') &&
+          (channel === 'task-updated' ||
+            channel === 'task-created' ||
+            channel === 'task-restored') &&
           data.task?.id &&
           data.boardId
         ) {
           // Keep enough for the Kanban merge; drop bulky nested arrays / description
+          // (and never re-attach large positionUpdates — NOTIFY is 8KB max)
           console.warn(
             `⚠️ Payload too large (${payloadSize} bytes) for ${channel}, sending compact task notification`
           );
@@ -252,8 +255,11 @@ class PostgresNotificationService {
               boardId: data.task.boardId || data.boardId,
               columnId: data.task.columnId || data.task.columnid,
               memberId: data.task.memberId ?? data.task.memberid ?? null,
+              requesterId: data.task.requesterId ?? data.task.requesterid ?? null,
               ticket: data.task.ticket ?? null,
               position: data.task.position ?? 0,
+              deletedAt: null,
+              deletedBy: null,
               ...(data.task.previousColumnId
                 ? { previousColumnId: data.task.previousColumnId }
                 : {}),
@@ -261,6 +267,23 @@ class PostgresNotificationService {
                 ? { previousBoardId: data.task.previousBoardId }
                 : {})
             },
+            timestamp: data.timestamp || new Date().toISOString(),
+            truncated: true
+          });
+        } else if (
+          channel === 'tasks-positions-updated' &&
+          data.boardId &&
+          Array.isArray(data.updates)
+        ) {
+          // Large columns: ask clients to refresh rather than dropping the event
+          console.warn(
+            `⚠️ Payload too large (${payloadSize} bytes) for ${channel}, sending refresh hint`
+          );
+          payload = JSON.stringify({
+            ...shrinkMeta,
+            boardId: data.boardId,
+            columnId: data.updates[0]?.columnId || data.columnId || null,
+            refresh: true,
             timestamp: data.timestamp || new Date().toISOString(),
             truncated: true
           });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -64,6 +64,7 @@ import { useTaskDeleteConfirmation } from './hooks/useTaskDeleteConfirmation';
 import api, { getMembers, getBoards, deleteTask, updateTask, reorderTasks, reorderColumns, reorderBoards, updateColumn, updateBoard, createTaskAtTop, createTask, copyTask, createColumn, createBoard, deleteColumn, deleteBoard, getBoardTrashCount, purgeBoard, getUserSettings, createUser, getUserStatus, getActivityFeed, updateSavedFilterView, getCurrentUser, updateAppUrl, restoreTask, purgeTask, getTaskById } from './api';
 import { toast, ToastContainer } from './utils/toast';
 import { getWipStatus, hasWipLimit, getBoardWipTaskCount, getBoardWipTasks, isBoardWipActiveColumn } from './utils/kanbanFlowUtils';
+import { scrollKanbanPageToTopFastSmooth } from './utils/kanbanScroll';
 import { applyActiveColumnFilters } from './utils/columnFilters';
 import { closeBoardTrashView } from './utils/boardTrashEvents';
 import {
@@ -305,37 +306,42 @@ function AppContent() {
       Object.keys(updatedColumns).forEach(columnId => {
         const column = updatedColumns[columnId];
         if (column) {
-          const remainingTasks = column.tasks.filter(task => task.id !== taskId);
-          const renumberedTasks = remainingTasks
-            .sort((a, b) => (a.position || 0) - (b.position || 0))
-            .map((task, index) => ({
-              ...task,
-              position: index
-            }));
+          // Keep position gaps (matches server soft-delete) so restore can reclaim its slot
           updatedColumns[columnId] = {
             ...column,
-            tasks: renumberedTasks
+            tasks: column.tasks.filter(task => task.id !== taskId)
           };
         }
       });
       return updatedColumns;
     });
 
+    setBoards(prevBoards =>
+      prevBoards.map(board => {
+        if (!board.columns) return board;
+        let changed = false;
+        const nextColumns = { ...board.columns };
+        Object.keys(nextColumns).forEach(columnId => {
+          const column = nextColumns[columnId];
+          if (!column?.tasks?.some(task => task.id === taskId)) return;
+          changed = true;
+          nextColumns[columnId] = {
+            ...column,
+            tasks: column.tasks.filter(task => task.id !== taskId)
+          };
+        });
+        return changed ? { ...board, columns: nextColumns } : board;
+      })
+    );
+
     taskFilters.setFilteredColumns(prevFilteredColumns => {
       const updatedFilteredColumns = { ...prevFilteredColumns };
       Object.keys(updatedFilteredColumns).forEach(columnId => {
         const column = updatedFilteredColumns[columnId];
         if (column) {
-          const remainingTasks = column.tasks.filter(task => task.id !== taskId);
-          const renumberedTasks = remainingTasks
-            .sort((a, b) => (a.position || 0) - (b.position || 0))
-            .map((task, index) => ({
-              ...task,
-              position: index
-            }));
           updatedFilteredColumns[columnId] = {
             ...column,
-            tasks: renumberedTasks
+            tasks: column.tasks.filter(task => task.id !== taskId)
           };
         }
       });
@@ -347,40 +353,68 @@ function AppContent() {
     taskId: string,
     options?: { skipEmail?: boolean }
   ) => {
-    try {
-      recentlyDeletedTasksRef.current.add(taskId);
-      setTimeout(() => {
-        recentlyDeletedTasksRef.current.delete(taskId);
-      }, 10000);
+    recentlyDeletedTasksRef.current.add(taskId);
+    setTimeout(() => {
+      recentlyDeletedTasksRef.current.delete(taskId);
+    }, 10000);
 
-      let boardIdForTrash = selectedBoardRef.current;
-      for (const column of Object.values(columns)) {
-        const found = column?.tasks?.find((task) => task.id === taskId);
-        if (found) {
-          boardIdForTrash = found.boardId || boardIdForTrash;
-          break;
-        }
+    let boardIdForTrash = selectedBoardRef.current;
+    for (const column of Object.values(columnsRef.current || columns)) {
+      const found = column?.tasks?.find((task) => task.id === taskId);
+      if (found) {
+        boardIdForTrash = found.boardId || boardIdForTrash;
+        break;
       }
+    }
 
+    // Optimistic: remove from UI immediately (don't wait on DELETE round-trip)
+    removeTaskFromLocalColumns(taskId);
+    if (selectedTask?.id === taskId) {
+      handleSelectTask(null);
+    }
+
+    try {
       await deleteTask(taskId, options);
-      removeTaskFromLocalColumns(taskId);
       notifyBoardTrashChanged(boardIdForTrash);
     } catch (error) {
+      recentlyDeletedTasksRef.current.delete(taskId);
+      const refresh = refreshBoardDataRef.current;
+      if (refresh) {
+        await refresh({ force: true, forBoardId: boardIdForTrash || undefined }).catch(() => {});
+      }
       throw error;
     }
   };
 
   /** Admin hard-delete (Shift+click) — bypasses trash. */
   const handleTaskPermanentDelete = async (taskId: string) => {
-    try {
-      recentlyDeletedTasksRef.current.add(taskId);
-      setTimeout(() => {
-        recentlyDeletedTasksRef.current.delete(taskId);
-      }, 10000);
+    recentlyDeletedTasksRef.current.add(taskId);
+    setTimeout(() => {
+      recentlyDeletedTasksRef.current.delete(taskId);
+    }, 10000);
 
+    let boardIdForRefresh = selectedBoardRef.current;
+    for (const column of Object.values(columnsRef.current || columns)) {
+      const found = column?.tasks?.find((task) => task.id === taskId);
+      if (found) {
+        boardIdForRefresh = found.boardId || boardIdForRefresh;
+        break;
+      }
+    }
+
+    removeTaskFromLocalColumns(taskId);
+    if (selectedTask?.id === taskId) {
+      handleSelectTask(null);
+    }
+
+    try {
       await purgeTask(taskId);
-      removeTaskFromLocalColumns(taskId);
     } catch (error: any) {
+      recentlyDeletedTasksRef.current.delete(taskId);
+      const refresh = refreshBoardDataRef.current;
+      if (refresh) {
+        await refresh({ force: true, forBoardId: boardIdForRefresh || undefined }).catch(() => {});
+      }
       toast.error(error?.response?.data?.error || t('trash.purgeFailed'));
       throw error;
     }
@@ -459,6 +493,17 @@ function AppContent() {
   const [taskCreationPause, setTaskCreationPause] = useState(false);
   const [boardCreationPause, setBoardCreationPause] = useState(false);
   const [animateCopiedTaskId, setAnimateCopiedTaskId] = useState<string | null>(null);
+  const [highlightedNewTaskId, setHighlightedNewTaskId] = useState<string | null>(null);
+  const highlightedNewTaskTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (highlightedNewTaskTimerRef.current) {
+        clearTimeout(highlightedNewTaskTimerRef.current);
+      }
+    };
+  }, []);
+
   const [pendingCopyAnimation, setPendingCopyAnimation] = useState<{
     title: string;
     columnId: string;
@@ -3204,6 +3249,11 @@ function AppContent() {
       return false;
     }
 
+    // New tasks land at the top of the column — scroll there so the card is visible.
+    if (taskFilters.viewModeRef.current === 'kanban') {
+      await scrollKanbanPageToTopFastSmooth();
+    }
+
     const targetColumnForWip = columnsRef.current[columnId] || columns[columnId];
     if (targetColumnForWip && isBoardWipActiveColumn(targetColumnForWip)) {
       const currentBoard = boards.find((b) => b.id === selectedBoard);
@@ -3278,6 +3328,16 @@ function AppContent() {
         }
       };
     });
+
+    // Brief highlight so the new card is easy to spot after scroll-to-top
+    if (highlightedNewTaskTimerRef.current) {
+      clearTimeout(highlightedNewTaskTimerRef.current);
+    }
+    setHighlightedNewTaskId(newTask.id);
+    highlightedNewTaskTimerRef.current = setTimeout(() => {
+      setHighlightedNewTaskId((current) => (current === newTask.id ? null : current));
+      highlightedNewTaskTimerRef.current = null;
+    }, 1000);
     
     // ALSO update boards state for tab counters
     setBoards(prev => {
@@ -5600,6 +5660,7 @@ function AppContent() {
                                     onMoveTaskToColumn={handleMoveTaskToColumn}
                                     onGanttReorderTask={handleGanttReorderTask}
                                     animateCopiedTaskId={animateCopiedTaskId}
+                                    highlightedNewTaskId={highlightedNewTaskId}
                                     onEditColumn={handleEditColumn}
                                     onRemoveColumn={handleRemoveColumn}
                                     onAddColumn={handleAddColumn}

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -120,6 +120,9 @@ interface KanbanColumnProps {
   /** When true, task count pill uses the blue “filtered” style (same as board tabs). */
   hasActiveFilters?: boolean;
 
+  /** Task id briefly highlighted after create-at-top. */
+  highlightedNewTaskId?: string | null;
+
   /** Multi-check set for this board. */
   checkedTaskIds?: Set<string>;
   onToggleTaskChecked?: (taskId: string, options?: ToggleTaskCheckedOptions) => void;
@@ -219,6 +222,7 @@ function KanbanColumn({
   selectedSprintId = null,
   availableSprints,
   hasActiveFilters = false,
+  highlightedNewTaskId = null,
   checkedTaskIds,
   onToggleTaskChecked,
   onClearAllChecked,
@@ -1061,6 +1065,7 @@ function KanbanColumn({
             selectedSprintId={selectedSprintId}
             availableSprints={availableSprints}
             isChecked={!!checkedTaskIds?.has(task.id)}
+            isNewlyCreatedHighlight={highlightedNewTaskId === task.id}
             onToggleChecked={
               canMutate && onToggleTaskChecked
                 ? (options) =>
@@ -1322,7 +1327,11 @@ function KanbanColumn({
             )
           )}
           {isEditing ? (
-            <form onSubmit={handleTitleSubmit} className="flex-1 space-y-3" onClick={(e) => e.stopPropagation()}>
+            <form
+              onSubmit={handleTitleSubmit}
+              className="flex-1 min-w-0 space-y-3 rounded-lg border border-gray-200 bg-white p-2.5 shadow-xl dark:border-gray-600 dark:bg-gray-800"
+              onClick={(e) => e.stopPropagation()}
+            >
               <input
                 ref={editInputRef}
                 type="text"
@@ -1402,48 +1411,50 @@ function KanbanColumn({
                 </label>
               </div>
 
-              {/* Soft WIP limit — label + field + clear on one line */}
+              {/* Soft WIP limit — label wraps; input + clear stay together */}
               {!isFinished && !isArchived && (
                 <div className="bg-gray-50 dark:bg-gray-800 p-3 rounded-lg border dark:border-gray-600">
-                  <div className="flex items-center gap-2">
+                  <div className="flex flex-wrap items-center gap-2">
                     <label
                       htmlFor={`column-wip-${column.id}`}
-                      className="text-sm font-medium text-gray-700 dark:text-gray-200 shrink-0 inline-flex items-center gap-1"
+                      className="text-sm font-medium text-gray-700 dark:text-gray-200 min-w-0 basis-[min(100%,11rem)] grow inline-flex items-center gap-1"
                     >
-                      {t('column.wipLimit')}
+                      <span className="min-w-0 break-words">{t('column.wipLimit')}</span>
                       <KanbanChromeTooltip label={t('column.wipLimitHint')}>
                         <span
-                          className="inline-flex text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 cursor-help"
+                          className="inline-flex shrink-0 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 cursor-help"
                           aria-label={t('column.wipLimitHint')}
                         >
                           <HelpCircle size={14} />
                         </span>
                       </KanbanChromeTooltip>
                     </label>
-                    <input
-                      id={`column-wip-${column.id}`}
-                      type="number"
-                      inputMode="numeric"
-                      min={1}
-                      step={1}
-                      value={wipLimitInput}
-                      onChange={(e) => setWipLimitInput(e.target.value)}
-                      className="w-[2.75rem] shrink-0 px-1.5 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm text-center [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
-                      disabled={isSubmitting}
-                    />
-                    {!!String(wipLimitInput).trim() && (
-                      <KanbanChromeTooltip label={t('column.clearWipLimit')}>
-                        <button
-                          type="button"
-                          onClick={() => setWipLimitInput('')}
-                          disabled={isSubmitting}
-                          className="p-1 rounded text-gray-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
-                          aria-label={t('column.clearWipLimit')}
-                        >
-                          <Trash2 size={14} />
-                        </button>
-                      </KanbanChromeTooltip>
-                    )}
+                    <div className="flex shrink-0 items-center gap-1">
+                      <input
+                        id={`column-wip-${column.id}`}
+                        type="number"
+                        inputMode="numeric"
+                        min={1}
+                        step={1}
+                        value={wipLimitInput}
+                        onChange={(e) => setWipLimitInput(e.target.value)}
+                        className="w-[2.75rem] shrink-0 px-1.5 py-1.5 border border-gray-300 dark:border-gray-600 rounded-md bg-white dark:bg-gray-700 text-gray-900 dark:text-gray-100 text-sm text-center [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+                        disabled={isSubmitting}
+                      />
+                      {!!String(wipLimitInput).trim() && (
+                        <KanbanChromeTooltip label={t('column.clearWipLimit')}>
+                          <button
+                            type="button"
+                            onClick={() => setWipLimitInput('')}
+                            disabled={isSubmitting}
+                            className="p-1 rounded text-gray-400 hover:text-red-600 dark:hover:text-red-400 hover:bg-gray-200 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
+                            aria-label={t('column.clearWipLimit')}
+                          >
+                            <Trash2 size={14} />
+                          </button>
+                        </KanbanChromeTooltip>
+                      )}
+                    </div>
                   </div>
                 </div>
               )}

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -128,6 +128,8 @@ interface TaskCardProps {
   onToggleChecked?: (options?: { range?: boolean }) => void;
   /** True when multi-check spans multiple columns — disables this card’s DnD. */
   isMultiSelectDragLocked?: boolean;
+  /** Brief highlight after create-at-top (kanban). */
+  isNewlyCreatedHighlight?: boolean;
   /** false for viewer — hide toolbar, pencil, multi-select, inline editors */
   canMutate?: boolean;
 }
@@ -179,6 +181,7 @@ const TaskCard = React.memo(function TaskCard({
   isChecked = false,
   onToggleChecked,
   isMultiSelectDragLocked = false,
+  isNewlyCreatedHighlight = false,
   canMutate = true,
 }: TaskCardProps) {
   const { t } = useTranslation('tasks');
@@ -1591,6 +1594,10 @@ const TaskCard = React.memo(function TaskCard({
             }
             return '';
           })() : ''
+        } ${
+          isNewlyCreatedHighlight && !isSelected
+            ? 'ring-2 ring-sky-400 bg-sky-50 dark:bg-sky-900/50 shadow-md transition-shadow duration-300'
+            : 'transition-shadow duration-300'
         }`}
         {...attributes}
         {...listeners}

--- a/src/components/TeamMembers.tsx
+++ b/src/components/TeamMembers.tsx
@@ -703,6 +703,13 @@ export default function TeamMembers({
     () => loadUserPreferences(currentUserId ?? null).memberDisplayOrder || []
   );
 
+  // Hide System chip when unused; clear sticky filter so it cannot stay on invisibly
+  useEffect(() => {
+    if (systemTaskCount === 0 && includeSystem && onToggleSystem) {
+      onToggleSystem(false);
+    }
+  }, [systemTaskCount, includeSystem, onToggleSystem]);
+
   useEffect(() => {
     let cancelled = false;
     loadUserPreferencesAsync(currentUserId ?? null).then((prefs) => {
@@ -894,18 +901,19 @@ export default function TeamMembers({
                 </button>
               </KanbanChromeTooltip>
 
-              {onToggleSystem && currentUser?.roles?.includes('admin') && (
+              {onToggleSystem &&
+                currentUser?.roles?.includes('admin') &&
+                systemTaskCount > 0 && (
                 <KanbanChromeTooltip label={t('teamMembers.systemTooltip')}>
                   <button
+                    type="button"
                     onClick={() => onToggleSystem(!includeSystem)}
                     className={roleChipClass(includeSystem)}
                   >
                     <span>{t('teamMembers.system')}</span>
-                    {systemTaskCount > 0 && (
-                      <span className="ml-0.5 px-1.5 py-0.5 bg-blue-200 dark:bg-blue-800 text-blue-800 dark:text-blue-200 rounded-full text-xs font-semibold">
-                        {systemTaskCount}
-                      </span>
-                    )}
+                    <span className="ml-0.5 px-1.5 py-0.5 bg-blue-200 dark:bg-blue-800 text-blue-800 dark:text-blue-200 rounded-full text-xs font-semibold">
+                      {systemTaskCount}
+                    </span>
                   </button>
                 </KanbanChromeTooltip>
               )}

--- a/src/components/layout/KanbanPage.tsx
+++ b/src/components/layout/KanbanPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback, Suspense } from 'react';
 import { DndContext, DragOverlay, useDroppable } from '@dnd-kit/core';
 import { SortableContext, rectSortingStrategy } from '@dnd-kit/sortable';
-import { ChevronLeft, ChevronRight, Calendar, ChevronDown } from 'lucide-react';
+import { ChevronLeft, ChevronRight, ChevronUp, Calendar, ChevronDown } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useKanbanModifierKeys } from '../../hooks/useKanbanModifierKeys';
 import { useAppHeaderStickyTop } from '../../hooks/useAppHeaderStickyTop';
@@ -56,6 +56,7 @@ import {
 } from '../../utils/boardTrashEvents';
 import { getTaskSprintId, taskMatchesSelectedSprint } from '../../utils/columnFilters';
 import { isArchivedColumnFlag } from '../../utils/columnUtils';
+import { isKanbanPageScrolledDown, scrollKanbanPageToTopFastSmooth } from '../../utils/kanbanScroll';
 import { onHelpReveal, takeHelpReveal } from '../../utils/helpGoThere';
 
 import { lazyWithRetry } from '../../utils/lazyWithRetry';
@@ -158,6 +159,8 @@ interface KanbanPageProps {
   onMoveTaskToColumn: (taskId: string, targetColumnId: string) => Promise<void>;
   onGanttReorderTask?: (taskId: string, columnId: string, targetIndex: number) => Promise<void>;
   animateCopiedTaskId?: string | null;
+  /** Brief highlight after create-at-top (kanban). */
+  highlightedNewTaskId?: string | null;
   onEditColumn: (
     columnId: string,
     title: string,
@@ -326,6 +329,7 @@ const KanbanPage: React.FC<KanbanPageProps> = ({
   onMoveTaskToColumn,
   onGanttReorderTask,
   animateCopiedTaskId,
+  highlightedNewTaskId,
   onEditColumn,
   onRemoveColumn,
   onAddColumn,
@@ -1066,6 +1070,8 @@ const KanbanPage: React.FC<KanbanPageProps> = ({
 
   const [canScrollLeft, setCanScrollLeft] = useState(false);
   const [canScrollRight, setCanScrollRight] = useState(false);
+  const [showScrollToTop, setShowScrollToTop] = useState(false);
+  const [scrollToTopRightPx, setScrollToTopRightPx] = useState(48);
   
   // ListView scroll controls
   const [listViewScrollControls, setListViewScrollControls] = useState<{
@@ -1089,6 +1095,38 @@ const KanbanPage: React.FC<KanbanPageProps> = ({
     setCanScrollLeft(container.scrollLeft > 0);
     setCanScrollRight(container.scrollLeft < container.scrollWidth - container.clientWidth);
   };
+
+  // Align “back to top” with the horizontal right-chevron gutter (-right-12).
+  // Prefer this over a fixed viewport `right-6`: same board chrome lane, stays clear of cards.
+  const syncScrollToTopGutter = useCallback(() => {
+    const container = columnsContainerRef.current;
+    if (!container) return;
+    const rect = container.getBoundingClientRect();
+    // Match Tailwind `-right-12` (3rem): button right edge sits 48px past the scroller.
+    setScrollToTopRightPx(Math.max(8, window.innerWidth - rect.right - 48));
+  }, []);
+
+  useEffect(() => {
+    const onWindowScroll = () => {
+      setShowScrollToTop(isKanbanPageScrolledDown());
+    };
+    onWindowScroll();
+    window.addEventListener('scroll', onWindowScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onWindowScroll);
+  }, []);
+
+  useEffect(() => {
+    syncScrollToTopGutter();
+    window.addEventListener('resize', syncScrollToTopGutter);
+    const container = columnsContainerRef.current;
+    const resizeObserver =
+      typeof ResizeObserver !== 'undefined' ? new ResizeObserver(() => syncScrollToTopGutter()) : null;
+    if (container && resizeObserver) resizeObserver.observe(container);
+    return () => {
+      window.removeEventListener('resize', syncScrollToTopGutter);
+      resizeObserver?.disconnect();
+    };
+  }, [syncScrollToTopGutter, viewMode, selectedBoard]);
 
   // Column scroll functions
   const scrollColumnsLeft = () => {
@@ -1633,6 +1671,21 @@ const KanbanPage: React.FC<KanbanPageProps> = ({
                 )}
               </div>
             )}
+
+            {showScrollToTop && (
+              <button
+                type="button"
+                onClick={() => {
+                  void scrollKanbanPageToTopFastSmooth();
+                }}
+                className="fixed z-40 bottom-6 p-2 bg-white/60 dark:bg-gray-800/70 hover:bg-white/95 dark:hover:bg-gray-800/95 rounded-full shadow-sm hover:shadow-lg transition-all duration-200 opacity-50 hover:opacity-100 hover:scale-110"
+                style={{ right: scrollToTopRightPx }}
+                title={t('boardTabs.scrollToTop', { ns: 'common' })}
+                aria-label={t('boardTabs.scrollToTop', { ns: 'common' })}
+              >
+                <ChevronUp size={18} className="text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-gray-100" />
+              </button>
+            )}
             
             {/* Scrollable columns container */}
             <div
@@ -1753,6 +1806,7 @@ const KanbanPage: React.FC<KanbanPageProps> = ({
                             selectedSprintId={selectedSprintId}
                             availableSprints={availableSprints}
                             hasActiveFilters={activeFilters}
+                            highlightedNewTaskId={highlightedNewTaskId}
                             checkedTaskIds={checkedTaskIds}
                             onToggleTaskChecked={onToggleTaskChecked}
                             onToggleColumnChecked={onToggleColumnChecked}
@@ -1862,6 +1916,7 @@ const KanbanPage: React.FC<KanbanPageProps> = ({
                       selectedSprintId={selectedSprintId}
                       availableSprints={availableSprints}
                       hasActiveFilters={activeFilters}
+                      highlightedNewTaskId={highlightedNewTaskId}
                       checkedTaskIds={checkedTaskIds}
                       onToggleTaskChecked={onToggleTaskChecked}
                       onToggleColumnChecked={onToggleColumnChecked}

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -146,6 +146,7 @@ interface MainLayoutProps {
   onSelectTask: (task: Task | null, options?: { scrollToComments?: boolean }) => void;
   onTaskDropOnBoard: (taskId: string, targetBoardId: string) => Promise<void>;
   animateCopiedTaskId?: string | null;
+  highlightedNewTaskId?: string | null;
   showColumnDeleteConfirm?: string | null;
   onConfirmColumnDelete?: (columnId: string) => Promise<void>;
   onCancelColumnDelete?: () => void;

--- a/src/hooks/useTaskWebSocket.ts
+++ b/src/hooks/useTaskWebSocket.ts
@@ -2,7 +2,7 @@ import { useCallback, useRef, useEffect, RefObject } from 'react';
 import { Board, Columns, Task, TeamMember } from '../types';
 import { getBoardTaskRelationships } from '../api';
 import { feDebug } from '../utils/clientDebug';
-import { dedupeTasksInColumns, stripTaskFromAllColumns } from '../utils/taskReorderingUtils';
+import { dedupeTasksInColumns, stripTaskFromAllColumns, applyRestoredTaskToColumns } from '../utils/taskReorderingUtils';
 import { scheduleSettledBoardRefresh } from '../utils/boardRestoredRefresh';
 
 function wsHookLog(...args: unknown[]) {
@@ -843,20 +843,12 @@ export const useTaskWebSocket = ({
             const column = updatedColumns[columnId];
             const taskIndex = column.tasks.findIndex(t => t.id === data.taskId);
             if (taskIndex !== -1) {
-              // Remove the deleted task
+              // Keep position gaps (matches server soft-delete) so restore can reclaim its slot
               const remainingTasks = column.tasks.filter(task => task.id !== data.taskId);
-              
-              // Renumber remaining tasks sequentially from 0
-              const renumberedTasks = remainingTasks
-                .sort((a, b) => (a.position || 0) - (b.position || 0))
-                .map((task, index) => ({
-                  ...task,
-                  position: index
-                }));
               
               updatedColumns[columnId] = {
                 ...column,
-                tasks: renumberedTasks
+                tasks: remainingTasks
               };
             }
           });
@@ -880,20 +872,12 @@ export const useTaskWebSocket = ({
           
           const taskIndex = column.tasks.findIndex(t => t && t.id === data.taskId);
           if (taskIndex !== -1) {
-            // Remove the deleted task
+            // Keep position gaps (matches server soft-delete) so restore can reclaim its slot
             const remainingTasks = column.tasks.filter(task => task && task.id !== data.taskId);
-            
-            // Renumber remaining tasks sequentially from 0
-            const renumberedTasks = remainingTasks
-              .sort((a, b) => (a.position || 0) - (b.position || 0))
-              .map((task, index) => ({
-                ...task,
-                position: index
-              }));
             
             updatedColumns[columnId] = {
               ...column,
-              tasks: renumberedTasks
+              tasks: remainingTasks
             };
           }
         });
@@ -930,7 +914,43 @@ export const useTaskWebSocket = ({
     data.task.deletedBy = null;
     data.task.deleted_at = null;
     data.task.deleted_by = null;
-    handleTaskCreated(data);
+
+    const positionUpdates = Array.isArray(data.positionUpdates)
+      ? data.positionUpdates
+      : undefined;
+
+    // Single state update: reclaim original slot + shift siblings (or apply server snapshot)
+    setBoards((prevBoards) => {
+      const boardExists = prevBoards.some((b) => b.id === data.boardId);
+      if (!boardExists) {
+        return [
+          ...prevBoards,
+          {
+            id: data.boardId,
+            title: data.boardTitle || data.task?.boardTitle || 'Board',
+            columns: applyRestoredTaskToColumns({}, data.task, { positionUpdates }),
+            deletedAt: null,
+          } as Board,
+        ];
+      }
+      return prevBoards.map((board) => {
+        if (board.id !== data.boardId) return board;
+        return {
+          ...board,
+          deletedAt: null,
+          columns: applyRestoredTaskToColumns(board.columns || {}, data.task, {
+            positionUpdates,
+          }),
+        };
+      });
+    });
+
+    if (data.boardId === selectedBoardRef.current) {
+      setColumns((prev) =>
+        applyRestoredTaskToColumns(prev, data.task, { positionUpdates })
+      );
+    }
+
     // Lifecycle "restore board then tasks" still needs a settled force refresh.
     // Local trash/details restores already patched from HTTP — skip the 1.5s flash
     // (including the WS echo for our own restore).
@@ -951,7 +971,7 @@ export const useTaskWebSocket = ({
         deleted_by: null,
       });
     }
-  }, [handleTaskCreated, recentlyDeletedTasksRef, setSelectedTask, refreshBoardDataRef, pendingSelfTaskRestoresRef]);
+  }, [setBoards, setColumns, selectedBoardRef, recentlyDeletedTasksRef, setSelectedTask, refreshBoardDataRef, pendingSelfTaskRestoresRef]);
 
   const handleTaskPurged = useCallback((data: any) => {
     if (!data.taskId) return;
@@ -1431,6 +1451,14 @@ export const useTaskWebSocket = ({
    * Payload: { boardId, updates: [{ taskId, position, columnId }] }
    */
   const handleTasksPositionsUpdated = useCallback((data: any) => {
+    if (!data) return;
+
+    // Oversized NOTIFY was compacted to a refresh hint (large columns)
+    if (data.refresh === true && data.boardId) {
+      scheduleSettledBoardRefresh(refreshBoardDataRef.current);
+      return;
+    }
+
     if (!data?.updates || !Array.isArray(data.updates) || data.updates.length === 0) {
       return;
     }
@@ -1491,7 +1519,7 @@ export const useTaskWebSocket = ({
         return { ...board, columns: updatedColumns };
       })
     );
-  }, [setColumns, setBoards, selectedBoardRef]);
+  }, [setColumns, setBoards, selectedBoardRef, refreshBoardDataRef]);
   
   return {
     handleTaskCreated,

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1035,6 +1035,7 @@
     "scrollRight": "Scroll right",
     "scrollColumnsLeft": "Click or hold to scroll left",
     "scrollColumnsRight": "Click or hold to scroll right",
+    "scrollToTop": "Back to top",
     "scrollListLeft": "Scroll left",
     "scrollListRight": "Scroll right",
     "addNewBoard": "Add New Board (Admin only)",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -50,7 +50,7 @@
     "pleaseWait": "Veuillez patienter...",
     "readOnlyMode": "Votre compte est en lecture seule. Vous ne pouvez pas modifier les données.",
     "readOnlyBadge": "Lecture seule",
-    "unassignedMember": "Non assigné",
+    "unassignedMember": "Non assignée",
     "adminBadge": "Admin"
   },
   "navigation": {
@@ -1035,6 +1035,7 @@
     "scrollRight": "Défiler vers la droite",
     "scrollColumnsLeft": "Cliquer ou maintenir pour défiler vers la gauche",
     "scrollColumnsRight": "Cliquer ou maintenir pour défiler vers la droite",
+    "scrollToTop": "Retour en haut",
     "scrollListLeft": "Défiler vers la gauche",
     "scrollListRight": "Défiler vers la droite",
     "addNewBoard": "Ajouter un nouveau tableau (Admin uniquement)",
@@ -1204,8 +1205,8 @@
     "collaboratorsTooltip": "Afficher les tâches où les membres sélectionnés collaborent activement",
     "requesters": "Demandeurs",
     "requestersTooltip": "Afficher les tâches demandées par les membres sélectionnés",
-    "unassigned": "Non assigné",
-    "unassignedTooltip": "Afficher les tâches sans assigné (travail à revendiquer)",
+    "unassigned": "Non assignées",
+    "unassignedTooltip": "Afficher les tâches non assignées (travail à revendiquer)",
     "system": "Système",
     "systemTooltip": "Afficher les tâches assignées à l'utilisateur système (admin uniquement)",
     "noFiltersSelected": "⚠️ Aucune option de filtre sélectionnée. Sélectionnez au moins une option ci-dessus pour afficher les tâches.",

--- a/src/utils/kanbanScroll.ts
+++ b/src/utils/kanbanScroll.ts
@@ -1,0 +1,40 @@
+/** Instantly jump the window to the top (Kanban board page scroll). */
+export function scrollKanbanPageToTop(behavior: ScrollBehavior = 'auto'): void {
+  if (typeof window === 'undefined') return;
+  if (window.scrollY <= 0 && document.documentElement.scrollTop <= 0) return;
+  window.scrollTo({ top: 0, behavior });
+}
+
+/**
+ * Fast ease-out scroll to top (shorter than native smooth for tall pages).
+ * Resolves when the animation finishes (or immediately if already at top).
+ */
+export function scrollKanbanPageToTopFastSmooth(): Promise<void> {
+  if (typeof window === 'undefined') return Promise.resolve();
+  const start = Math.max(window.scrollY, document.documentElement.scrollTop);
+  if (start <= 0) return Promise.resolve();
+
+  // ~180–420ms depending on distance — snappy but still smooth
+  const duration = Math.min(420, Math.max(180, start * 0.28));
+  const t0 = performance.now();
+
+  return new Promise((resolve) => {
+    const step = (now: number) => {
+      const t = Math.min(1, (now - t0) / duration);
+      const eased = 1 - (1 - t) ** 3;
+      window.scrollTo(0, start * (1 - eased));
+      if (t < 1) {
+        requestAnimationFrame(step);
+      } else {
+        resolve();
+      }
+    };
+    requestAnimationFrame(step);
+  });
+}
+
+/** True when the page is scrolled down enough to warrant a “back to top” control. */
+export function isKanbanPageScrolledDown(thresholdPx = 200): boolean {
+  if (typeof window === 'undefined') return false;
+  return Math.max(window.scrollY, document.documentElement.scrollTop) > thresholdPx;
+}

--- a/src/utils/taskReorderingUtils.ts
+++ b/src/utils/taskReorderingUtils.ts
@@ -222,6 +222,96 @@ export function stripTaskFromAllColumns(
   return changed ? next : columns;
 }
 
+export type TaskPositionUpdate = {
+  taskId: string;
+  position: number;
+  columnId?: string;
+};
+
+/**
+ * Insert/update a restored task at its original position, shifting siblings down.
+ *
+ * - If `positionUpdates` is provided (small shifted-sibling list), apply those first.
+ * - Otherwise bump only when the insert slot is already occupied (collision), so we
+ *   don't double-shift after a prior tasks-positions-updated event.
+ *
+ * Note: full-column snapshots are not sent over WS (PostgreSQL NOTIFY 8KB limit).
+ */
+export function applyRestoredTaskToColumns(
+  columns: Columns,
+  task: Task,
+  options?: { positionUpdates?: TaskPositionUpdate[] }
+): Columns {
+  const targetColumnId = task.columnId || (task as any).columnid;
+  if (!targetColumnId) return columns;
+
+  const insertPos = Number(task.position);
+  const updates = options?.positionUpdates;
+
+  let next = stripTaskFromAllColumns(columns, task.id, {
+    renumber: false,
+  });
+
+  const column = next[targetColumnId] || {
+    id: targetColumnId,
+    boardId: task.boardId || (task as any).boardid,
+    title: 'Unknown Column',
+    tasks: [] as Task[],
+    position: 0,
+    is_finished: false,
+    is_archived: false,
+  };
+
+  let tasks = [...(column.tasks || [])];
+
+  if (updates && updates.length > 0) {
+    const byId = new Map<string, TaskPositionUpdate>();
+    for (const u of updates) {
+      if (!u?.taskId) continue;
+      byId.set(u.taskId, {
+        taskId: u.taskId,
+        position:
+          typeof u.position === 'number' ? u.position : parseFloat(String(u.position)) || 0,
+        columnId: u.columnId,
+      });
+    }
+    tasks = tasks.map((t) => {
+      const u = byId.get(t.id);
+      if (!u) return t;
+      return {
+        ...t,
+        position: u.position,
+        columnId: u.columnId || t.columnId,
+      };
+    });
+  } else if (Number.isFinite(insertPos)) {
+    // Only shift when the insert slot is occupied (e.g. dense local state after delete).
+    // If tasks-positions-updated already opened a gap, inserting alone is enough.
+    const hasCollision = tasks.some((t) => parsePos(t.position) === insertPos);
+    if (hasCollision) {
+      tasks = tasks.map((t) => {
+        const p = parsePos(t.position);
+        return p >= insertPos ? { ...t, position: p + 1 } : t;
+      });
+    }
+  }
+
+  const exists = tasks.some((t) => t.id === task.id);
+  tasks = exists
+    ? tasks.map((t) => (t.id === task.id ? { ...t, ...task, deletedAt: null, deletedBy: null } : t))
+    : [...tasks, { ...task, deletedAt: null, deletedBy: null }];
+
+  tasks.sort((a, b) => parsePos(a.position) - parsePos(b.position));
+
+  return {
+    ...next,
+    [targetColumnId]: {
+      ...column,
+      tasks,
+    },
+  };
+}
+
 /**
  * If the same task id appears in multiple columns, keep only one copy:
  * prefer the column matching task.columnId, else the first seen.


### PR DESCRIPTION
## Summary
- Fix restore-from-trash so peers on large boards still see the card (keep NOTIFY payloads under PostgreSQL’s 8KB limit; reclaim original slot and shift siblings).
- Optimistic soft-delete so cards leave the board immediately; create-at-top uses fast scroll-to-top plus a brief card highlight.
- French member-filter copy (“Non assignées”) and hide the System chip when there are no system-assigned tasks.

## Test plan
- [ ] Delete a mid-column task → restore from trash on another session → both sessions show it in the original slot with siblings shifted
- [ ] Repeat on a board with 200+ cards (NOTIFY must not drop the restore event)
- [ ] Soft-delete without confirmation: card disappears immediately
- [ ] Create task while scrolled down: smooth scroll to top + ~1s highlight
- [ ] FR locale: Unassigned pill reads “Non assignées”; System chip hidden when count is 0


Made with [Cursor](https://cursor.com)