### PR TITLE
Fix empty Google SSO card in demo Admin

### DIFF
--- a/server/migrations/index.js
+++ b/server/migrations/index.js
@@ -1062,7 +1062,7 @@ const migrations = [
       if (!mode) {
         if (managedFlag === 'true') mode = 'managed';
         else if (clientId) mode = 'byo';
-        else mode = 'off';
+        else mode = '';
         await settingsQueries.upsertSetting(db, GOOGLE_SSO_MODE_KEY, mode);
       }
 
@@ -1118,6 +1118,29 @@ const migrations = [
            )`
       );
       console.log('✅ Migration 48: users.activated_at present and backfilled');
+    }
+  },
+  {
+    version: 49,
+    name: 'clear_empty_google_sso_off',
+    description:
+      'Treat never-configured Google SSO as unset (empty mode), not Disabled with no credentials',
+    up: async (db) => {
+      const { settings: settingsQueries } = await import('../utils/sqlManager/index.js');
+      const { GOOGLE_SSO_MODE_KEY, GOOGLE_SSO_RESUME_MODE_KEY } = await import(
+        '../constants/ssoSettings.js'
+      );
+      const read = async (key) => {
+        const row = await settingsQueries.getSettingByKey(db, key);
+        return String(row?.value ?? '').trim();
+      };
+      const mode = await read(GOOGLE_SSO_MODE_KEY);
+      const resume = await read(GOOGLE_SSO_RESUME_MODE_KEY);
+      const clientId = await read('GOOGLE_CLIENT_ID');
+      if (mode === 'off' && !resume && !clientId) {
+        await settingsQueries.upsertSetting(db, GOOGLE_SSO_MODE_KEY, '');
+      }
+      console.log('✅ Migration 49: empty Google SSO off-state cleared when never configured');
     }
   }
 ];

--- a/server/routes/settings.js
+++ b/server/routes/settings.js
@@ -33,8 +33,10 @@ import {
   SSO_MANAGED_HIDDEN_KEYS,
   isSsoLastSuccessKey,
   GOOGLE_SSO_MODE_KEY,
+  GOOGLE_SSO_MANAGED_ELIGIBLE_KEY,
   GOOGLE_SSO_RESUME_MODE_KEY,
   applyPublicSsoSettings,
+  isDemoSsoDisabled,
 } from '../constants/ssoSettings.js';
 import { getAuthHubCallbackUrl } from '../utils/authHub.js';
 import {
@@ -292,7 +294,8 @@ router.get('/', authenticateToken, requireRole(['admin']), async (req, res, next
       }
     );
     const ssoEligible =
-      settings.find((s) => s.key === 'GOOGLE_SSO_MANAGED_ELIGIBLE')?.value === 'true';
+      !isDemoSsoDisabled() &&
+      settings.find((s) => s.key === GOOGLE_SSO_MANAGED_ELIGIBLE_KEY)?.value === 'true';
     const ssoResume = String(
       settings.find((s) => s.key === GOOGLE_SSO_RESUME_MODE_KEY)?.value || ''
     )
@@ -335,6 +338,10 @@ router.get('/', authenticateToken, requireRole(['admin']), async (req, res, next
 
     if (ssoManaged || (hideGoogleCreds && ssoEligible)) {
       settingsObj[SSO_HUB_CALLBACK_DISPLAY_KEY] = getAuthHubCallbackUrl();
+    }
+
+    if (isDemoSsoDisabled()) {
+      settingsObj[GOOGLE_SSO_MANAGED_ELIGIBLE_KEY] = 'false';
     }
 
     // Multi-tenant: overlay platform runner env so Admin shows the shared runner (read-only in UI)
@@ -603,6 +610,12 @@ router.put('/', authenticateToken, requireRole(['admin']), async (req, res, next
       });
     }
 
+    if (key === GOOGLE_SSO_MANAGED_ELIGIBLE_KEY || key === GOOGLE_SSO_RESUME_MODE_KEY) {
+      return res.status(403).json({
+        error: 'This setting is managed by the platform and cannot be updated',
+      });
+    }
+
     if (SSO_MANAGED_HIDDEN_KEYS.includes(key)) {
       const ssoMode = await resolveGoogleSsoMode(db);
       if (ssoMode === 'managed') {
@@ -712,6 +725,17 @@ router.put('/', authenticateToken, requireRole(['admin']), async (req, res, next
         value: upsert.hasValue ? SECRET_SETTING_PLACEHOLDER : '',
         // Always string for admin settings maps (avoid boolean crashing FE .trim())
         [`${key}_SET`]: upsert.hasValue ? 'true' : 'false'
+      });
+    }
+
+    if (
+      key === GOOGLE_SSO_MODE_KEY &&
+      String(safeValue || '')
+        .trim()
+        .toLowerCase() === 'managed'
+    ) {
+      return res.status(403).json({
+        error: 'Platform Google sign-in can only be restored through the dedicated endpoint',
       });
     }
 
@@ -1244,6 +1268,12 @@ router.post('/google-sso/enable', authenticateToken, requireRole(['admin']), asy
     const tenantId = getTenantId(req);
     const result = await enableGoogleSso(db, tenantId);
     if (!result.ok) {
+      if (result.error === 'missing_credentials') {
+        return res.status(400).json({
+          error: 'Google OAuth credentials are required before enabling sign-in',
+          code: 'missing_credentials',
+        });
+      }
       if (result.error === 'not_eligible') {
         return res.status(403).json({
           error: 'This instance is not eligible for platform Google sign-in',

--- a/server/utils/googleSsoMode.js
+++ b/server/utils/googleSsoMode.js
@@ -7,6 +7,7 @@ import {
   GOOGLE_SSO_MODE_KEY,
   GOOGLE_SSO_MODES,
   GOOGLE_SSO_RESUME_MODE_KEY,
+  isDemoSsoDisabled,
 } from '../constants/ssoSettings.js';
 import {
   clearSecretSetting,
@@ -187,11 +188,22 @@ export async function enableGoogleSso(db, tenantId) {
   if (resume === 'managed') {
     return restoreManagedGoogleSso(db, tenantId);
   }
-  await setGoogleSsoModeState(db, 'byo', tenantId);
-  return { ok: true, mode: 'byo' };
+  const clientId = await getSettingValue(db, ACTIVE_KEYS.clientId);
+  if (clientId) {
+    await setGoogleSsoModeState(db, 'byo', tenantId);
+    return { ok: true, mode: 'byo' };
+  }
+  const eligible = await getSettingValue(db, GOOGLE_SSO_MANAGED_ELIGIBLE_KEY);
+  if (!isDemoSsoDisabled() && eligible === 'true') {
+    return restoreManagedGoogleSso(db, tenantId);
+  }
+  return { ok: false, error: 'missing_credentials' };
 }
 
 export async function restoreManagedGoogleSso(db, tenantId) {
+  if (isDemoSsoDisabled()) {
+    return { ok: false, error: 'not_eligible' };
+  }
   const eligible = await getSettingValue(db, GOOGLE_SSO_MANAGED_ELIGIBLE_KEY);
   if (eligible !== 'true') {
     return { ok: false, error: 'not_eligible' };

--- a/src/components/admin/AdminSSOTab.tsx
+++ b/src/components/admin/AdminSSOTab.tsx
@@ -220,7 +220,10 @@ const AdminSSOTab: React.FC<AdminSSOTabProps> = ({
       await reloadSettings();
     } catch (err: unknown) {
       const code = (err as { response?: { data?: { code?: string } } })?.response?.data?.code;
-      if (code === 'not_eligible') {
+      if (code === 'missing_credentials') {
+        onSettingsChange(buildByoOAuthDraftFromOff(editingSettings));
+        closeConfirm();
+      } else if (code === 'not_eligible') {
         toast.error(t('sso.restoreManagedNotEligible'), '');
       } else if (code === 'platform_unavailable') {
         toast.error(t('sso.restoreManagedUnavailable'), '');

--- a/src/utils/ssoAdminValidation.ts
+++ b/src/utils/ssoAdminValidation.ts
@@ -24,43 +24,6 @@ export function resolveGoogleSsoModeFromSettings(
   return 'off';
 }
 
-export function isGoogleSsoManagedEligible(settings: AdminSettingsMap): boolean {
-  return String(settings.GOOGLE_SSO_MANAGED_ELIGIBLE || '').trim() === 'true';
-}
-
-export function googleSsoResumeMode(settings: AdminSettingsMap): 'managed' | 'byo' {
-  const resume = String(settings.GOOGLE_SSO_RESUME_MODE || '').trim().toLowerCase();
-  if (resume === 'managed' || resume === 'byo') return resume;
-  if (isGoogleSsoManagedEligible(settings) && !String(settings.GOOGLE_CLIENT_ID || '').trim()) {
-    return 'managed';
-  }
-  return 'byo';
-}
-
-/** True when this instance has a Google SSO card (including disabled). Eligibility alone does not keep the card. */
-export function isGoogleSsoConfigured(settings: AdminSettingsMap): boolean {
-  const raw = String(settings.GOOGLE_SSO_MODE || '').trim().toLowerCase();
-  if (raw === 'managed' || raw === 'byo' || raw === 'off') return true;
-  if (String(settings.GOOGLE_CLIENT_ID || '').trim()) return true;
-  return false;
-}
-
-export function isSimpleSsoConfigured(
-  settings: AdminSettingsMap,
-  modeKey: string,
-  clientIdKey: string
-): boolean {
-  const raw = String(settings[modeKey] || '').trim().toLowerCase();
-  if (raw === 'byo' || raw === 'off') return true;
-  return Boolean(String(settings[clientIdKey] || '').trim());
-}
-
-export function isGoogleSsoLoginEnabled(settings: AdminSettingsMap): boolean {
-  if (isDemoSsoLocked(settings)) return false;
-  const mode = resolveGoogleSsoModeFromSettings(settings);
-  return mode === 'managed' || mode === 'byo';
-}
-
 export function isDemoSsoLocked(settings?: AdminSettingsMap): boolean {
   if (String(settings?.DEPLOY_DEMO_ENABLED || '').trim() === 'true') return true;
   try {
@@ -71,6 +34,48 @@ export function isDemoSsoLocked(settings?: AdminSettingsMap): boolean {
   } catch {
     return false;
   }
+}
+
+export function isGoogleSsoManagedEligible(settings: AdminSettingsMap): boolean {
+  if (isDemoSsoLocked(settings)) return false;
+  return String(settings.GOOGLE_SSO_MANAGED_ELIGIBLE || '').trim() === 'true';
+}
+
+export function googleSsoResumeMode(settings: AdminSettingsMap): 'managed' | 'byo' {
+  const resume = String(settings.GOOGLE_SSO_RESUME_MODE || '').trim().toLowerCase();
+  if (resume === 'managed' || resume === 'byo') return resume;
+  return 'byo';
+}
+
+/** True when this instance has a Google SSO card (including disabled). Bare `off` with no creds is not a card. */
+export function isGoogleSsoConfigured(settings: AdminSettingsMap): boolean {
+  const raw = String(settings.GOOGLE_SSO_MODE || '').trim().toLowerCase();
+  if (raw === 'managed' || raw === 'byo') return true;
+  if (raw === 'off') {
+    const resume = String(settings.GOOGLE_SSO_RESUME_MODE || '').trim().toLowerCase();
+    if (resume === 'managed' || resume === 'byo') return true;
+    return Boolean(String(settings.GOOGLE_CLIENT_ID || '').trim());
+  }
+  return Boolean(String(settings.GOOGLE_CLIENT_ID || '').trim());
+}
+
+export function isSimpleSsoConfigured(
+  settings: AdminSettingsMap,
+  modeKey: string,
+  clientIdKey: string
+): boolean {
+  const raw = String(settings[modeKey] || '').trim().toLowerCase();
+  if (raw === 'byo') return true;
+  if (raw === 'off') {
+    return Boolean(String(settings[clientIdKey] || '').trim());
+  }
+  return Boolean(String(settings[clientIdKey] || '').trim());
+}
+
+export function isGoogleSsoLoginEnabled(settings: AdminSettingsMap): boolean {
+  if (isDemoSsoLocked(settings)) return false;
+  const mode = resolveGoogleSsoModeFromSettings(settings);
+  return mode === 'managed' || mode === 'byo';
 }
 
 export function isSimpleSsoLoginEnabled(


### PR DESCRIPTION
## Summary
- Treat never-configured Google SSO as unset (no Disabled ghost card; migration 49 clears leftover `off`).
- Re-enable no longer marks Google Active without saved Client ID; platform/managed SSO stays off in demo and unless `GOOGLE_SSO_MANAGED_ELIGIBLE` is true.
- GitHub / Microsoft Add-as-BYO drafts are unchanged (Save still requires credentials).

## Test plan
- [ ] On demo Admin → SSO: no empty Disabled Google card; Add Google/GitHub/M365 opens a draft, Save without creds stays invalid.
- [ ] Re-enable is not available for empty Google; after a real Disable (creds still stored), Re-enable still works.
- [ ] No “Use platform Google sign-in” on demo (`DEMO_ENABLED`, no managed eligible).
- [ ] Login page still has no SSO buttons in demo.


Made with [Cursor](https://cursor.com)