### PR TITLE
Apply ?lng= app-wide like the language switcher

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,7 +98,7 @@ import websocketClient from './services/websocketClient';
 import { resolveActivityFeedPosition } from './utils/activityFeedPosition';
 import { isMobileViewport } from './utils/mobileViewport';
 import { loadUserPreferences, loadUserPreferencesAsync, mergeClearedKanbanVisibilityFilters, saveUserPreferences, updateUserPreference, updateActivityFeedPreference, loadAdminDefaults, TaskViewMode, ViewMode, isGloballySavingPreferences, registerSavingStateCallback, UserPreferences, clearAllUserPreferenceCookies } from './utils/userPreferences';
-import { resolveGuestLanguage, normalizeAppLanguage, getExplicitGuestLanguage, setExplicitGuestLanguage } from './utils/guestLanguage';
+import { resolveGuestLanguage, normalizeAppLanguage, getExplicitGuestLanguage, setExplicitGuestLanguage, consumeLanguageQueryParam } from './utils/guestLanguage';
 import { versionDetection } from './utils/versionDetection';
 import { getAllPriorities, getAllTags, getTags, getPriorities, getSettings, getTaskWatchers, getTaskCollaborators, addTagToTask, removeTagFromTask, getBoardTaskRelationships, getTaskRelationships, getAllSprints, getUserSettings, removeTaskRelationship } from './api';
 import { 
@@ -1137,6 +1137,24 @@ function AppContent() {
   
   // Load auto-refresh setting and sprint selection from user preferences
   useEffect(() => {
+    // Deep-link / marketing `?lng=` / `?lang=` — same effect as the header language switcher.
+    // Must run before any early return so the param is not left on the URL.
+    const fromUrl = consumeLanguageQueryParam();
+    if (fromUrl) {
+      setExplicitGuestLanguage(fromUrl);
+      if (isDemoModeClient()) {
+        try {
+          sessionStorage.setItem('ekDemoSessionLang', fromUrl);
+        } catch {
+          /* ignore */
+        }
+      }
+      void i18n.changeLanguage(fromUrl);
+      if (currentUser?.id) {
+        void updateUserPreference('language', fromUrl, currentUser.id);
+      }
+    }
+
     if (currentUser) {
       const restorePreferences = async () => {
         try {
@@ -1144,7 +1162,7 @@ function AppContent() {
           const prefs = await loadUserPreferencesAsync(currentUser.id);
           
           // Language sync (login ↔ app):
-          // 1) Explicit choice made on login/guest screens wins and is saved as user pref
+          // 1) Explicit choice made on login/guest screens (or ?lng=) wins and is saved as user pref
           // 2) Else existing user pref from DB
           // 3) Else seed from browser → APP_LANGUAGE and save once
           const dbSettings = await getUserSettings();

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { login } from '../api';
 import { Github, MousePointerClick, RefreshCw, Sparkles } from 'lucide-react';
 import { useSettings } from '../contexts/SettingsContext';
-import { setExplicitGuestLanguage, normalizeAppLanguage } from '../utils/guestLanguage';
+import { setExplicitGuestLanguage, normalizeAppLanguage, peekLanguageQueryParam } from '../utils/guestLanguage';
 import { updateUserPreference } from '../utils/userPreferences';
 import { AGILA_GITHUB_URL } from '../constants';
 import { resolvePublicBrandLogoSrc } from '../utils/brandLogo';
@@ -71,8 +71,8 @@ export default function Login({ onLogin, siteSettings, hasDefaultAdmin = true, i
   
   const [demoLang, setDemoLang] = useState<DemoSessionLang | null>(() => {
     try {
-      const params = new URLSearchParams(window.location.search);
-      const fromUrl = normalizeAppLanguage(params.get('lng') ?? params.get('lang'));
+      // App.tsx consumes/strips ?lng=; peek here so demo EN/FR buttons preselect on first paint.
+      const fromUrl = peekLanguageQueryParam();
       if (fromUrl) {
         sessionStorage.setItem('ekDemoSessionLang', fromUrl);
         return fromUrl;
@@ -105,26 +105,6 @@ export default function Login({ onLogin, siteSettings, hasDefaultAdmin = true, i
     setExplicitGuestLanguage(lang);
     await i18n.changeLanguage(lang);
   };
-
-  // Marketing site deep-link: ?lng=fr|en preselects the demo language buttons.
-  useEffect(() => {
-    if (!isDemoMode) return;
-    let fromUrl: DemoSessionLang | null = null;
-    try {
-      const params = new URLSearchParams(window.location.search);
-      fromUrl = normalizeAppLanguage(params.get('lng') ?? params.get('lang'));
-      if (!fromUrl) return;
-      params.delete('lng');
-      params.delete('lang');
-      const qs = params.toString();
-      const next = `${window.location.pathname}${qs ? `?${qs}` : ''}${window.location.hash}`;
-      window.history.replaceState({}, '', next);
-    } catch {
-      return;
-    }
-    void handleDemoLanguagePick(fromUrl);
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- run once on mount for URL bootstrap
-  }, [isDemoMode]);
 
   /** Fetch once. Returns credentials only when the real seeded password is available. */
   const fetchAdminCredentials = useCallback(async (): Promise<{

--- a/src/utils/guestLanguage.ts
+++ b/src/utils/guestLanguage.ts
@@ -41,6 +41,45 @@ export function setExplicitGuestLanguage(lang: AppUiLanguage): void {
   }
 }
 
+/** Read `?lng=` / `?lang=` without mutating the URL. */
+export function peekLanguageQueryParam(
+  search: string = typeof window !== 'undefined' ? window.location.search : '',
+): AppUiLanguage | null {
+  try {
+    const params = new URLSearchParams(search);
+    return normalizeAppLanguage(params.get('lng') ?? params.get('lang'));
+  } catch {
+    return null;
+  }
+}
+
+/** Remove `lng` / `lang` from the current URL via replaceState. */
+export function stripLanguageQueryParam(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const params = new URLSearchParams(window.location.search);
+    if (!params.has('lng') && !params.has('lang')) return;
+    params.delete('lng');
+    params.delete('lang');
+    const qs = params.toString();
+    const next = `${window.location.pathname}${qs ? `?${qs}` : ''}${window.location.hash}`;
+    window.history.replaceState({}, '', next);
+  } catch {
+    /* ignore */
+  }
+}
+
+/**
+ * If the URL has a valid `?lng=` / `?lang=`, strip it and return the language.
+ * Same effect as the header switcher once the caller applies i18n + persistence.
+ */
+export function consumeLanguageQueryParam(): AppUiLanguage | null {
+  const lang = peekLanguageQueryParam();
+  if (!lang) return null;
+  stripLanguageQueryParam();
+  return lang;
+}
+
 /**
  * Resolve language for unauthenticated screens.
  * 1) Explicit guest toggle  2) browser  3) APP_LANGUAGE (site default)  4) en


### PR DESCRIPTION
## Summary
- Consume `?lng=` / `?lang=` on App bootstrap with the same effect as the header language switcher (i18n + explicit guest lang + user pref when logged in).
- Strip the query param after apply; leave browser/saved prefs alone when no param is present.
- Demo login peeks the param for EN/FR button preselect; strip/apply lives in App so any deep link works.

## Test plan
- [ ] Open app with `?lng=fr` while logged out → French UI, param stripped, survives refresh via explicit guest lang
- [ ] Open with `?lng=en` while logged in as a French user → English UI and language pref updated
- [ ] Open with no `lng` → language unchanged from browser / saved preference
- [ ] Demo login with `?lng=fr` → French button preselected and session lang set

Made with [Cursor](https://cursor.com)