### PR TITLE
Fix notification queue INSERT column mismatch

### DIFF
--- a/server/services/notificationThrottler.js
+++ b/server/services/notificationThrottler.js
@@ -178,7 +178,7 @@ class NotificationThrottler {
               old_value, new_value, task_data, participants_data, actor_data,
               status, scheduled_send_time, first_change_time, last_change_time,
               change_count, created_at, updated_at
-            ) VALUES (?, ?, ?, NULL, 'email', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+            ) VALUES (?, ?, ?, NULL, 'email', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
           `),
             'INSERT'
           ).run(
@@ -212,7 +212,6 @@ class NotificationThrottler {
               FROM notification_queue
               WHERE user_id = ? AND task_id = ? AND status = 'pending'
                 AND COALESCE(delivery_channel, 'email') = 'email'
-            AND COALESCE(delivery_channel, 'email') = 'email'
               ORDER BY created_at DESC
               LIMIT 1
             `),


### PR DESCRIPTION
## Summary
- Email enqueue listed `change_count` without a matching `VALUES` placeholder, which Postgres rejects (`INSERT has more target columns than expressions`).
- Task notification emails never entered the queue on EKS after the 42–52 rollout.

## Test plan
- [ ] Rebuild/redeploy the tenant image from `main`
- [ ] Edit a task that should email a watcher/assignee
- [ ] Confirm no `[THROTTLER] Failed to queue notification` and a pending row appears in Admin → Notifications → Queue


Made with [Cursor](https://cursor.com)