### PR TITLE
Align storage with STORAGE_MODE and platform S3 shadows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,7 +36,15 @@ RUNNER_TOKEN=kanban-runner-dev-token-change-me
 # MANAGED_SMTP_FROM_NAME=Agila
 # MANAGED_SMTP_PASSWORD=
 
-# --- Optional managed S3 for licensed / multi-tenant SaaS (seeded at tenant init) ---
+# --- Optional platform S3 for licensed / multi-tenant SaaS (seeded at tenant init) ---
+# Prefer PLATFORM_S3_*; MANAGED_S3_* is a legacy alias for the same values.
+# PLATFORM_S3_BUCKET=
+# PLATFORM_S3_REGION=
+# PLATFORM_S3_ENDPOINT=
+# PLATFORM_S3_ACCESS_KEY_ID=
+# PLATFORM_S3_SECRET_ACCESS_KEY=
+# PLATFORM_S3_FORCE_PATH_STYLE=false
+# PLATFORM_S3_KEY_PREFIX=
 # MANAGED_S3_BUCKET=
 # MANAGED_S3_REGION=
 # MANAGED_S3_ENDPOINT=

--- a/server/config/database.js
+++ b/server/config/database.js
@@ -1008,7 +1008,9 @@ const initializeDefaultData = async (db, tenantId = null) => {
       ['STORAGE_LIMIT', '5368709120'], // 5GB storage limit in bytes (5 * 1024^3)
       ['STORAGE_USED', '0'], // Current storage usage in bytes
       ['STORAGE_BACKEND', 'disk'], // disk | s3
+      ['STORAGE_MODE', ''],
       ['STORAGE_MANAGED', 'false'],
+      ['STORAGE_MANAGED_ELIGIBLE', 'false'],
       ['S3_ENDPOINT', ''],
       ['S3_REGION', ''],
       ['S3_BUCKET', ''],
@@ -1177,40 +1179,61 @@ const initializeDefaultData = async (db, tenantId = null) => {
           ['PLATFORM_SMTP_SECURE', 'tls']
         ];
         
-        const managedSmtpStmt = db.prepare('INSERT INTO settings (key, value, updated_at) VALUES (?, ?, CURRENT_TIMESTAMP) ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = CURRENT_TIMESTAMP');
+        const licensedSeedStmt = db.prepare('INSERT INTO settings (key, value, updated_at) VALUES (?, ?, CURRENT_TIMESTAMP) ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = CURRENT_TIMESTAMP');
         for (const [key, value] of managedSmtpSettings) {
-          await wrapQuery(managedSmtpStmt, 'INSERT').run(key, value);
+          await wrapQuery(licensedSeedStmt, 'INSERT').run(key, value);
         }
         console.log('✅ Configured managed SMTP settings');
+        }
 
-        // Managed S3 (optional — only when MANAGED_S3_BUCKET is set)
-        if (process.env.MANAGED_S3_BUCKET) {
+        // Platform S3 (optional). Prefer PLATFORM_S3_* env; MANAGED_S3_* is a legacy alias.
+        const existingStorageMode = String(
+          (await wrapQuery(db.prepare('SELECT value FROM settings WHERE key = ?'), 'SELECT').get('STORAGE_MODE'))
+            ?.value || ''
+        )
+          .trim()
+          .toLowerCase();
+        const platformS3Env = (suffix) =>
+          process.env[`PLATFORM_S3_${suffix}`] || process.env[`MANAGED_S3_${suffix}`] || '';
+        const platformS3Bucket = platformS3Env('BUCKET');
+        if (existingStorageMode === 'byo') {
+          console.log('ℹ️  STORAGE_MODE=byo — leaving licensed storage seed unchanged');
+        } else if (platformS3Bucket) {
           const { encryptSettingValue: encryptS3Secret } = await import('../utils/secretCrypto.js');
-          const managedS3SecretPlain = process.env.MANAGED_S3_SECRET_ACCESS_KEY || '';
+          const managedS3SecretPlain = platformS3Env('SECRET_ACCESS_KEY');
           const managedS3SecretStored = managedS3SecretPlain
             ? encryptS3Secret(managedS3SecretPlain)
             : '';
           const tenantPrefix =
             tenantId && process.env.MULTI_TENANT === 'true'
               ? `tenants/${tenantId}/`
-              : (process.env.MANAGED_S3_KEY_PREFIX || '');
+              : platformS3Env('KEY_PREFIX');
           const managedS3Settings = [
             ['STORAGE_BACKEND', 's3'],
+            ['STORAGE_MODE', 'managed'],
             ['STORAGE_MANAGED', 'true'],
-            ['S3_ENDPOINT', process.env.MANAGED_S3_ENDPOINT || ''],
-            ['S3_REGION', process.env.MANAGED_S3_REGION || ''],
-            ['S3_BUCKET', process.env.MANAGED_S3_BUCKET],
-            ['S3_ACCESS_KEY_ID', process.env.MANAGED_S3_ACCESS_KEY_ID || ''],
+            ['STORAGE_MANAGED_ELIGIBLE', 'true'],
+            ['S3_ENDPOINT', platformS3Env('ENDPOINT')],
+            ['S3_REGION', platformS3Env('REGION')],
+            ['S3_BUCKET', platformS3Bucket],
+            ['S3_ACCESS_KEY_ID', platformS3Env('ACCESS_KEY_ID')],
             ['S3_SECRET_ACCESS_KEY', managedS3SecretStored],
-            ['S3_FORCE_PATH_STYLE', process.env.MANAGED_S3_FORCE_PATH_STYLE || 'false'],
+            ['S3_FORCE_PATH_STYLE', platformS3Env('FORCE_PATH_STYLE') || 'false'],
             ['S3_KEY_PREFIX', tenantPrefix],
+            ['PLATFORM_S3_ENDPOINT', platformS3Env('ENDPOINT')],
+            ['PLATFORM_S3_REGION', platformS3Env('REGION')],
+            ['PLATFORM_S3_BUCKET', platformS3Bucket],
+            ['PLATFORM_S3_ACCESS_KEY_ID', platformS3Env('ACCESS_KEY_ID')],
+            ['PLATFORM_S3_SECRET_ACCESS_KEY', managedS3SecretStored],
+            ['PLATFORM_S3_FORCE_PATH_STYLE', platformS3Env('FORCE_PATH_STYLE') || 'false'],
+            ['PLATFORM_S3_KEY_PREFIX', tenantPrefix],
             ['STORAGE_TEST_OK', 'false']
           ];
+          const licensedS3Stmt = db.prepare('INSERT INTO settings (key, value, updated_at) VALUES (?, ?, CURRENT_TIMESTAMP) ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, updated_at = CURRENT_TIMESTAMP');
           for (const [key, value] of managedS3Settings) {
-            await wrapQuery(managedSmtpStmt, 'INSERT').run(key, value);
+            await wrapQuery(licensedS3Stmt, 'INSERT').run(key, value);
           }
-          console.log('✅ Configured managed S3 storage settings');
-        }
+          console.log('✅ Configured platform S3 storage settings');
         }
       }
     }

--- a/server/constants/secretSettings.js
+++ b/server/constants/secretSettings.js
@@ -11,7 +11,8 @@ export const SECRET_SETTING_KEYS = Object.freeze([
   'M365_CLIENT_SECRET',
   'AI_API_KEY',
   'AI_RUNNER_TOKEN',
-  'S3_SECRET_ACCESS_KEY'
+  'S3_SECRET_ACCESS_KEY',
+  'PLATFORM_S3_SECRET_ACCESS_KEY'
 ]);
 
 /** Placeholder returned on admin GET — never the raw secret */

--- a/server/constants/storageSettings.js
+++ b/server/constants/storageSettings.js
@@ -2,9 +2,17 @@
  * Object / file storage admin settings (disk vs S3).
  */
 
+export const STORAGE_MODE_KEY = 'STORAGE_MODE';
+export const STORAGE_MANAGED_ELIGIBLE_KEY = 'STORAGE_MANAGED_ELIGIBLE';
+
+/** `off` is not a stored mode — empty STORAGE_MODE means disk / not using platform S3. */
+export const STORAGE_MODES = Object.freeze(['managed', 'byo']);
+
 export const STORAGE_SETTING_DEFAULTS = Object.freeze([
   ['STORAGE_BACKEND', 'disk'], // disk | s3
+  ['STORAGE_MODE', ''],
   ['STORAGE_MANAGED', 'false'],
+  ['STORAGE_MANAGED_ELIGIBLE', 'false'],
   ['S3_ENDPOINT', ''],
   ['S3_REGION', ''],
   ['S3_BUCKET', ''],
@@ -17,7 +25,7 @@ export const STORAGE_SETTING_DEFAULTS = Object.freeze([
   ['STORAGE_TEST_OK', 'false']
 ]);
 
-/** S3 credential fields hidden when STORAGE_MANAGED=true (like SMTP when MAIL_MANAGED). */
+/** Live S3 fields hidden from tenant admins while storage is platform-managed. */
 export const STORAGE_MANAGED_HIDDEN_KEYS = Object.freeze([
   'S3_ENDPOINT',
   'S3_REGION',
@@ -28,12 +36,17 @@ export const STORAGE_MANAGED_HIDDEN_KEYS = Object.freeze([
   'S3_KEY_PREFIX'
 ]);
 
-export const STORAGE_S3_CONFIG_KEYS = Object.freeze([
-  'S3_ENDPOINT',
-  'S3_REGION',
-  'S3_BUCKET',
-  'S3_ACCESS_KEY_ID',
-  'S3_SECRET_ACCESS_KEY',
-  'S3_FORCE_PATH_STYLE',
-  'S3_KEY_PREFIX'
+export const STORAGE_S3_CONFIG_KEYS = Object.freeze([...STORAGE_MANAGED_HIDDEN_KEYS]);
+
+/** Platform shadow copy — never exposed on tenant admin GET. */
+export const PLATFORM_S3_KEYS = Object.freeze([
+  'PLATFORM_S3_ENDPOINT',
+  'PLATFORM_S3_REGION',
+  'PLATFORM_S3_BUCKET',
+  'PLATFORM_S3_ACCESS_KEY_ID',
+  'PLATFORM_S3_SECRET_ACCESS_KEY',
+  'PLATFORM_S3_FORCE_PATH_STYLE',
+  'PLATFORM_S3_KEY_PREFIX'
 ]);
+
+export const STORAGE_ADMIN_INTERNAL_KEYS = Object.freeze([...PLATFORM_S3_KEYS]);

--- a/server/migrations/index.js
+++ b/server/migrations/index.js
@@ -1229,6 +1229,73 @@ const migrations = [
       if (legacyEligible) await settingsQueries.upsertSetting(db, 'MAIL_MANAGED_ELIGIBLE', '');
       console.log('✅ Migration 51: SMTP_MODE / SMTP_MANAGED_ELIGIBLE renamed from MAIL_*');
     }
+  },
+  {
+    version: 52,
+    name: 'add_storage_mode_and_platform_s3_shadow',
+    description:
+      'Add STORAGE_MODE, STORAGE_MANAGED_ELIGIBLE, and platform S3 shadow keys for restore',
+    up: async (db) => {
+      const { settings: settingsQueries } = await import('../utils/sqlManager/index.js');
+      const { getDecryptedSetting, upsertSecretSetting } = await import(
+        '../utils/settingsSecrets.js'
+      );
+      const { STORAGE_MODE_KEY, STORAGE_MANAGED_ELIGIBLE_KEY } = await import(
+        '../constants/storageSettings.js'
+      );
+
+      const read = async (key) => {
+        const row = await settingsQueries.getSettingByKey(db, key);
+        return String(row?.value ?? '').trim();
+      };
+
+      const managedFlag = await read('STORAGE_MANAGED');
+      const bucket = await read('S3_BUCKET');
+      const accessKeyId = await read('S3_ACCESS_KEY_ID');
+      const secret = await getDecryptedSetting(db, 'S3_SECRET_ACCESS_KEY');
+
+      let mode = await read(STORAGE_MODE_KEY);
+      if (!mode) {
+        if (managedFlag === 'true') mode = 'managed';
+        else if (bucket) mode = 'byo';
+        else mode = '';
+        await settingsQueries.upsertSetting(db, STORAGE_MODE_KEY, mode);
+      }
+
+      await settingsQueries.upsertSetting(
+        db,
+        'STORAGE_MANAGED',
+        mode === 'managed' ? 'true' : 'false'
+      );
+
+      const eligibleExisting = await read(STORAGE_MANAGED_ELIGIBLE_KEY);
+      if (!eligibleExisting) {
+        await settingsQueries.upsertSetting(
+          db,
+          STORAGE_MANAGED_ELIGIBLE_KEY,
+          managedFlag === 'true' || mode === 'managed' ? 'true' : 'false'
+        );
+      }
+
+      const shadowBucket = await read('PLATFORM_S3_BUCKET');
+      if (!shadowBucket && mode === 'managed' && bucket && accessKeyId && secret) {
+        await settingsQueries.upsertSetting(db, 'PLATFORM_S3_ENDPOINT', await read('S3_ENDPOINT'));
+        await settingsQueries.upsertSetting(db, 'PLATFORM_S3_REGION', await read('S3_REGION'));
+        await settingsQueries.upsertSetting(db, 'PLATFORM_S3_BUCKET', bucket);
+        await settingsQueries.upsertSetting(db, 'PLATFORM_S3_ACCESS_KEY_ID', accessKeyId);
+        await upsertSecretSetting(db, 'PLATFORM_S3_SECRET_ACCESS_KEY', secret);
+        await settingsQueries.upsertSetting(
+          db,
+          'PLATFORM_S3_FORCE_PATH_STYLE',
+          (await read('S3_FORCE_PATH_STYLE')) || 'false'
+        );
+        await settingsQueries.upsertSetting(db, 'PLATFORM_S3_KEY_PREFIX', await read('S3_KEY_PREFIX'));
+      }
+
+      console.log(
+        `✅ Migration 52: STORAGE_MODE=${mode}, platform S3 shadow backfilled when applicable`
+      );
+    }
   }
 ];
 

--- a/server/routes/adminPortal.js
+++ b/server/routes/adminPortal.js
@@ -28,6 +28,10 @@ import {
   markMailManagedEligible,
   mirrorActiveMailToPlatformShadow,
 } from '../utils/mailMode.js';
+import {
+  markStorageManagedEligible,
+  mirrorActiveS3ToPlatformShadow,
+} from '../utils/storageMode.js';
 import { deleteAvatarFileIfUnused } from '../utils/avatarCleanup.js';
 import { getRequestStoragePaths } from '../services/storage/index.js';
 import { getObject, filenameFromPublicUrl, purgeManagedTenantObjects } from '../services/storage/objectStorage.js';
@@ -179,7 +183,7 @@ router.put('/owner', authenticateAdminPortal, async (req, res) => {
 /**
  * Permanently delete all objects under this tenant's managed S3 prefix.
  * Used by the admin portal before DROP SCHEMA on instance destroy.
- * Skips when STORAGE_MANAGED is not true (custom buckets are left alone).
+ * Skips when STORAGE_MODE is not managed (custom buckets are left alone).
  */
 router.post('/storage/purge-managed', authenticateAdminPortal, async (req, res) => {
   try {
@@ -447,6 +451,18 @@ router.put('/settings', authenticateAdminPortal, async (req, res) => {
       if (managedMail) {
         await mirrorActiveMailToPlatformShadow(db);
         await markMailManagedEligible(db);
+      }
+    }
+    const storageKeys = ['S3_BUCKET', 'S3_SECRET_ACCESS_KEY', 'STORAGE_MANAGED', 'STORAGE_MODE'];
+    if (results.some((row) => storageKeys.includes(row.key))) {
+      const managedStorage =
+        String(settings.STORAGE_MODE || '').trim().toLowerCase() === 'managed' ||
+        String(settings.STORAGE_MANAGED || '').trim() === 'true';
+      if (managedStorage) {
+        await mirrorActiveS3ToPlatformShadow(db);
+        if (String(settings.STORAGE_MANAGED_ELIGIBLE || '').trim().toLowerCase() !== 'false') {
+          await markStorageManagedEligible(db);
+        }
       }
     }
     for (const row of results) {

--- a/server/routes/settings.js
+++ b/server/routes/settings.js
@@ -26,7 +26,12 @@ import {
   upsertSecretSetting
 } from '../utils/settingsSecrets.js';
 import { avatarUpload } from '../config/multer.js';
-import { STORAGE_MANAGED_HIDDEN_KEYS } from '../constants/storageSettings.js';
+import {
+  STORAGE_ADMIN_INTERNAL_KEYS,
+  STORAGE_MANAGED_ELIGIBLE_KEY,
+  STORAGE_MANAGED_HIDDEN_KEYS,
+  STORAGE_MODE_KEY,
+} from '../constants/storageSettings.js';
 import {
   SSO_HUB_CALLBACK_DISPLAY_KEY,
   SSO_ADMIN_INTERNAL_KEYS,
@@ -63,6 +68,12 @@ import {
   restoreManagedMail,
   switchToByoMail,
 } from '../utils/mailMode.js';
+import {
+  normalizeStorageMode,
+  resolveStorageMode,
+  storageClientPatch,
+  switchToByoStorage,
+} from '../utils/storageMode.js';
 import {
   commitUploadedFile,
   deleteObject,
@@ -303,7 +314,14 @@ router.get('/', authenticateToken, requireRole(['admin']), async (req, res, next
       host: settings.find((s) => s.key === 'SMTP_HOST')?.value,
     });
     const mailManaged = mailMode === 'managed';
-    const storageManaged = settings.find(s => s.key === 'STORAGE_MANAGED')?.value === 'true';
+    const storageMode = normalizeStorageMode(
+      settings.find((s) => s.key === STORAGE_MODE_KEY)?.value,
+      {
+        managedFlag: settings.find((s) => s.key === 'STORAGE_MANAGED')?.value,
+        bucket: settings.find((s) => s.key === 'S3_BUCKET')?.value,
+      }
+    );
+    const storageManaged = storageMode === 'managed';
     const ssoMode = normalizeGoogleSsoMode(
       settings.find((s) => s.key === GOOGLE_SSO_MODE_KEY)?.value,
       {
@@ -329,7 +347,8 @@ router.get('/', authenticateToken, requireRole(['admin']), async (req, res, next
       }
       if (
         SSO_ADMIN_INTERNAL_KEYS.includes(setting.key) ||
-        MAIL_ADMIN_INTERNAL_KEYS.includes(setting.key)
+        MAIL_ADMIN_INTERNAL_KEYS.includes(setting.key) ||
+        STORAGE_ADMIN_INTERNAL_KEYS.includes(setting.key)
       ) {
         return;
       }
@@ -372,6 +391,11 @@ router.get('/', authenticateToken, requireRole(['admin']), async (req, res, next
     }
     settingsObj[SMTP_MODE_KEY] = mailMode;
     settingsObj.MAIL_MANAGED = mailManaged ? 'true' : 'false';
+    const storageEligibleRow = settings.find((s) => s.key === STORAGE_MANAGED_ELIGIBLE_KEY);
+    settingsObj[STORAGE_MANAGED_ELIGIBLE_KEY] =
+      String(storageEligibleRow?.value || '').trim().toLowerCase() === 'true' ? 'true' : 'false';
+    settingsObj[STORAGE_MODE_KEY] = storageMode;
+    settingsObj.STORAGE_MANAGED = storageManaged ? 'true' : 'false';
 
     // Multi-tenant: overlay platform runner env so Admin shows the shared runner (read-only in UI)
     if (process.env.MULTI_TENANT === 'true') {
@@ -619,15 +643,19 @@ router.put('/', authenticateToken, requireRole(['admin']), async (req, res, next
 
     // Managed storage: tenant cannot overwrite platform S3 credentials
     if (STORAGE_MANAGED_HIDDEN_KEYS.includes(key)) {
-      const storageManaged = (await getSettingValue(db, 'STORAGE_MANAGED')) === 'true';
-      if (storageManaged) {
+      const storageMode = await resolveStorageMode(db);
+      if (storageMode === 'managed') {
         return res.status(403).json({
           error: 'S3 storage settings are managed by the platform and cannot be updated'
         });
       }
     }
 
-    if (SSO_ADMIN_INTERNAL_KEYS.includes(key) || MAIL_ADMIN_INTERNAL_KEYS.includes(key)) {
+    if (
+      SSO_ADMIN_INTERNAL_KEYS.includes(key) ||
+      MAIL_ADMIN_INTERNAL_KEYS.includes(key) ||
+      STORAGE_ADMIN_INTERNAL_KEYS.includes(key)
+    ) {
       return res.status(403).json({
         error: 'Platform shadow settings cannot be updated from the admin panel',
       });
@@ -642,7 +670,8 @@ router.put('/', authenticateToken, requireRole(['admin']), async (req, res, next
     if (
       key === GOOGLE_SSO_MANAGED_ELIGIBLE_KEY ||
       key === GOOGLE_SSO_RESUME_MODE_KEY ||
-      key === SMTP_MANAGED_ELIGIBLE_KEY
+      key === SMTP_MANAGED_ELIGIBLE_KEY ||
+      key === STORAGE_MANAGED_ELIGIBLE_KEY
     ) {
       return res.status(403).json({
         error: 'This setting is managed by the platform and cannot be updated',
@@ -694,9 +723,9 @@ router.put('/', authenticateToken, requireRole(['admin']), async (req, res, next
         (await getSettingValue(db, 'STORAGE_BACKEND')) || 'disk'
       ).toLowerCase();
       if (currentBackend !== 's3') {
-        const storageManaged = (await getSettingValue(db, 'STORAGE_MANAGED')) === 'true';
+        const storageMode = await resolveStorageMode(db);
         const testOk = (await getSettingValue(db, 'STORAGE_TEST_OK')) === 'true';
-        if (!storageManaged) {
+        if (storageMode !== 'managed') {
           if (!testOk) {
             return res.status(400).json({
               error:
@@ -780,6 +809,17 @@ router.put('/', authenticateToken, requireRole(['admin']), async (req, res, next
     ) {
       return res.status(403).json({
         error: 'Platform mail can only be restored through the dedicated endpoint',
+      });
+    }
+
+    if (
+      key === STORAGE_MODE_KEY &&
+      String(safeValue || '')
+        .trim()
+        .toLowerCase() === 'managed'
+    ) {
+      return res.status(403).json({
+        error: 'Platform storage can only be restored through the dedicated endpoint',
       });
     }
 
@@ -1051,35 +1091,18 @@ router.post('/clear-storage', authenticateToken, requireRole(['admin']), async (
 
   try {
     const db = getRequestDatabase(req);
-    const keysToClear = [...STORAGE_MANAGED_HIDDEN_KEYS];
-    const batchQueries = keysToClear.map((key) => ({
-      query: `INSERT INTO settings (key, value, updated_at) VALUES ($1, $2, CURRENT_TIMESTAMP) ON CONFLICT (key) DO UPDATE SET value = $2, updated_at = CURRENT_TIMESTAMP`,
-      params: [key, '']
-    }));
-
-    batchQueries.push({
-      query: `INSERT INTO settings (key, value, updated_at) VALUES ($1, $2, CURRENT_TIMESTAMP) ON CONFLICT (key) DO UPDATE SET value = $2, updated_at = CURRENT_TIMESTAMP`,
-      params: ['STORAGE_MANAGED', 'false']
-    });
-    batchQueries.push({
-      query: `INSERT INTO settings (key, value, updated_at) VALUES ($1, $2, CURRENT_TIMESTAMP) ON CONFLICT (key) DO UPDATE SET value = $2, updated_at = CURRENT_TIMESTAMP`,
-      params: ['STORAGE_TEST_OK', 'false']
-    });
-    // Keep STORAGE_BACKEND as-is until admin configures custom S3 and migrates
-
-    await db.executeBatchTransaction(batchQueries);
-
+    await switchToByoStorage(db);
+    const settings = storageClientPatch('byo');
     const tenantId = getTenantId(req);
-    await notificationService.publish('settings-updated', {
-      key: 'STORAGE_SETTINGS_CLEARED',
-      value: 'all',
-      timestamp: new Date().toISOString(),
-      clearedSettings: [...keysToClear, 'STORAGE_MANAGED', 'STORAGE_TEST_OK']
-    }, tenantId);
+    await notificationService.publish(
+      'settings-updated',
+      { settings, timestamp: new Date().toISOString() },
+      tenantId
+    );
 
     res.json({
-      message: 'Storage settings cleared successfully',
-      clearedSettings: [...keysToClear, 'STORAGE_MANAGED', 'STORAGE_TEST_OK']
+      message: 'Storage settings switched to your own S3',
+      settings,
     });
   } catch (error) {
     console.error('❌ Error clearing storage settings:', error);

--- a/server/services/storage/objectStorage.js
+++ b/server/services/storage/objectStorage.js
@@ -220,7 +220,7 @@ function prefixBelongsToTenant(prefix, tenantId) {
 }
 
 /**
- * Permanently delete all objects under the tenant's S3_KEY_PREFIX when STORAGE_MANAGED=true.
+ * Permanently delete all objects under the tenant's S3_KEY_PREFIX when STORAGE_MODE=managed.
  * No-op (skipped) for custom / unmanaged storage so we never touch a customer bucket from destroy.
  *
  * @param {*} db
@@ -236,7 +236,7 @@ function prefixBelongsToTenant(prefix, tenantId) {
 export async function purgeManagedTenantObjects(db, options = {}) {
   const config = await loadStorageConfig(db);
   if (!config.managed) {
-    return { skipped: true, reason: 'STORAGE_MANAGED is not true' };
+    return { skipped: true, reason: 'STORAGE_MODE is not managed' };
   }
 
   const validation = validateS3Config(config);
@@ -304,7 +304,8 @@ function sameS3Target(a, b) {
 async function persistLiveS3Config(db, config) {
   const { upsertSecretSetting } = await import('../../utils/settingsSecrets.js');
   await settingsQueries.upsertSetting(db, 'STORAGE_BACKEND', 's3');
-  await settingsQueries.upsertSetting(db, 'STORAGE_MANAGED', 'false');
+  const { markStorageByoAfterCutover } = await import('../../utils/storageMode.js');
+  await markStorageByoAfterCutover(db);
   await settingsQueries.upsertSetting(db, 'S3_ENDPOINT', config.endpoint || '');
   await settingsQueries.upsertSetting(db, 'S3_REGION', config.region || '');
   await settingsQueries.upsertSetting(db, 'S3_BUCKET', config.bucket || '');

--- a/server/services/storage/storageConfig.js
+++ b/server/services/storage/storageConfig.js
@@ -62,10 +62,15 @@ export async function loadStorageConfig(db) {
 
   const backendRaw = (await get('STORAGE_BACKEND', 'disk')).toLowerCase();
   const backend = backendRaw === 's3' ? 's3' : 'disk';
+  const { normalizeStorageMode } = await import('../../utils/storageMode.js');
+  const storageMode = normalizeStorageMode(await get('STORAGE_MODE', ''), {
+    managedFlag: await get('STORAGE_MANAGED', 'false'),
+    bucket: await get('S3_BUCKET', ''),
+  });
 
   return {
     backend,
-    managed: (await get('STORAGE_MANAGED', 'false')) === 'true',
+    managed: storageMode === 'managed',
     endpoint: await get('S3_ENDPOINT', ''),
     region: await get('S3_REGION', ''),
     bucket: await get('S3_BUCKET', ''),

--- a/server/utils/storageMode.js
+++ b/server/utils/storageMode.js
@@ -1,0 +1,147 @@
+import { settings as settingsQueries } from './sqlManager/index.js';
+import {
+  STORAGE_MANAGED_ELIGIBLE_KEY,
+  STORAGE_MODE_KEY,
+  STORAGE_MODES,
+} from '../constants/storageSettings.js';
+import {
+  getDecryptedSetting,
+  upsertSecretSetting,
+} from './settingsSecrets.js';
+
+const ACTIVE_KEYS = {
+  endpoint: 'S3_ENDPOINT',
+  region: 'S3_REGION',
+  bucket: 'S3_BUCKET',
+  accessKeyId: 'S3_ACCESS_KEY_ID',
+  secretAccessKey: 'S3_SECRET_ACCESS_KEY',
+  forcePathStyle: 'S3_FORCE_PATH_STYLE',
+  keyPrefix: 'S3_KEY_PREFIX',
+};
+
+const SHADOW_KEYS = {
+  endpoint: 'PLATFORM_S3_ENDPOINT',
+  region: 'PLATFORM_S3_REGION',
+  bucket: 'PLATFORM_S3_BUCKET',
+  accessKeyId: 'PLATFORM_S3_ACCESS_KEY_ID',
+  secretAccessKey: 'PLATFORM_S3_SECRET_ACCESS_KEY',
+  forcePathStyle: 'PLATFORM_S3_FORCE_PATH_STYLE',
+  keyPrefix: 'PLATFORM_S3_KEY_PREFIX',
+};
+
+async function getSettingValue(db, key) {
+  const row = await settingsQueries.getSettingByKey(db, key);
+  return String(row?.value ?? '').trim();
+}
+
+export function normalizeStorageMode(raw, { managedFlag = '', bucket = '' } = {}) {
+  const mode = String(raw || '')
+    .trim()
+    .toLowerCase();
+  if (STORAGE_MODES.includes(mode)) return mode;
+  if (String(managedFlag).trim().toLowerCase() === 'true') return 'managed';
+  if (String(bucket || '').trim()) return 'byo';
+  return '';
+}
+
+export async function resolveStorageMode(db) {
+  const [modeRaw, managedFlag, bucket] = await Promise.all([
+    getSettingValue(db, STORAGE_MODE_KEY),
+    getSettingValue(db, 'STORAGE_MANAGED'),
+    getSettingValue(db, ACTIVE_KEYS.bucket),
+  ]);
+  return normalizeStorageMode(modeRaw, { managedFlag, bucket });
+}
+
+export async function setStorageModeState(db, mode) {
+  await settingsQueries.upsertSetting(db, STORAGE_MODE_KEY, mode);
+  await settingsQueries.upsertSetting(db, 'STORAGE_MANAGED', mode === 'managed' ? 'true' : 'false');
+}
+
+export async function writePlatformS3Shadow(db, creds) {
+  const { endpoint, region, bucket, accessKeyId, secretAccessKey, forcePathStyle, keyPrefix } =
+    creds;
+  if (endpoint != null) await settingsQueries.upsertSetting(db, SHADOW_KEYS.endpoint, endpoint);
+  if (region != null) await settingsQueries.upsertSetting(db, SHADOW_KEYS.region, region);
+  if (bucket) await settingsQueries.upsertSetting(db, SHADOW_KEYS.bucket, bucket);
+  if (accessKeyId) await settingsQueries.upsertSetting(db, SHADOW_KEYS.accessKeyId, accessKeyId);
+  if (forcePathStyle != null) {
+    await settingsQueries.upsertSetting(db, SHADOW_KEYS.forcePathStyle, forcePathStyle);
+  }
+  if (keyPrefix != null) await settingsQueries.upsertSetting(db, SHADOW_KEYS.keyPrefix, keyPrefix);
+  if (secretAccessKey) {
+    await upsertSecretSetting(db, SHADOW_KEYS.secretAccessKey, secretAccessKey);
+  }
+}
+
+export async function mirrorActiveS3ToPlatformShadow(db) {
+  const [endpoint, region, bucket, accessKeyId, forcePathStyle, keyPrefix, secretAccessKey] =
+    await Promise.all([
+      getSettingValue(db, ACTIVE_KEYS.endpoint),
+      getSettingValue(db, ACTIVE_KEYS.region),
+      getSettingValue(db, ACTIVE_KEYS.bucket),
+      getSettingValue(db, ACTIVE_KEYS.accessKeyId),
+      getSettingValue(db, ACTIVE_KEYS.forcePathStyle),
+      getSettingValue(db, ACTIVE_KEYS.keyPrefix),
+      getDecryptedSetting(db, ACTIVE_KEYS.secretAccessKey),
+    ]);
+  if (!bucket || !accessKeyId || !secretAccessKey) return;
+  await writePlatformS3Shadow(db, {
+    endpoint,
+    region,
+    bucket,
+    accessKeyId,
+    secretAccessKey,
+    forcePathStyle: forcePathStyle || 'false',
+    keyPrefix,
+  });
+}
+
+export async function markStorageManagedEligible(db) {
+  await settingsQueries.upsertSetting(db, STORAGE_MANAGED_ELIGIBLE_KEY, 'true');
+}
+
+/** Mark BYO after S3→S3 cutover. Live dest creds are already persisted. */
+export async function markStorageByoAfterCutover(db) {
+  const current = await resolveStorageMode(db);
+  if (current === 'managed') {
+    await mirrorActiveS3ToPlatformShadow(db);
+  }
+  await setStorageModeState(db, 'byo');
+}
+
+/** Switch off platform ownership without wiping live S3 (files still on the platform bucket). */
+export async function switchToByoStorage(db) {
+  const current = await resolveStorageMode(db);
+  if (current === 'managed') {
+    await mirrorActiveS3ToPlatformShadow(db);
+  }
+  await setStorageModeState(db, 'byo');
+  await settingsQueries.upsertSetting(db, 'STORAGE_TEST_OK', 'false');
+  return { ok: true, mode: 'byo' };
+}
+
+export function storageClientPatch(mode) {
+  if (mode === 'managed') {
+    return {
+      STORAGE_MODE: 'managed',
+      STORAGE_MANAGED: 'true',
+      STORAGE_BACKEND: 's3',
+      S3_ENDPOINT: '',
+      S3_REGION: '',
+      S3_BUCKET: '',
+      S3_ACCESS_KEY_ID: '',
+      S3_SECRET_ACCESS_KEY: '',
+      S3_SECRET_ACCESS_KEY_SET: 'false',
+      S3_FORCE_PATH_STYLE: '',
+      S3_KEY_PREFIX: '',
+    };
+  }
+  if (mode === 'byo') {
+    return {
+      STORAGE_MODE: 'byo',
+      STORAGE_MANAGED: 'false',
+    };
+  }
+  return {};
+}

--- a/src/components/Admin.tsx
+++ b/src/components/Admin.tsx
@@ -982,6 +982,9 @@ const Admin: React.FC<AdminProps> = ({
       if (nextBackend === 's3' && currBackend !== 's3') {
         const managed =
           settingValueAsString(
+            settingsToSave.STORAGE_MODE || settings.STORAGE_MODE
+          ).trim() === 'managed' ||
+          settingValueAsString(
             settingsToSave.STORAGE_MANAGED || settings.STORAGE_MANAGED
           ).trim() === 'true';
         const testOk =
@@ -1098,6 +1101,10 @@ const Admin: React.FC<AdminProps> = ({
 
         // Migration detail / other large JSON blobs — not edited in the form
         if (key === 'STORAGE_MIGRATION_DETAIL') {
+          continue;
+        }
+
+        if (key === 'STORAGE_MODE' || key === 'STORAGE_MANAGED_ELIGIBLE') {
           continue;
         }
         

--- a/src/components/admin/AdminStorageTab.tsx
+++ b/src/components/admin/AdminStorageTab.tsx
@@ -17,11 +17,14 @@ import {
   adminInputBoundedClass,
 } from './AdminSection';
 import { isMultiTenantDeploy } from '../../utils/ownerSetup';
+import { resolveStorageModeFromSettings } from '../../utils/storageAdminMode';
 import { useEscapeDismiss } from '../../hooks/useEscapeDismiss';
 
 interface Settings {
   STORAGE_BACKEND?: string;
+  STORAGE_MODE?: string;
   STORAGE_MANAGED?: string;
+  STORAGE_MANAGED_ELIGIBLE?: string;
   STORAGE_TEST_OK?: string;
   STORAGE_MIGRATION_STATUS?: string;
   STORAGE_MIGRATION_DETAIL?: string;
@@ -190,7 +193,7 @@ const AdminStorageTab: React.FC<AdminStorageTabProps> = ({
     }
   }, []);
 
-  const isManaged = editingSettings.STORAGE_MANAGED === 'true';
+  const isManaged = resolveStorageModeFromSettings(editingSettings) === 'managed';
   const backend = (editingSettings.STORAGE_BACKEND || 'disk').toLowerCase();
   const savedBackend = (settings.STORAGE_BACKEND || 'disk').toLowerCase();
   const isS3 = backend === 's3';
@@ -513,6 +516,7 @@ const AdminStorageTab: React.FC<AdminStorageTabProps> = ({
       patch.STORAGE_BACKEND = 'disk';
     } else if (data.ok && data.detail?.direction === 's3-to-s3' && data.detail?.cutoverApplied) {
       patch.STORAGE_BACKEND = 's3';
+      patch.STORAGE_MODE = 'byo';
       patch.STORAGE_MANAGED = 'false';
       patch.STORAGE_TEST_OK = 'true';
       patch.S3_ENDPOINT = destDraft.S3_ENDPOINT;

--- a/src/components/ownerSetup/OwnerSetupChecklist.tsx
+++ b/src/components/ownerSetup/OwnerSetupChecklist.tsx
@@ -84,23 +84,32 @@ const OwnerSetupChecklist: React.FC = () => {
     const rawMail = (systemSettings?.MAIL_MANAGED ?? siteSettings?.MAIL_MANAGED) as
       | string
       | undefined;
+    const rawStorageMode = (systemSettings?.STORAGE_MODE ?? siteSettings?.STORAGE_MODE) as
+      | string
+      | undefined;
     const rawStorage = (systemSettings?.STORAGE_MANAGED ?? siteSettings?.STORAGE_MANAGED) as
       | string
       | undefined;
+    const storageKnown =
+      (rawStorageMode !== undefined && rawStorageMode !== '') ||
+      (rawStorage !== undefined && rawStorage !== '');
     return {
       multiTenant: isMultiTenantDeploy(),
       mailManaged:
         rawMail === undefined || rawMail === ''
           ? undefined
           : String(rawMail).toLowerCase() === 'true',
-      storageManaged:
-        rawStorage === undefined || rawStorage === ''
-          ? undefined
-          : String(rawStorage).toLowerCase() === 'true',
+      storageManaged: storageKnown
+        ? String(rawStorageMode || '').toLowerCase() === 'managed' ||
+          (String(rawStorageMode || '').trim() === '' &&
+            String(rawStorage || '').toLowerCase() === 'true')
+        : undefined,
     };
   }, [
     siteSettings?.MAIL_MANAGED,
     systemSettings?.MAIL_MANAGED,
+    siteSettings?.STORAGE_MODE,
+    systemSettings?.STORAGE_MODE,
     siteSettings?.STORAGE_MANAGED,
     systemSettings?.STORAGE_MANAGED,
   ]);

--- a/src/contexts/OwnerSetupContext.tsx
+++ b/src/contexts/OwnerSetupContext.tsx
@@ -128,19 +128,24 @@ export const OwnerSetupProvider: React.FC<OwnerSetupProviderProps> = ({
 
   const guideFieldContext = useMemo(() => {
     const rawMail = mergedSettings.MAIL_MANAGED;
+    const rawStorageMode = mergedSettings.STORAGE_MODE;
     const rawStorage = mergedSettings.STORAGE_MANAGED;
+    const storageKnown =
+      (rawStorageMode !== undefined && rawStorageMode !== '') ||
+      (rawStorage !== undefined && rawStorage !== '');
     return {
       multiTenant: isMultiTenantDeploy(),
       mailManaged:
         rawMail === undefined || rawMail === ''
           ? undefined
           : String(rawMail).toLowerCase() === 'true',
-      storageManaged:
-        rawStorage === undefined || rawStorage === ''
-          ? undefined
-          : String(rawStorage).toLowerCase() === 'true',
+      storageManaged: storageKnown
+        ? String(rawStorageMode || '').toLowerCase() === 'managed' ||
+          (String(rawStorageMode || '').trim() === '' &&
+            String(rawStorage || '').toLowerCase() === 'true')
+        : undefined,
     };
-  }, [mergedSettings.MAIL_MANAGED, mergedSettings.STORAGE_MANAGED]);
+  }, [mergedSettings.MAIL_MANAGED, mergedSettings.STORAGE_MODE, mergedSettings.STORAGE_MANAGED]);
 
   // Detect owner + load progress
   useEffect(() => {

--- a/src/utils/adminSettingsDirty.ts
+++ b/src/utils/adminSettingsDirty.ts
@@ -92,7 +92,9 @@ function isStorageKey(key: string): boolean {
   return (
     key.startsWith('S3_') ||
     key === 'STORAGE_BACKEND' ||
+    key === 'STORAGE_MODE' ||
     key === 'STORAGE_MANAGED' ||
+    key === 'STORAGE_MANAGED_ELIGIBLE' ||
     key === 'STORAGE_TEST_OK' ||
     key === 'STORAGE_MIGRATION_STATUS' ||
     key === 'STORAGE_MIGRATION_DETAIL'

--- a/src/utils/ownerSetup.ts
+++ b/src/utils/ownerSetup.ts
@@ -61,7 +61,7 @@ export type OwnerSetupGuideFieldContext = {
    */
   mailManaged?: boolean;
   /**
-   * Platform-managed object storage (`STORAGE_MANAGED === 'true'`).
+   * Platform-managed object storage (`STORAGE_MODE === 'managed'`).
    * `undefined` = unknown / not loaded yet (treat as possibly managed on MULTI_TENANT).
    */
   storageManaged?: boolean;
@@ -621,7 +621,10 @@ export function computeOwnerSetupHints(input: {
 
   const sso = String(s.GOOGLE_CLIENT_ID || '').trim().length > 0;
 
-  const storageManaged = String(s.STORAGE_MANAGED || '').toLowerCase() === 'true';
+  const storageManaged =
+    String(s.STORAGE_MODE || '').trim().toLowerCase() === 'managed' ||
+    (String(s.STORAGE_MODE || '').trim() === '' &&
+      String(s.STORAGE_MANAGED || '').toLowerCase() === 'true');
   const storageBackend = String(s.STORAGE_BACKEND || '').toLowerCase();
   const storage =
     !storageManaged &&

--- a/src/utils/storageAdminMode.ts
+++ b/src/utils/storageAdminMode.ts
@@ -1,0 +1,26 @@
+type AdminSettingsMap = Record<string, string | undefined>;
+
+export type StorageMode = 'managed' | 'byo' | '';
+
+export function resolveStorageModeFromSettings(settings: AdminSettingsMap): StorageMode {
+  const mode = String(settings.STORAGE_MODE || '').trim().toLowerCase();
+  if (mode === 'managed' || mode === 'byo') return mode;
+  if (String(settings.STORAGE_MANAGED || '').trim() === 'true') return 'managed';
+  if (String(settings.S3_BUCKET || '').trim()) return 'byo';
+  return '';
+}
+
+/** `undefined` when mode flags have not loaded yet. */
+export function storageManagedFromSettings(
+  settings: AdminSettingsMap
+): boolean | undefined {
+  const modeRaw = settings.STORAGE_MODE;
+  const flagRaw = settings.STORAGE_MANAGED;
+  if (
+    (modeRaw === undefined || modeRaw === '') &&
+    (flagRaw === undefined || flagRaw === '')
+  ) {
+    return undefined;
+  }
+  return resolveStorageModeFromSettings(settings) === 'managed';
+}


### PR DESCRIPTION
## Summary
- Add `STORAGE_MODE` (`managed` / `byo`) with `STORAGE_MANAGED` kept in sync, plus `PLATFORM_S3_*` shadows and `STORAGE_MANAGED_ELIGIBLE`.
- Migration 52 backfills existing tenants; S3→S3 cutover still writes the destination bucket and sets `byo`.
- `MANAGED_S3_*` env remains a legacy alias so current K8s ConfigMaps/secrets keep working.

## Test plan
- [ ] Restart Agila and confirm migration 52 applies (`STORAGE_MODE=managed` on platform-S3 tenants)
- [ ] Admin → System Settings → Storage: managed banner, dest form, migrate still work
- [ ] Custom/BYO S3 tenants stay `STORAGE_MODE=byo` and are not overwritten on restart
- [ ] After EKS (app.agila.dev) looks good, roll the same image to the customer K8s cluster


Made with [Cursor](https://cursor.com)