### PR TITLE
Fix Help Assistant Go There for nested Settings and Microsoft SSO

### DIFF
--- a/scripts/harvest-help-ui-index.js
+++ b/scripts/harvest-help-ui-index.js
@@ -9,6 +9,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { hashFromAdminTourValue, validateHelpGoEntries } from '../server/config/helpAdminGoHash.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.join(__dirname, '..');
@@ -17,12 +18,15 @@ const OUT = path.join(ROOT, 'server/config/helpUiIndex.generated.json');
 
 const ATTRS = [
   { attr: 'data-setting-key', kind: 'setting' },
+  { attr: 'settingKey', kind: 'setting' },
   { attr: 'data-tour-id', kind: 'tour' },
   { attr: 'data-help-target', kind: 'help' },
   { attr: 'data-owner-setup', kind: 'ownerSetup' }
 ];
 
 const SKIP_VALUE = /\$\{|`/;
+const VALID_TARGET_ID = /^[A-Za-z][A-Za-z0-9_-]*$/;
+const SKIP_HARVEST_FILES = /(?:^|\/)adminSearchIndex\.ts$/;
 
 function walk(dir, acc = []) {
   for (const name of fs.readdirSync(dir)) {
@@ -145,31 +149,39 @@ function inferNav(kind, value, fileRel, adminByKey) {
   if (kind === 'ownerSetup') {
     return {
       navKind: 'admin',
-      hash: '#admin',
+      hash: hashFromFile(fileRel),
       adminOnly: true,
       highlights: [`[data-owner-setup="${value}"]`]
     };
   }
   if (kind === 'help') {
+    const highlights = [`[data-help-target="${value}"]`];
     if (value.startsWith('profile')) {
       return {
         navKind: 'profile',
         profileFocus: value.includes('activity') ? 'activityFeed' : 'displayName',
         adminOnly: false,
-        highlights: [`[data-help-target="${value}"]`]
+        highlights
       };
     }
-    return {
-      navKind: 'view',
-      mode: 'kanban',
-      adminOnly: false,
-      highlights: [`[data-help-target="${value}"]`]
-    };
+    if (inAdmin) {
+      return {
+        navKind: 'admin',
+        hash: hashFromFile(fileRel),
+        adminOnly: true,
+        highlights
+      };
+    }
+    if (value.includes('calendar')) {
+      return { navKind: 'view', mode: 'calendar', adminOnly: false, highlights };
+    }
+    return { navKind: 'view', mode: 'kanban', adminOnly: false, highlights };
   }
   // tour
   const highlights = [`[data-tour-id="${value}"]`];
   if (value.startsWith('admin-') || inAdmin) {
-    return { navKind: 'admin', hash: '#admin', adminOnly: true, highlights };
+    const hash = hashFromAdminTourValue(value) || hashFromFile(fileRel);
+    return { navKind: 'admin', hash, adminOnly: true, highlights };
   }
   if (value.includes('report')) {
     return { navKind: 'page', page: 'reports', adminOnly: false, highlights };
@@ -177,13 +189,39 @@ function inferNav(kind, value, fileRel, adminByKey) {
   if (value.includes('gantt')) {
     return { navKind: 'view', mode: 'gantt', adminOnly: false, highlights };
   }
-  if (value.includes('list-view') || value === 'list-view') {
+  if (value === 'column-visibility' || value.includes('list-view') || /ListView/.test(rel)) {
     return { navKind: 'view', mode: 'list', adminOnly: false, highlights };
   }
   if (value.includes('profile')) {
     return { navKind: 'view', mode: 'kanban', adminOnly: false, highlights };
   }
   return { navKind: 'view', mode: 'kanban', adminOnly: false, highlights };
+}
+
+function extractAttrValues(source, attr) {
+  const out = [];
+  const re = new RegExp(`${attr}=(\\{[^}]*\\}|["'\`][^"'\`]+["'\`])`, 'g');
+  let m;
+  while ((m = re.exec(source))) {
+    const raw = m[1];
+    if (raw.startsWith('{')) {
+      const quoted = raw.match(/["'`]([^"'`]+)["'`]/g) || [];
+      for (const q of quoted) {
+        const value = q.slice(1, -1).trim();
+        if (value && value !== 'undefined') out.push({ value, index: m.index });
+      }
+    } else {
+      out.push({ value: raw.slice(1, -1).trim(), index: m.index });
+    }
+  }
+  return out;
+}
+
+function isHarvestableValue(kind, value) {
+  if (!value || SKIP_VALUE.test(value) || !VALID_TARGET_ID.test(value)) return false;
+  if (value.endsWith('-')) return false;
+  if (kind === 'tour' && (value === 'admin' || value === 'admin-')) return false;
+  return true;
 }
 
 function buildEntries() {
@@ -195,21 +233,18 @@ function buildEntries() {
   for (const file of files) {
     const source = fs.readFileSync(file, 'utf8');
     const fileRel = path.relative(ROOT, file);
+    if (SKIP_HARVEST_FILES.test(fileRel.replace(/\\/g, '/'))) continue;
     for (const { attr, kind } of ATTRS) {
-      // Matches literals (attr="x") and conditional attributes (attr={cond ? 'x' : undefined});
-      // the brace-free lead-in keeps the match inside a single JSX expression.
-      const re = new RegExp(`${attr}=(?:\\{[^{}]{0,80}?)?["'\`]([^"'\`]+)["'\`]`, 'g');
-      let m;
-      while ((m = re.exec(source))) {
+      for (const hit of extractAttrValues(source, attr)) {
         if (kind === 'setting' || kind === 'ownerSetup') {
           if (/HelpModal\.tsx$/.test(fileRel)) continue;
         }
-        const value = m[1].trim();
-        if (!value || SKIP_VALUE.test(value)) continue;
+        const value = hit.value;
+        if (!isHarvestableValue(kind, value)) continue;
         const id = `${kind}:${value}`;
         if (seen.has(id)) continue;
         const nav = inferNav(kind, value, fileRel, adminByKey);
-        const nearby = nearbyTKeys(source, m.index);
+        const nearby = nearbyTKeys(source, hit.index);
         const fromNearby = nearby.map((k) => lookupLocale(locales, k));
         let en = '';
         let fr = '';
@@ -261,6 +296,21 @@ function buildEntries() {
           extraEn += ' full page task page TaskPage ticket direct link';
           extraFr += ' page tache vue page ticket lien direct';
         }
+        if (value === 'm365-sso') {
+          const lab = lookupLocale(locales, 'admin.sso.m365Title');
+          en = lab.en || en;
+          fr = lab.fr || fr;
+          extraEn += ' oauth microsoft azure entra login create add provider SSO';
+          extraFr += ' oauth microsoft azure entra connexion creer ajouter fournisseur SSO';
+        }
+        if (value === 'github-sso') {
+          extraEn += ' oauth github login create add provider SSO';
+          extraFr += ' oauth github connexion creer ajouter fournisseur SSO';
+        }
+        if (value === 'sso-add-provider') {
+          extraEn += ' add provider oauth sso microsoft github google';
+          extraFr += ' ajouter fournisseur oauth sso microsoft github google';
+        }
 
         seen.set(id, {
           id,
@@ -282,6 +332,39 @@ function buildEntries() {
         });
       }
     }
+    if (source.includes('TOUR_ID_BY_TAB')) {
+      const tourIds = source.matchAll(/'(admin-[a-z0-9-]+)'/g);
+      for (const tm of tourIds) {
+        const value = tm[1];
+        if (!isHarvestableValue('tour', value) || seen.has(`tour:${value}`)) continue;
+        const nav = inferNav('tour', value, fileRel, adminByKey);
+        seen.set(`tour:${value}`, {
+          id: `tour:${value}`,
+          attr: 'tour',
+          value,
+          en: value.replace(/[-_]/g, ' '),
+          fr: value.replace(/[-_]/g, ' '),
+          searchEn: value,
+          searchFr: value,
+          kind: nav.navKind,
+          hash: nav.hash || undefined,
+          highlights: nav.highlights,
+          adminOnly: Boolean(nav.adminOnly),
+          audience: nav.adminOnly ? 'admin' : 'user',
+          file: fileRel
+        });
+      }
+    }
+  }
+
+  const logo = seen.get('setting:SITE_LOGO');
+  if (logo && !seen.has('setting:SITE_LOGO_DARK')) {
+    seen.set('setting:SITE_LOGO_DARK', {
+      ...logo,
+      id: 'setting:SITE_LOGO_DARK',
+      value: 'SITE_LOGO_DARK',
+      highlights: ['[data-setting-key="SITE_LOGO_DARK"]']
+    });
   }
 
   return [...seen.values()].sort((a, b) => a.id.localeCompare(b.id));
@@ -293,6 +376,24 @@ function canonical(entries) {
 
 const check = process.argv.includes('--check');
 const entries = buildEntries();
+const helpModal = fs.readFileSync(path.join(SRC, 'components/HelpModal.tsx'), 'utf8');
+const helpModalHashes = [...helpModal.matchAll(/adminGo\(\s*'([^']+)'/g)].map((m) => m[1]);
+const hashErrors = validateHelpGoEntries(entries, helpModalHashes);
+for (const [key, meta] of parseAdminSearchIndex()) {
+  const row = entries.find((e) => e.id === `setting:${key}`);
+  if (!row) {
+    hashErrors.push(`adminSearchIndex setting ${key} has no harvested Go There row`);
+    continue;
+  }
+  if (row.hash !== meta.hash) {
+    hashErrors.push(`setting:${key} hash ${row.hash} != adminSearchIndex ${meta.hash}`);
+  }
+}
+if (hashErrors.length) {
+  console.error('Help Go There hashes failed validation:');
+  for (const err of hashErrors) console.error(`  - ${err}`);
+  process.exit(1);
+}
 const next = canonical(entries);
 
 if (check) {

--- a/server/config/helpAdminGoHash.js
+++ b/server/config/helpAdminGoHash.js
@@ -1,0 +1,124 @@
+/**
+ * Deep-link hashes for Help “Go there”.
+ * Keep aligned with src/utils/adminNavigation.ts (ADMIN_LEGACY_TAB_HASH / adminHashForTabId).
+ */
+
+const ADMIN_TOUR_HASH = {
+  sso: '#admin#system-settings#sso',
+  'mail-server': '#admin#notifications#mail-server',
+  storage: '#admin#system-settings#storage',
+  lifecycle: '#admin#project-settings#lifecycle',
+  'lifecycle-content': '#admin#project-settings#lifecycle',
+  'notification-queue': '#admin#notifications#queue',
+  queue: '#admin#notifications#queue',
+  'notification-settings': '#admin#notifications#notification-settings',
+  notifications: '#admin#notifications#notification-settings',
+  'sprint-settings': '#admin#project-settings#sprint-settings',
+  reporting: '#admin#project-settings#reporting',
+  ai: '#admin#system-settings#ai',
+  'file-uploads': '#admin#system-settings#file-uploads',
+  uploads: '#admin#system-settings#file-uploads',
+  webhooks: '#admin#notifications#webhooks',
+  'project-settings': '#admin#project-settings#project',
+  'project-general': '#admin#project-settings#project',
+  'system-settings': '#admin#system-settings#sso',
+  'app-settings': '#admin#app-settings#user-interface',
+  'features-panel': '#admin#project-settings#features',
+  features: '#admin#project-settings#features',
+  users: '#admin#users',
+  'site-settings': '#admin#site-settings',
+  tags: '#admin#tags',
+  priorities: '#admin#priorities',
+  licensing: '#admin#licensing'
+};
+
+const GENERIC_ADMIN_TOUR = new Set(['', 'tab', 'tabs']);
+
+/** Hashes Admin actually mounts. Bare `#admin` only opens the Users tab. */
+export const CANONICAL_ADMIN_HASHES = new Set([
+  '#admin',
+  '#admin#users',
+  '#admin#site-settings',
+  '#admin#tags',
+  '#admin#priorities',
+  '#admin#licensing',
+  '#admin#system-settings#sso',
+  '#admin#system-settings#storage',
+  '#admin#system-settings#file-uploads',
+  '#admin#system-settings#ai',
+  '#admin#notifications#notification-settings',
+  '#admin#notifications#mail-server',
+  '#admin#notifications#webhooks',
+  '#admin#notifications#queue',
+  '#admin#app-settings#user-interface',
+  '#admin#app-settings#troubleshooting',
+  '#admin#project-settings#project',
+  '#admin#project-settings#features',
+  '#admin#project-settings#sprint-settings',
+  '#admin#project-settings#reporting',
+  '#admin#project-settings#lifecycle'
+]);
+
+const ALLOWED_SHALLOW_ADMIN_IDS = new Set(['tour:admin-tab', 'tour:admin-tabs']);
+
+/** Map a data-tour-id like admin-sprint-settings to a Settings hash. */
+export function hashFromAdminTourValue(value) {
+  const raw = String(value || '');
+  if (!raw.startsWith('admin-')) return null;
+  const tabId = raw.slice('admin-'.length);
+  if (GENERIC_ADMIN_TOUR.has(tabId)) return '#admin';
+  if (ADMIN_TOUR_HASH[tabId]) return ADMIN_TOUR_HASH[tabId];
+  return `#admin#${tabId}`;
+}
+
+/**
+ * `#admin` only opens Settings on the Users tab. Nested tour / owner-setup
+ * targets need the compound hash or the highlight never mounts.
+ */
+export function refineAdminGoHash(row, fallbackHash) {
+  const current = row?.hash || fallbackHash || '#admin';
+  if (current && current !== '#admin' && current !== 'admin') return current;
+  const fromTour = hashFromAdminTourValue(row?.value);
+  if (fromTour && fromTour !== '#admin') return fromTour;
+  return current.startsWith('#') ? current : `#${current}`;
+}
+
+function normalizeHash(hash) {
+  if (!hash) return '';
+  return hash.startsWith('#') ? hash : `#${hash}`;
+}
+
+/** Fail the harvest/check if a Go There URL cannot open the highlighted panel. */
+export function validateHelpGoEntries(entries, extraHashes = []) {
+  const errors = [];
+  for (const row of entries) {
+    if (row.kind === 'admin') {
+      const hash = normalizeHash(refineAdminGoHash(row, row.hash || '#admin'));
+      if (!CANONICAL_ADMIN_HASHES.has(hash)) {
+        errors.push(`${row.id} has unknown Settings hash ${hash} (${row.file})`);
+      }
+      if (hash === '#admin' && !ALLOWED_SHALLOW_ADMIN_IDS.has(row.id)) {
+        errors.push(`${row.id} still uses #admin; nested Settings chrome will not mount (${row.file})`);
+      }
+      if (row.attr === 'setting' && !/^[A-Z][A-Z0-9_]*$/.test(row.value || '')) {
+        errors.push(`${row.id} is not a real setting key`);
+      }
+    }
+    if (row.attr === 'help' && /\/admin\//.test(row.file || '') && row.kind !== 'admin') {
+      errors.push(`${row.id} is in Admin UI but Go There kind is ${row.kind} (${row.file})`);
+    }
+    if (row.id === 'tour:column-visibility' && row.mode !== 'list') {
+      errors.push('tour:column-visibility must switch to list view');
+    }
+    if (row.id === 'help:calendar-column-filter' && row.mode !== 'calendar') {
+      errors.push('help:calendar-column-filter must switch to calendar view');
+    }
+  }
+  for (const raw of extraHashes) {
+    const hash = normalizeHash(raw);
+    if (!CANONICAL_ADMIN_HASHES.has(hash)) {
+      errors.push(`HelpModal adminGo('${raw}') is not a canonical Settings hash`);
+    }
+  }
+  return errors;
+}

--- a/server/config/helpUiIndex.generated.json
+++ b/server/config/helpUiIndex.generated.json
@@ -19,20 +19,37 @@
       "file": "src/components/ActivityFeed.tsx"
     },
     {
+      "id": "help:calendar-column-filter",
+      "attr": "help",
+      "value": "calendar-column-filter",
+      "en": "calendar column filter",
+      "fr": "calendar column filter",
+      "searchEn": "calendar column filter  calendar-column-filter",
+      "searchFr": "calendar column filter  calendar-column-filter",
+      "kind": "view",
+      "mode": "calendar",
+      "highlights": [
+        "[data-help-target=\"calendar-column-filter\"]"
+      ],
+      "adminOnly": false,
+      "audience": "user",
+      "file": "src/components/ColumnFilterDropdown.tsx"
+    },
+    {
       "id": "help:github-sso",
       "attr": "help",
       "value": "github-sso",
       "en": "GitHub Single Sign-on Configuration",
       "fr": "Configuration de l’authentification unique GitHub",
-      "searchEn": "GitHub Single Sign-on Configuration GitHub Single Sign-on Configuration Disabled github-sso",
-      "searchFr": "Configuration de l’authentification unique GitHub Configuration de l’authentification unique GitHub Désactivé github-sso",
-      "kind": "view",
-      "mode": "kanban",
+      "searchEn": "GitHub Single Sign-on Configuration GitHub Single Sign-on Configuration Disabled oauth github login create add provider SSO github-sso",
+      "searchFr": "Configuration de l’authentification unique GitHub Configuration de l’authentification unique GitHub Désactivé oauth github connexion creer ajouter fournisseur SSO github-sso",
+      "kind": "admin",
+      "hash": "#admin#system-settings#sso",
       "highlights": [
         "[data-help-target=\"github-sso\"]"
       ],
-      "adminOnly": false,
-      "audience": "user",
+      "adminOnly": true,
+      "audience": "admin",
       "file": "src/components/admin/AdminSSOTab.tsx"
     },
     {
@@ -56,17 +73,17 @@
       "id": "help:m365-sso",
       "attr": "help",
       "value": "m365-sso",
-      "en": "e.g., {{callbackUrl}}",
-      "fr": "ex. : {{callbackUrl}}",
-      "searchEn": "e.g., {{callbackUrl}} e.g., {{callbackUrl}} Microsoft 365 Single Sign-on Configuration Disabled m365-sso",
-      "searchFr": "ex. : {{callbackUrl}} ex. : {{callbackUrl}} Configuration de l’authentification unique Microsoft 365 Désactivé m365-sso",
-      "kind": "view",
-      "mode": "kanban",
+      "en": "Microsoft 365 Single Sign-on Configuration",
+      "fr": "Configuration de l’authentification unique Microsoft 365",
+      "searchEn": "Microsoft 365 Single Sign-on Configuration e.g., {{callbackUrl}} Microsoft 365 Single Sign-on Configuration Disabled oauth microsoft azure entra login create add provider SSO m365-sso",
+      "searchFr": "Configuration de l’authentification unique Microsoft 365 ex. : {{callbackUrl}} Configuration de l’authentification unique Microsoft 365 Désactivé oauth microsoft azure entra connexion creer ajouter fournisseur SSO m365-sso",
+      "kind": "admin",
+      "hash": "#admin#system-settings#sso",
       "highlights": [
         "[data-help-target=\"m365-sso\"]"
       ],
-      "adminOnly": false,
-      "audience": "user",
+      "adminOnly": true,
+      "audience": "admin",
       "file": "src/components/admin/AdminSSOTab.tsx"
     },
     {
@@ -85,6 +102,23 @@
       "adminOnly": false,
       "audience": "user",
       "file": "src/components/Profile.tsx"
+    },
+    {
+      "id": "help:sso-add-provider",
+      "attr": "help",
+      "value": "sso-add-provider",
+      "en": "Remove {{provider}} sign-in",
+      "fr": "Retirer la connexion {{provider}}",
+      "searchEn": "Remove {{provider}} sign-in Remove {{provider}} sign-in Single sign-on Add provider add provider oauth sso microsoft github google sso-add-provider",
+      "searchFr": "Retirer la connexion {{provider}} Retirer la connexion {{provider}} Authentification unique Ajouter un fournisseur ajouter fournisseur oauth sso microsoft github google sso-add-provider",
+      "kind": "admin",
+      "hash": "#admin#system-settings#sso",
+      "highlights": [
+        "[data-help-target=\"sso-add-provider\"]"
+      ],
+      "adminOnly": true,
+      "audience": "admin",
+      "file": "src/components/admin/AdminSSOTab.tsx"
     },
     {
       "id": "help:task-page-link",
@@ -112,7 +146,7 @@
       "searchEn": "Add Priority Add Priority add-priority",
       "searchFr": "Ajouter une priorité Ajouter une priorité add-priority",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#priorities",
       "highlights": [
         "[data-owner-setup=\"add-priority\"]"
       ],
@@ -129,7 +163,7 @@
       "searchEn": "Add Tag Add Tag add-tag",
       "searchFr": "Ajouter une étiquette Ajouter une étiquette add-tag",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#tags",
       "highlights": [
         "[data-owner-setup=\"add-tag\"]"
       ],
@@ -146,7 +180,7 @@
       "searchEn": "Failed to check user limit. Please try again. Failed to check user limit. Please try again. User limit reached. Cannot create more users. Add User add-user",
       "searchFr": "Échec de la vérification de la limite d'utilisateurs. Veuillez réessayer. Échec de la vérification de la limite d'utilisateurs. Veuillez réessayer. Limite d'utilisateurs atteinte. Impossible de créer plus d'utilisateurs. Ajouter un utilisateur add-user",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#users",
       "highlights": [
         "[data-owner-setup=\"add-user\"]"
       ],
@@ -163,7 +197,7 @@
       "searchEn": "Create Sprint Create Sprint Edit Sprint Create a new sprint create-sprint",
       "searchFr": "Créer un sprint Créer un sprint Modifier le sprint Créer un nouveau sprint create-sprint",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#project-settings#sprint-settings",
       "highlights": [
         "[data-owner-setup=\"create-sprint\"]"
       ],
@@ -180,7 +214,7 @@
       "searchEn": "Open Customer Portal Open Customer Portal Website URL not configured. Please contact your system administrator to set the WEBSITE_URL in Site Settings. Overview Manage Subscription licensing-panel",
       "searchFr": "Ouvrir le portail client Ouvrir le portail client URL du site Web non configurée. Veuillez contacter votre administrateur système pour définir WEBSITE_URL dans les paramètres du site. Vue d'ensemble Gérer l'abonnement licensing-panel",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#licensing",
       "highlights": [
         "[data-owner-setup=\"licensing-panel\"]"
       ],
@@ -197,7 +231,7 @@
       "searchEn": "Force path-style URLs Force path-style URLs optional Leave off for Amazon S3. Turn on for MinIO and some S3-compatible providers. Testing… Test S3 connection Test passed. storage-test-connection",
       "searchFr": "Forcer les URL path-style Forcer les URL path-style optionnel Laissez désactivé pour Amazon S3. Activez pour MinIO et certains fournisseurs compatibles S3. Test en cours… Tester la connexion S3 Test réussi. storage-test-connection",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#system-settings#storage",
       "highlights": [
         "[data-owner-setup=\"storage-test-connection\"]"
       ],
@@ -214,7 +248,7 @@
       "searchEn": "Managed Email Service Managed Email Service Your email service is currently managed by Agila. This means emails are sent using our infrastructure with the sender address Switch to Custom SMTP switch-custom-smtp",
       "searchFr": "Service de messagerie géré Service de messagerie géré Votre service de messagerie est actuellement géré par Agila. Cela signifie que les emails sont envoyés en utilisant notre infrastructure avec l'adresse d'expéditeur Passer à SMTP personnalisé switch-custom-smtp",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#notifications#mail-server",
       "highlights": [
         "[data-owner-setup=\"switch-custom-smtp\"]"
       ],
@@ -231,30 +265,13 @@
       "searchEn": "Managed Storage Managed Storage Object storage is provided by Agila. Attachments and avatars use the platform S3 configuration. Use your own S3 bucket Configure the destination, test it, then run Migrate S3 → S3. Platform credentials stay until cutover. switch-custom-storage",
       "searchFr": "Stockage géré Stockage géré Le stockage objet est fourni par Agila. Les pièces jointes et avatars utilisent la configuration S3 de la plateforme. Utiliser votre propre bucket S3 Configurez la destination, testez-la, puis lancez Migrer S3 → S3. Les identifiants plateforme restent jusqu’au basculement. switch-custom-storage",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#system-settings#storage",
       "highlights": [
         "[data-owner-setup=\"switch-custom-storage\"]"
       ],
       "adminOnly": true,
       "audience": "admin",
       "file": "src/components/admin/AdminStorageTab.tsx"
-    },
-    {
-      "id": "setting:…",
-      "attr": "setting",
-      "value": "…",
-      "en": "…",
-      "fr": "…",
-      "searchEn": "…  …",
-      "searchFr": "…  …",
-      "kind": "admin",
-      "hash": "#admin",
-      "highlights": [
-        "[data-setting-key=\"…\"]"
-      ],
-      "adminOnly": true,
-      "audience": "admin",
-      "file": "src/constants/adminSearchIndex.ts"
     },
     {
       "id": "setting:AI_API_BASE_URL",
@@ -427,6 +444,57 @@
       "file": "src/components/admin/AdminAppSettingsTab.tsx"
     },
     {
+      "id": "setting:DEFAULT_ACTIVITY_FEED_HEIGHT",
+      "attr": "setting",
+      "value": "DEFAULT_ACTIVITY_FEED_HEIGHT",
+      "en": "Default Height",
+      "fr": "Hauteur par défaut",
+      "searchEn": "Default Height Default Height Default height in pixels ({{min}}–{{max}}) activity feed profile DEFAULT_ACTIVITY_FEED_HEIGHT",
+      "searchFr": "Hauteur par défaut Hauteur par défaut Hauteur par défaut en pixels ({{min}}–{{max}}) fil activite profil DEFAULT_ACTIVITY_FEED_HEIGHT",
+      "kind": "admin",
+      "hash": "#admin#app-settings#user-interface",
+      "highlights": [
+        "[data-setting-key=\"DEFAULT_ACTIVITY_FEED_HEIGHT\"]"
+      ],
+      "adminOnly": true,
+      "audience": "admin",
+      "file": "src/components/admin/AdminAppSettingsTab.tsx"
+    },
+    {
+      "id": "setting:DEFAULT_ACTIVITY_FEED_POSITION",
+      "attr": "setting",
+      "value": "DEFAULT_ACTIVITY_FEED_POSITION",
+      "en": "Enabled",
+      "fr": "Activé",
+      "searchEn": "Enabled Enabled Disabled Default Position Which side to dock to, how far from that edge ({{min}}–{{max}}px), and how far from the top ({{yMin}}–{{yMax}}px). Inset is the gap from the edge — separate from panel width. activity feed profile DEFAULT_ACTIVITY_FEED_POSITION",
+      "searchFr": "Activé Activé Désactivé Position par défaut De quel côté ancrer le panneau, à quelle distance de ce bord ({{min}}–{{max}} px), et à quelle distance du haut ({{yMin}}–{{yMax}} px). La marge est l’espace depuis le bord — distincte de la largeur du panneau. fil activite profil DEFAULT_ACTIVITY_FEED_POSITION",
+      "kind": "admin",
+      "hash": "#admin#app-settings#user-interface",
+      "highlights": [
+        "[data-setting-key=\"DEFAULT_ACTIVITY_FEED_POSITION\"]"
+      ],
+      "adminOnly": true,
+      "audience": "admin",
+      "file": "src/components/admin/AdminAppSettingsTab.tsx"
+    },
+    {
+      "id": "setting:DEFAULT_ACTIVITY_FEED_WIDTH",
+      "attr": "setting",
+      "value": "DEFAULT_ACTIVITY_FEED_WIDTH",
+      "en": "Default Position",
+      "fr": "Position par défaut",
+      "searchEn": "Default Position Default Position Default Width Default width in pixels ({{min}}–{{max}}) activity feed profile DEFAULT_ACTIVITY_FEED_WIDTH",
+      "searchFr": "Position par défaut Position par défaut Largeur par défaut Largeur par défaut en pixels ({{min}}–{{max}}) fil activite profil DEFAULT_ACTIVITY_FEED_WIDTH",
+      "kind": "admin",
+      "hash": "#admin#app-settings#user-interface",
+      "highlights": [
+        "[data-setting-key=\"DEFAULT_ACTIVITY_FEED_WIDTH\"]"
+      ],
+      "adminOnly": true,
+      "audience": "admin",
+      "file": "src/components/admin/AdminAppSettingsTab.tsx"
+    },
+    {
       "id": "setting:DEFAULT_BOARD_COLUMNS",
       "attr": "setting",
       "value": "DEFAULT_BOARD_COLUMNS",
@@ -455,6 +523,40 @@
       "hash": "#admin#project-settings#project",
       "highlights": [
         "[data-setting-key=\"DEFAULT_FINISHED_COLUMN_NAMES\"]"
+      ],
+      "adminOnly": true,
+      "audience": "admin",
+      "file": "src/components/admin/AdminProjectSettingsTab.tsx"
+    },
+    {
+      "id": "setting:DEFAULT_PROJ_PREFIX",
+      "attr": "setting",
+      "value": "DEFAULT_PROJ_PREFIX",
+      "en": "DEFAULT PROJ PREFIX",
+      "fr": "DEFAULT PROJ PREFIX",
+      "searchEn": "DEFAULT PROJ PREFIX  DEFAULT_PROJ_PREFIX",
+      "searchFr": "DEFAULT PROJ PREFIX  DEFAULT_PROJ_PREFIX",
+      "kind": "admin",
+      "hash": "#admin#project-settings#project",
+      "highlights": [
+        "[data-setting-key=\"DEFAULT_PROJ_PREFIX\"]"
+      ],
+      "adminOnly": true,
+      "audience": "admin",
+      "file": "src/components/admin/AdminProjectSettingsTab.tsx"
+    },
+    {
+      "id": "setting:DEFAULT_TASK_PREFIX",
+      "attr": "setting",
+      "value": "DEFAULT_TASK_PREFIX",
+      "en": "DEFAULT TASK PREFIX",
+      "fr": "DEFAULT TASK PREFIX",
+      "searchEn": "DEFAULT TASK PREFIX  DEFAULT_TASK_PREFIX",
+      "searchFr": "DEFAULT TASK PREFIX  DEFAULT_TASK_PREFIX",
+      "kind": "admin",
+      "hash": "#admin#project-settings#project",
+      "highlights": [
+        "[data-setting-key=\"DEFAULT_TASK_PREFIX\"]"
       ],
       "adminOnly": true,
       "audience": "admin",
@@ -903,6 +1005,23 @@
       "file": "src/utils/ownerSetup.ts"
     },
     {
+      "id": "setting:SITE_LOGO_DARK",
+      "attr": "setting",
+      "value": "SITE_LOGO_DARK",
+      "en": "Site Logo",
+      "fr": "Logo du site",
+      "searchEn": "Site Logo  SITE_LOGO",
+      "searchFr": "Logo du site  SITE_LOGO",
+      "kind": "admin",
+      "hash": "#admin#site-settings",
+      "highlights": [
+        "[data-setting-key=\"SITE_LOGO_DARK\"]"
+      ],
+      "adminOnly": true,
+      "audience": "admin",
+      "file": "src/utils/ownerSetup.ts"
+    },
+    {
       "id": "setting:SITE_NAME",
       "attr": "setting",
       "value": "SITE_NAME",
@@ -1141,6 +1260,23 @@
       "file": "src/components/admin/AdminMailTab.tsx"
     },
     {
+      "id": "setting:TASK_NOTIFICATION_CHANNELS",
+      "attr": "setting",
+      "value": "TASK_NOTIFICATION_CHANNELS",
+      "en": "Delivery channel",
+      "fr": "Canal d'envoi",
+      "searchEn": "Delivery channel Delivery channel Choose whether task activity is emailed, sent to webhooks, or both. TASK_NOTIFICATION_CHANNELS",
+      "searchFr": "Canal d'envoi Canal d'envoi Choisissez si l'activité des tâches est envoyée par email, par webhooks, ou les deux. TASK_NOTIFICATION_CHANNELS",
+      "kind": "admin",
+      "hash": "#admin#notifications#webhooks",
+      "highlights": [
+        "[data-setting-key=\"TASK_NOTIFICATION_CHANNELS\"]"
+      ],
+      "adminOnly": true,
+      "audience": "admin",
+      "file": "src/components/admin/AdminNotificationChannelMode.tsx"
+    },
+    {
       "id": "setting:TROUBLESHOOTING_SECTION",
       "attr": "setting",
       "value": "TROUBLESHOOTING_SECTION",
@@ -1192,6 +1328,23 @@
       "file": "src/components/admin/AdminWebhooksTab.tsx"
     },
     {
+      "id": "setting:WEBHOOKS_LIST",
+      "attr": "setting",
+      "value": "WEBHOOKS_LIST",
+      "en": "Webhooks",
+      "fr": "Webhooks",
+      "searchEn": "Webhooks Test webhook Webhooks Loading… Create a new outgoing webhook WEBHOOKS_LIST",
+      "searchFr": "Webhooks Tester le webhook Webhooks Chargement… Créer un nouveau webhook sortant WEBHOOKS_LIST",
+      "kind": "admin",
+      "hash": "#admin#notifications#webhooks",
+      "highlights": [
+        "[data-setting-key=\"WEBHOOKS_LIST\"]"
+      ],
+      "adminOnly": true,
+      "audience": "admin",
+      "file": "src/components/admin/AdminWebhooksTab.tsx"
+    },
+    {
       "id": "tour:add-board-button",
       "attr": "tour",
       "value": "add-board-button",
@@ -1226,38 +1379,21 @@
       "file": "src/components/Column.tsx"
     },
     {
-      "id": "tour:admin-",
-      "attr": "tour",
-      "value": "admin-",
-      "en": "admin ",
-      "fr": "admin ",
-      "searchEn": "admin   admin-",
-      "searchFr": "admin   admin-",
-      "kind": "admin",
-      "hash": "#admin",
-      "highlights": [
-        "[data-tour-id=\"admin-\"]"
-      ],
-      "adminOnly": true,
-      "audience": "admin",
-      "file": "src/contexts/TourContext.tsx"
-    },
-    {
       "id": "tour:admin-ai",
       "attr": "tour",
       "value": "admin-ai",
-      "en": "Enable the in-app Agent, connect an LLM provider, and configure the runner that executes coding jobs.",
-      "fr": "Activez l'Agent intégré, connectez un fournisseur LLM et configurez le runner qui exécute les tâches de code.",
-      "searchEn": "Enable the in-app Agent, connect an LLM provider, and configure the runner that executes coding jobs. System Settings groups SSO, storage, file uploads, and AI for this instance. Configure Single Sign-On (SSO) authentication using Google OAuth. Enable or disable Google login and manage OAuth credentials. Choose how attachments and avatars are stored — local disk or S3-compatible object storage — and test or migrate between backends. Set attachment size limits and which file types users may upload. Enable the in-app Agent, connect an LLM provider, and configure the runner that executes coding jobs. Notifications groups email delivery settings, the mail server, webhooks, and the outgoing queue. Configure email server settings for sending notifications, invitations, and other system emails. S",
-      "searchFr": "Activez l'Agent intégré, connectez un fournisseur LLM et configurez le runner qui exécute les tâches de code. Les Paramètres système regroupent le SSO, le stockage, les téléversements et l'IA pour cette instance. Configurez l'authentification Single Sign-On (SSO) à l'aide de Google OAuth. Activez ou désactivez la connexion Google et gérez les identifiants OAuth. Choisissez comment les pièces jointes et avatars sont stockés — disque local ou stockage objet compatible S3 — et testez ou migrez entre les backends. Définissez les limites de taille et les types de fichiers que les utilisateurs peuvent téléverser. Activez l'Agent intégré, connectez un fournisseur LLM et configurez le runner qui exécute les tâches de code. Notifications regroupe les paramètres d'envoi d'e-mails, le serveur de mess",
+      "en": "admin ai",
+      "fr": "admin ai",
+      "searchEn": "admin-ai",
+      "searchFr": "admin-ai",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#system-settings#ai",
       "highlights": [
         "[data-tour-id=\"admin-ai\"]"
       ],
       "adminOnly": true,
       "audience": "admin",
-      "file": "src/components/tour/TourSteps.tsx"
+      "file": "src/components/admin/AdminSystemSettingsTab.tsx"
     },
     {
       "id": "tour:admin-app-settings",
@@ -1268,13 +1404,30 @@
       "searchEn": "Configure application settings, user preferences, and system behavior in the App Settings tab. Notifications groups email delivery settings, the mail server, webhooks, and the outgoing queue. Configure email server settings for sending notifications, invitations, and other system emails. Set up SMTP server details and test email functionality. Create and manage tags to categorize and organize your tasks effectively. Set up priority levels for your tasks to help team members understand urgency. Configure application settings, user preferences, and system behavior in the App Settings tab. Manage project-specific settings, workflows, and custom configurations in Project Settings. Create and manage sprints for your projects. Sprints are time-based planning periods used to organize tasks and tr",
       "searchFr": "Configurez les paramètres de l'application, les préférences utilisateur et le comportement du système dans l'onglet Paramètres de l'application. Notifications regroupe les paramètres d'envoi d'e-mails, le serveur de messagerie, les webhooks et la file d'attente. Configurez les paramètres du serveur de messagerie pour l'envoi de notifications, d'invitations et d'autres e-mails système. Configurez les détails du serveur SMTP et testez la fonctionnalité e-mail. Créez et gérez des étiquettes pour catégoriser et organiser efficacement vos tâches. Configurez les niveaux de priorité pour vos tâches afin d'aider les membres de l'équipe à comprendre l'urgence. Configurez les paramètres de l'application, les préférences utilisateur et le comportement du système dans l'onglet Paramètres de l'applicat",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#app-settings#user-interface",
       "highlights": [
         "[data-tour-id=\"admin-app-settings\"]"
       ],
       "adminOnly": true,
       "audience": "admin",
       "file": "src/components/tour/TourSteps.tsx"
+    },
+    {
+      "id": "tour:admin-features",
+      "attr": "tour",
+      "value": "admin-features",
+      "en": "admin features",
+      "fr": "admin features",
+      "searchEn": "admin-features",
+      "searchFr": "admin-features",
+      "kind": "admin",
+      "hash": "#admin#project-settings#features",
+      "highlights": [
+        "[data-tour-id=\"admin-features\"]"
+      ],
+      "adminOnly": true,
+      "audience": "admin",
+      "file": "src/components/admin/AdminProjectHubTab.tsx"
     },
     {
       "id": "tour:admin-features-panel",
@@ -1285,7 +1438,7 @@
       "searchEn": "admin features panel  admin-features-panel",
       "searchFr": "admin features panel  admin-features-panel",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#project-settings#features",
       "highlights": [
         "[data-tour-id=\"admin-features-panel\"]"
       ],
@@ -1297,18 +1450,18 @@
       "id": "tour:admin-file-uploads",
       "attr": "tour",
       "value": "admin-file-uploads",
-      "en": "Set attachment size limits and which file types users may upload.",
-      "fr": "Définissez les limites de taille et les types de fichiers que les utilisateurs peuvent téléverser.",
-      "searchEn": "Set attachment size limits and which file types users may upload. Configure your site's basic settings including site name and URL. The site URL is used as a clickable title in the application header. System Settings groups SSO, storage, file uploads, and AI for this instance. Configure Single Sign-On (SSO) authentication using Google OAuth. Enable or disable Google login and manage OAuth credentials. Choose how attachments and avatars are stored — local disk or S3-compatible object storage — and test or migrate between backends. Set attachment size limits and which file types users may upload. Enable the in-app Agent, connect an LLM provider, and configure the runner that executes coding jobs. Notifications groups email delivery settings, the mail server, webhooks, and the outgoing queue.",
-      "searchFr": "Définissez les limites de taille et les types de fichiers que les utilisateurs peuvent téléverser. Configurez les paramètres de base de votre site, y compris le nom du site et l'URL. L'URL du site est utilisée comme titre cliquable dans l'en-tête de l'application. Les Paramètres système regroupent le SSO, le stockage, les téléversements et l'IA pour cette instance. Configurez l'authentification Single Sign-On (SSO) à l'aide de Google OAuth. Activez ou désactivez la connexion Google et gérez les identifiants OAuth. Choisissez comment les pièces jointes et avatars sont stockés — disque local ou stockage objet compatible S3 — et testez ou migrez entre les backends. Définissez les limites de taille et les types de fichiers que les utilisateurs peuvent téléverser. Activez l'Agent intégré, conne",
+      "en": "admin file uploads",
+      "fr": "admin file uploads",
+      "searchEn": "admin-file-uploads",
+      "searchFr": "admin-file-uploads",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#system-settings#file-uploads",
       "highlights": [
         "[data-tour-id=\"admin-file-uploads\"]"
       ],
       "adminOnly": true,
       "audience": "admin",
-      "file": "src/components/tour/TourSteps.tsx"
+      "file": "src/components/admin/AdminSystemSettingsTab.tsx"
     },
     {
       "id": "tour:admin-licensing",
@@ -1319,7 +1472,7 @@
       "searchEn": "View and manage your license information, usage limits, and subscription details. Create and manage sprints for your projects. Sprints are time-based planning periods used to organize tasks and track progress. Set sprint names, dates, and mark active sprints. Configure reporting features including gamification, leaderboard visibility, and achievement settings. Enable or disable various reporting capabilities for your team. Manage the lifecycle of deleted and archived work. Set automatic retention (purge) periods, restore soft-deleted tasks and boards, or permanently purge them when they are no longer needed. View and manage your license information, usage limits, and subscription details. This system usage panel shows real-time resource monitoring: RAM usage, CPU usage, and disk space. It ",
       "searchFr": "Consultez et gérez vos informations de licence, limites d'utilisation et détails d'abonnement. Créez et gérez des sprints pour vos projets. Les sprints sont des périodes de planification basées sur le temps utilisées pour organiser les tâches et suivre les progrès. Définissez les noms des sprints, les dates et marquez les sprints actifs. Configurez les fonctionnalités de rapport, y compris la gamification, la visibilité du classement et les paramètres d'achievements. Activez ou désactivez diverses capacités de rapport pour votre équipe. Gérez le cycle de vie des éléments supprimés et archivés. Définissez les périodes de rétention (purge) automatique, restaurez les tâches et tableaux en suppression récupérable, ou purgez-les définitivement lorsqu'ils ne sont plus nécessaires. Consultez et g",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#licensing",
       "highlights": [
         "[data-tour-id=\"admin-licensing\"]"
       ],
@@ -1331,18 +1484,18 @@
       "id": "tour:admin-lifecycle",
       "attr": "tour",
       "value": "admin-lifecycle",
-      "en": "Manage the lifecycle of deleted and archived work. Set automatic retention (purge) periods, restore soft-deleted tasks and boards, or permanently purge them when they are no longer needed.",
-      "fr": "Gérez le cycle de vie des éléments supprimés et archivés. Définissez les périodes de rétention (purge) automatique, restaurez les tâches et tableaux en suppression récupérable, ou purgez-les définitivement lorsqu'ils ne sont plus nécessaire",
-      "searchEn": "Manage the lifecycle of deleted and archived work. Set automatic retention (purge) periods, restore soft-deleted tasks and boards, or permanently purge them when they are no longer needed. Manage project-specific settings, workflows, and custom configurations in Project Settings. Create and manage sprints for your projects. Sprints are time-based planning periods used to organize tasks and track progress. Set sprint names, dates, and mark active sprints. Configure reporting features including gamification, leaderboard visibility, and achievement settings. Enable or disable various reporting capabilities for your team. Manage the lifecycle of deleted and archived work. Set automatic retention (purge) periods, restore soft-deleted tasks and boards, or permanently purge them when they are no ",
-      "searchFr": "Gérez le cycle de vie des éléments supprimés et archivés. Définissez les périodes de rétention (purge) automatique, restaurez les tâches et tableaux en suppression récupérable, ou purgez-les définitivement lorsqu'ils ne sont plus nécessaires. Gérez les paramètres spécifiques au projet, les flux de travail et les configurations personnalisées dans les Paramètres du projet. Créez et gérez des sprints pour vos projets. Les sprints sont des périodes de planification basées sur le temps utilisées pour organiser les tâches et suivre les progrès. Définissez les noms des sprints, les dates et marquez les sprints actifs. Configurez les fonctionnalités de rapport, y compris la gamification, la visibilité du classement et les paramètres d'achievements. Activez ou désactivez diverses capacités de rapp",
+      "en": "admin lifecycle",
+      "fr": "admin lifecycle",
+      "searchEn": "admin-lifecycle",
+      "searchFr": "admin-lifecycle",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#project-settings#lifecycle",
       "highlights": [
         "[data-tour-id=\"admin-lifecycle\"]"
       ],
       "adminOnly": true,
       "audience": "admin",
-      "file": "src/components/tour/TourSteps.tsx"
+      "file": "src/components/admin/AdminProjectHubTab.tsx"
     },
     {
       "id": "tour:admin-lifecycle-content",
@@ -1353,7 +1506,7 @@
       "searchEn": "admin lifecycle content  admin-lifecycle-content",
       "searchFr": "admin lifecycle content  admin-lifecycle-content",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#project-settings#lifecycle",
       "highlights": [
         "[data-tour-id=\"admin-lifecycle-content\"]"
       ],
@@ -1365,18 +1518,52 @@
       "id": "tour:admin-mail-server",
       "attr": "tour",
       "value": "admin-mail-server",
-      "en": "Configure email server settings for sending notifications, invitations, and other system emails. Set up SMTP server details and test email functionality.",
-      "fr": "Configurez les paramètres du serveur de messagerie pour l'envoi de notifications, d'invitations et d'autres e-mails système. Configurez les détails du serveur SMTP et testez la fonctionnalité e-mail.",
-      "searchEn": "Configure email server settings for sending notifications, invitations, and other system emails. Set up SMTP server details and test email functionality. Choose how attachments and avatars are stored — local disk or S3-compatible object storage — and test or migrate between backends. Set attachment size limits and which file types users may upload. Enable the in-app Agent, connect an LLM provider, and configure the runner that executes coding jobs. Notifications groups email delivery settings, the mail server, webhooks, and the outgoing queue. Configure email server settings for sending notifications, invitations, and other system emails. Set up SMTP server details and test email functionality. Create and manage tags to categorize and organize your tasks effectively. Set up priority levels",
-      "searchFr": "Configurez les paramètres du serveur de messagerie pour l'envoi de notifications, d'invitations et d'autres e-mails système. Configurez les détails du serveur SMTP et testez la fonctionnalité e-mail. Choisissez comment les pièces jointes et avatars sont stockés — disque local ou stockage objet compatible S3 — et testez ou migrez entre les backends. Définissez les limites de taille et les types de fichiers que les utilisateurs peuvent téléverser. Activez l'Agent intégré, connectez un fournisseur LLM et configurez le runner qui exécute les tâches de code. Notifications regroupe les paramètres d'envoi d'e-mails, le serveur de messagerie, les webhooks et la file d'attente. Configurez les paramètres du serveur de messagerie pour l'envoi de notifications, d'invitations et d'autres e-mails systèm",
+      "en": "admin mail server",
+      "fr": "admin mail server",
+      "searchEn": "admin-mail-server",
+      "searchFr": "admin-mail-server",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#notifications#mail-server",
       "highlights": [
         "[data-tour-id=\"admin-mail-server\"]"
       ],
       "adminOnly": true,
       "audience": "admin",
-      "file": "src/components/tour/TourSteps.tsx"
+      "file": "src/components/admin/AdminNotificationsHubTab.tsx"
+    },
+    {
+      "id": "tour:admin-notification-queue",
+      "attr": "tour",
+      "value": "admin-notification-queue",
+      "en": "admin notification queue",
+      "fr": "admin notification queue",
+      "searchEn": "admin-notification-queue",
+      "searchFr": "admin-notification-queue",
+      "kind": "admin",
+      "hash": "#admin#notifications#queue",
+      "highlights": [
+        "[data-tour-id=\"admin-notification-queue\"]"
+      ],
+      "adminOnly": true,
+      "audience": "admin",
+      "file": "src/components/admin/AdminNotificationsHubTab.tsx"
+    },
+    {
+      "id": "tour:admin-notification-settings",
+      "attr": "tour",
+      "value": "admin-notification-settings",
+      "en": "admin notification settings",
+      "fr": "admin notification settings",
+      "searchEn": "admin-notification-settings",
+      "searchFr": "admin-notification-settings",
+      "kind": "admin",
+      "hash": "#admin#notifications#notification-settings",
+      "highlights": [
+        "[data-tour-id=\"admin-notification-settings\"]"
+      ],
+      "adminOnly": true,
+      "audience": "admin",
+      "file": "src/components/admin/AdminNotificationsHubTab.tsx"
     },
     {
       "id": "tour:admin-notifications",
@@ -1387,7 +1574,7 @@
       "searchEn": "Notifications groups email delivery settings, the mail server, webhooks, and the outgoing queue. Configure Single Sign-On (SSO) authentication using Google OAuth. Enable or disable Google login and manage OAuth credentials. Choose how attachments and avatars are stored — local disk or S3-compatible object storage — and test or migrate between backends. Set attachment size limits and which file types users may upload. Enable the in-app Agent, connect an LLM provider, and configure the runner that executes coding jobs. Notifications groups email delivery settings, the mail server, webhooks, and the outgoing queue. Configure email server settings for sending notifications, invitations, and other system emails. Set up SMTP server details and test email functionality. Create and manage tags to ",
       "searchFr": "Notifications regroupe les paramètres d'envoi d'e-mails, le serveur de messagerie, les webhooks et la file d'attente. Configurez l'authentification Single Sign-On (SSO) à l'aide de Google OAuth. Activez ou désactivez la connexion Google et gérez les identifiants OAuth. Choisissez comment les pièces jointes et avatars sont stockés — disque local ou stockage objet compatible S3 — et testez ou migrez entre les backends. Définissez les limites de taille et les types de fichiers que les utilisateurs peuvent téléverser. Activez l'Agent intégré, connectez un fournisseur LLM et configurez le runner qui exécute les tâches de code. Notifications regroupe les paramètres d'envoi d'e-mails, le serveur de messagerie, les webhooks et la file d'attente. Configurez les paramètres du serveur de messagerie p",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#notifications#notification-settings",
       "highlights": [
         "[data-tour-id=\"admin-notifications\"]"
       ],
@@ -1404,13 +1591,30 @@
       "searchEn": "Set up priority levels for your tasks to help team members understand urgency. Enable the in-app Agent, connect an LLM provider, and configure the runner that executes coding jobs. Notifications groups email delivery settings, the mail server, webhooks, and the outgoing queue. Configure email server settings for sending notifications, invitations, and other system emails. Set up SMTP server details and test email functionality. Create and manage tags to categorize and organize your tasks effectively. Set up priority levels for your tasks to help team members understand urgency. Configure application settings, user preferences, and system behavior in the App Settings tab. Manage project-specific settings, workflows, and custom configurations in Project Settings. Create and manage sprints fo",
       "searchFr": "Configurez les niveaux de priorité pour vos tâches afin d'aider les membres de l'équipe à comprendre l'urgence. Activez l'Agent intégré, connectez un fournisseur LLM et configurez le runner qui exécute les tâches de code. Notifications regroupe les paramètres d'envoi d'e-mails, le serveur de messagerie, les webhooks et la file d'attente. Configurez les paramètres du serveur de messagerie pour l'envoi de notifications, d'invitations et d'autres e-mails système. Configurez les détails du serveur SMTP et testez la fonctionnalité e-mail. Créez et gérez des étiquettes pour catégoriser et organiser efficacement vos tâches. Configurez les niveaux de priorité pour vos tâches afin d'aider les membres de l'équipe à comprendre l'urgence. Configurez les paramètres de l'application, les préférences uti",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#priorities",
       "highlights": [
         "[data-tour-id=\"admin-priorities\"]"
       ],
       "adminOnly": true,
       "audience": "admin",
       "file": "src/components/tour/TourSteps.tsx"
+    },
+    {
+      "id": "tour:admin-project-general",
+      "attr": "tour",
+      "value": "admin-project-general",
+      "en": "admin project general",
+      "fr": "admin project general",
+      "searchEn": "admin-project-general",
+      "searchFr": "admin-project-general",
+      "kind": "admin",
+      "hash": "#admin#project-settings#project",
+      "highlights": [
+        "[data-tour-id=\"admin-project-general\"]"
+      ],
+      "adminOnly": true,
+      "audience": "admin",
+      "file": "src/components/admin/AdminProjectHubTab.tsx"
     },
     {
       "id": "tour:admin-project-settings",
@@ -1421,7 +1625,7 @@
       "searchEn": "Manage project-specific settings, workflows, and custom configurations in Project Settings. Configure email server settings for sending notifications, invitations, and other system emails. Set up SMTP server details and test email functionality. Create and manage tags to categorize and organize your tasks effectively. Set up priority levels for your tasks to help team members understand urgency. Configure application settings, user preferences, and system behavior in the App Settings tab. Manage project-specific settings, workflows, and custom configurations in Project Settings. Create and manage sprints for your projects. Sprints are time-based planning periods used to organize tasks and track progress. Set sprint names, dates, and mark active sprints. Configure reporting features includi",
       "searchFr": "Gérez les paramètres spécifiques au projet, les flux de travail et les configurations personnalisées dans les Paramètres du projet. Configurez les paramètres du serveur de messagerie pour l'envoi de notifications, d'invitations et d'autres e-mails système. Configurez les détails du serveur SMTP et testez la fonctionnalité e-mail. Créez et gérez des étiquettes pour catégoriser et organiser efficacement vos tâches. Configurez les niveaux de priorité pour vos tâches afin d'aider les membres de l'équipe à comprendre l'urgence. Configurez les paramètres de l'application, les préférences utilisateur et le comportement du système dans l'onglet Paramètres de l'application. Gérez les paramètres spécifiques au projet, les flux de travail et les configurations personnalisées dans les Paramètres du pr",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#project-settings#project",
       "highlights": [
         "[data-tour-id=\"admin-project-settings\"]"
       ],
@@ -1433,18 +1637,18 @@
       "id": "tour:admin-reporting",
       "attr": "tour",
       "value": "admin-reporting",
-      "en": "Configure reporting features including gamification, leaderboard visibility, and achievement settings. Enable or disable various reporting capabilities for your team.",
-      "fr": "Configurez les fonctionnalités de rapport, y compris la gamification, la visibilité du classement et les paramètres d'achievements. Activez ou désactivez diverses capacités de rapport pour votre équipe.",
-      "searchEn": "Configure reporting features including gamification, leaderboard visibility, and achievement settings. Enable or disable various reporting capabilities for your team. Configure application settings, user preferences, and system behavior in the App Settings tab. Manage project-specific settings, workflows, and custom configurations in Project Settings. Create and manage sprints for your projects. Sprints are time-based planning periods used to organize tasks and track progress. Set sprint names, dates, and mark active sprints. Configure reporting features including gamification, leaderboard visibility, and achievement settings. Enable or disable various reporting capabilities for your team. Manage the lifecycle of deleted and archived work. Set automatic retention (purge) periods, restore s",
-      "searchFr": "Configurez les fonctionnalités de rapport, y compris la gamification, la visibilité du classement et les paramètres d'achievements. Activez ou désactivez diverses capacités de rapport pour votre équipe. Configurez les paramètres de l'application, les préférences utilisateur et le comportement du système dans l'onglet Paramètres de l'application. Gérez les paramètres spécifiques au projet, les flux de travail et les configurations personnalisées dans les Paramètres du projet. Créez et gérez des sprints pour vos projets. Les sprints sont des périodes de planification basées sur le temps utilisées pour organiser les tâches et suivre les progrès. Définissez les noms des sprints, les dates et marquez les sprints actifs. Configurez les fonctionnalités de rapport, y compris la gamification, la vi",
+      "en": "admin reporting",
+      "fr": "admin reporting",
+      "searchEn": "admin-reporting",
+      "searchFr": "admin-reporting",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#project-settings#reporting",
       "highlights": [
         "[data-tour-id=\"admin-reporting\"]"
       ],
       "adminOnly": true,
       "audience": "admin",
-      "file": "src/components/tour/TourSteps.tsx"
+      "file": "src/components/admin/AdminProjectHubTab.tsx"
     },
     {
       "id": "tour:admin-site-settings",
@@ -1455,7 +1659,7 @@
       "searchEn": "Configure your site's basic settings including site name and URL. The site URL is used as a clickable title in the application header. Use this button to show or hide the system metrics panel. When enabled, you'll see real-time monitoring of RAM, CPU, and disk usage. Your preference is saved and will persist across sessions. Settings (open it from your profile menu) is where you manage users, boards, columns, and instance configuration. In Settings, manage team members, create new users, and assign roles. Configure your site's basic settings including site name and URL. The site URL is used as a clickable title in the application header. System Settings groups SSO, storage, file uploads, and AI for this instance. Configure Single Sign-On (SSO) authentication using Google OAuth. Enable or d",
       "searchFr": "Configurez les paramètres de base de votre site, y compris le nom du site et l'URL. L'URL du site est utilisée comme titre cliquable dans l'en-tête de l'application. Utilisez ce bouton pour afficher ou masquer le panneau de métriques système. Lorsqu'il est activé, vous verrez la surveillance en temps réel de la RAM, du CPU et de l'utilisation du disque. Votre préférence est enregistrée et persistera entre les sessions. Paramètres (ouvrez-les depuis le menu profil) est l'endroit où vous gérez les utilisateurs, les tableaux, les colonnes et la configuration de l'instance. Dans Paramètres, gérez les membres de l'équipe, créez de nouveaux utilisateurs et assignez des rôles. Configurez les paramètres de base de votre site, y compris le nom du site et l'URL. L'URL du site est utilisée comme titr",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#site-settings",
       "highlights": [
         "[data-tour-id=\"admin-site-settings\"]"
       ],
@@ -1467,52 +1671,52 @@
       "id": "tour:admin-sprint-settings",
       "attr": "tour",
       "value": "admin-sprint-settings",
-      "en": "Create and manage sprints for your projects. Sprints are time-based planning periods used to organize tasks and track progress. Set sprint names, dates, and mark active sprints.",
-      "fr": "Créez et gérez des sprints pour vos projets. Les sprints sont des périodes de planification basées sur le temps utilisées pour organiser les tâches et suivre les progrès. Définissez les noms des sprints, les dates et marquez les sprints act",
-      "searchEn": "Create and manage sprints for your projects. Sprints are time-based planning periods used to organize tasks and track progress. Set sprint names, dates, and mark active sprints. Create and manage tags to categorize and organize your tasks effectively. Set up priority levels for your tasks to help team members understand urgency. Configure application settings, user preferences, and system behavior in the App Settings tab. Manage project-specific settings, workflows, and custom configurations in Project Settings. Create and manage sprints for your projects. Sprints are time-based planning periods used to organize tasks and track progress. Set sprint names, dates, and mark active sprints. Configure reporting features including gamification, leaderboard visibility, and achievement settings. E",
-      "searchFr": "Créez et gérez des sprints pour vos projets. Les sprints sont des périodes de planification basées sur le temps utilisées pour organiser les tâches et suivre les progrès. Définissez les noms des sprints, les dates et marquez les sprints actifs. Créez et gérez des étiquettes pour catégoriser et organiser efficacement vos tâches. Configurez les niveaux de priorité pour vos tâches afin d'aider les membres de l'équipe à comprendre l'urgence. Configurez les paramètres de l'application, les préférences utilisateur et le comportement du système dans l'onglet Paramètres de l'application. Gérez les paramètres spécifiques au projet, les flux de travail et les configurations personnalisées dans les Paramètres du projet. Créez et gérez des sprints pour vos projets. Les sprints sont des périodes de pla",
+      "en": "admin sprint settings",
+      "fr": "admin sprint settings",
+      "searchEn": "admin-sprint-settings",
+      "searchFr": "admin-sprint-settings",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#project-settings#sprint-settings",
       "highlights": [
         "[data-tour-id=\"admin-sprint-settings\"]"
       ],
       "adminOnly": true,
       "audience": "admin",
-      "file": "src/components/tour/TourSteps.tsx"
+      "file": "src/components/admin/AdminProjectHubTab.tsx"
     },
     {
       "id": "tour:admin-sso",
       "attr": "tour",
       "value": "admin-sso",
-      "en": "Configure Single Sign-On (SSO) authentication using Google OAuth. Enable or disable Google login and manage OAuth credentials.",
-      "fr": "Configurez l'authentification Single Sign-On (SSO) à l'aide de Google OAuth. Activez ou désactivez la connexion Google et gérez les identifiants OAuth.",
-      "searchEn": "Configure Single Sign-On (SSO) authentication using Google OAuth. Enable or disable Google login and manage OAuth credentials. In Settings, manage team members, create new users, and assign roles. Configure your site's basic settings including site name and URL. The site URL is used as a clickable title in the application header. System Settings groups SSO, storage, file uploads, and AI for this instance. Configure Single Sign-On (SSO) authentication using Google OAuth. Enable or disable Google login and manage OAuth credentials. Choose how attachments and avatars are stored — local disk or S3-compatible object storage — and test or migrate between backends. Set attachment size limits and which file types users may upload. Enable the in-app Agent, connect an LLM provider, and configure the",
-      "searchFr": "Configurez l'authentification Single Sign-On (SSO) à l'aide de Google OAuth. Activez ou désactivez la connexion Google et gérez les identifiants OAuth. Dans Paramètres, gérez les membres de l'équipe, créez de nouveaux utilisateurs et assignez des rôles. Configurez les paramètres de base de votre site, y compris le nom du site et l'URL. L'URL du site est utilisée comme titre cliquable dans l'en-tête de l'application. Les Paramètres système regroupent le SSO, le stockage, les téléversements et l'IA pour cette instance. Configurez l'authentification Single Sign-On (SSO) à l'aide de Google OAuth. Activez ou désactivez la connexion Google et gérez les identifiants OAuth. Choisissez comment les pièces jointes et avatars sont stockés — disque local ou stockage objet compatible S3 — et testez ou m",
+      "en": "admin sso",
+      "fr": "admin sso",
+      "searchEn": "admin-sso",
+      "searchFr": "admin-sso",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#system-settings#sso",
       "highlights": [
         "[data-tour-id=\"admin-sso\"]"
       ],
       "adminOnly": true,
       "audience": "admin",
-      "file": "src/components/tour/TourSteps.tsx"
+      "file": "src/components/admin/AdminSystemSettingsTab.tsx"
     },
     {
       "id": "tour:admin-storage",
       "attr": "tour",
       "value": "admin-storage",
-      "en": "Choose how attachments and avatars are stored — local disk or S3-compatible object storage — and test or migrate between backends.",
-      "fr": "Choisissez comment les pièces jointes et avatars sont stockés — disque local ou stockage objet compatible S3 — et testez ou migrez entre les backends.",
-      "searchEn": "Choose how attachments and avatars are stored — local disk or S3-compatible object storage — and test or migrate between backends. In Settings, manage team members, create new users, and assign roles. Configure your site's basic settings including site name and URL. The site URL is used as a clickable title in the application header. System Settings groups SSO, storage, file uploads, and AI for this instance. Configure Single Sign-On (SSO) authentication using Google OAuth. Enable or disable Google login and manage OAuth credentials. Choose how attachments and avatars are stored — local disk or S3-compatible object storage — and test or migrate between backends. Set attachment size limits and which file types users may upload. Enable the in-app Agent, connect an LLM provider, and configure",
-      "searchFr": "Choisissez comment les pièces jointes et avatars sont stockés — disque local ou stockage objet compatible S3 — et testez ou migrez entre les backends. Dans Paramètres, gérez les membres de l'équipe, créez de nouveaux utilisateurs et assignez des rôles. Configurez les paramètres de base de votre site, y compris le nom du site et l'URL. L'URL du site est utilisée comme titre cliquable dans l'en-tête de l'application. Les Paramètres système regroupent le SSO, le stockage, les téléversements et l'IA pour cette instance. Configurez l'authentification Single Sign-On (SSO) à l'aide de Google OAuth. Activez ou désactivez la connexion Google et gérez les identifiants OAuth. Choisissez comment les pièces jointes et avatars sont stockés — disque local ou stockage objet compatible S3 — et testez ou mi",
+      "en": "admin storage",
+      "fr": "admin storage",
+      "searchEn": "admin-storage",
+      "searchFr": "admin-storage",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#system-settings#storage",
       "highlights": [
         "[data-tour-id=\"admin-storage\"]"
       ],
       "adminOnly": true,
       "audience": "admin",
-      "file": "src/components/tour/TourSteps.tsx"
+      "file": "src/components/admin/AdminSystemSettingsTab.tsx"
     },
     {
       "id": "tour:admin-system-settings",
@@ -1523,7 +1727,7 @@
       "searchEn": "System Settings groups SSO, storage, file uploads, and AI for this instance. Settings (open it from your profile menu) is where you manage users, boards, columns, and instance configuration. In Settings, manage team members, create new users, and assign roles. Configure your site's basic settings including site name and URL. The site URL is used as a clickable title in the application header. System Settings groups SSO, storage, file uploads, and AI for this instance. Configure Single Sign-On (SSO) authentication using Google OAuth. Enable or disable Google login and manage OAuth credentials. Choose how attachments and avatars are stored — local disk or S3-compatible object storage — and test or migrate between backends. Set attachment size limits and which file types users may upload. adm",
       "searchFr": "Les Paramètres système regroupent le SSO, le stockage, les téléversements et l'IA pour cette instance. Paramètres (ouvrez-les depuis le menu profil) est l'endroit où vous gérez les utilisateurs, les tableaux, les colonnes et la configuration de l'instance. Dans Paramètres, gérez les membres de l'équipe, créez de nouveaux utilisateurs et assignez des rôles. Configurez les paramètres de base de votre site, y compris le nom du site et l'URL. L'URL du site est utilisée comme titre cliquable dans l'en-tête de l'application. Les Paramètres système regroupent le SSO, le stockage, les téléversements et l'IA pour cette instance. Configurez l'authentification Single Sign-On (SSO) à l'aide de Google OAuth. Activez ou désactivez la connexion Google et gérez les identifiants OAuth. Choisissez comment l",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#system-settings#sso",
       "highlights": [
         "[data-tour-id=\"admin-system-settings\"]"
       ],
@@ -1574,7 +1778,7 @@
       "searchEn": "Create and manage tags to categorize and organize your tasks effectively. Set attachment size limits and which file types users may upload. Enable the in-app Agent, connect an LLM provider, and configure the runner that executes coding jobs. Notifications groups email delivery settings, the mail server, webhooks, and the outgoing queue. Configure email server settings for sending notifications, invitations, and other system emails. Set up SMTP server details and test email functionality. Create and manage tags to categorize and organize your tasks effectively. Set up priority levels for your tasks to help team members understand urgency. Configure application settings, user preferences, and system behavior in the App Settings tab. Manage project-specific settings, workflows, and custom con",
       "searchFr": "Créez et gérez des étiquettes pour catégoriser et organiser efficacement vos tâches. Définissez les limites de taille et les types de fichiers que les utilisateurs peuvent téléverser. Activez l'Agent intégré, connectez un fournisseur LLM et configurez le runner qui exécute les tâches de code. Notifications regroupe les paramètres d'envoi d'e-mails, le serveur de messagerie, les webhooks et la file d'attente. Configurez les paramètres du serveur de messagerie pour l'envoi de notifications, d'invitations et d'autres e-mails système. Configurez les détails du serveur SMTP et testez la fonctionnalité e-mail. Créez et gérez des étiquettes pour catégoriser et organiser efficacement vos tâches. Configurez les niveaux de priorité pour vos tâches afin d'aider les membres de l'équipe à comprendre l'",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#tags",
       "highlights": [
         "[data-tour-id=\"admin-tags\"]"
       ],
@@ -1591,7 +1795,7 @@
       "searchEn": "In Settings, manage team members, create new users, and assign roles. In List View, you can show or hide columns to customize your view. Click the menu icon in the table header to toggle column visibility. Use this button to show or hide the system metrics panel. When enabled, you'll see real-time monitoring of RAM, CPU, and disk usage. Your preference is saved and will persist across sessions. Settings (open it from your profile menu) is where you manage users, boards, columns, and instance configuration. In Settings, manage team members, create new users, and assign roles. Configure your site's basic settings including site name and URL. The site URL is used as a clickable title in the application header. System Settings groups SSO, storage, file uploads, and AI for this instance. Config",
       "searchFr": "Dans Paramètres, gérez les membres de l'équipe, créez de nouveaux utilisateurs et assignez des rôles. Dans la vue Liste, vous pouvez afficher ou masquer des colonnes pour personnaliser votre vue. Cliquez sur l'icône de menu dans l'en-tête du tableau pour basculer la visibilité des colonnes. Utilisez ce bouton pour afficher ou masquer le panneau de métriques système. Lorsqu'il est activé, vous verrez la surveillance en temps réel de la RAM, du CPU et de l'utilisation du disque. Votre préférence est enregistrée et persistera entre les sessions. Paramètres (ouvrez-les depuis le menu profil) est l'endroit où vous gérez les utilisateurs, les tableaux, les colonnes et la configuration de l'instance. Dans Paramètres, gérez les membres de l'équipe, créez de nouveaux utilisateurs et assignez des rô",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#users",
       "highlights": [
         "[data-tour-id=\"admin-users\"]"
       ],
@@ -1603,18 +1807,18 @@
       "id": "tour:admin-webhooks",
       "attr": "tour",
       "value": "admin-webhooks",
-      "en": "Send a test message to this webhook",
-      "fr": "Envoyer un message de test vers ce webhook",
-      "searchEn": "Send a test message to this webhook Send a test message to this webhook Test webhook Webhooks Loading… admin-webhooks",
-      "searchFr": "Envoyer un message de test vers ce webhook Envoyer un message de test vers ce webhook Tester le webhook Webhooks Chargement… admin-webhooks",
+      "en": "admin webhooks",
+      "fr": "admin webhooks",
+      "searchEn": "admin-webhooks",
+      "searchFr": "admin-webhooks",
       "kind": "admin",
-      "hash": "#admin",
+      "hash": "#admin#notifications#webhooks",
       "highlights": [
         "[data-tour-id=\"admin-webhooks\"]"
       ],
       "adminOnly": true,
       "audience": "admin",
-      "file": "src/components/admin/AdminWebhooksTab.tsx"
+      "file": "src/components/admin/AdminNotificationsHubTab.tsx"
     },
     {
       "id": "tour:app-nav-menu",
@@ -1812,7 +2016,7 @@
       "searchEn": "In List View, you can show or hide columns to customize your view. Click the menu icon in the table header to toggle column visibility. Show/Hide Columns column-visibility",
       "searchFr": "Dans la vue Liste, vous pouvez afficher ou masquer des colonnes pour personnaliser votre vue. Cliquez sur l'icône de menu dans l'en-tête du tableau pour basculer la visibilité des colonnes. Afficher/Masquer les colonnes column-visibility",
       "kind": "view",
-      "mode": "kanban",
+      "mode": "list",
       "highlights": [
         "[data-tour-id=\"column-visibility\"]"
       ],

--- a/server/config/helpUiIndex.js
+++ b/server/config/helpUiIndex.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { HELP_UI_REVEAL } from './helpUiReveal.js';
+import { refineAdminGoHash } from './helpAdminGoHash.js';
 
 const INDEX_PATH = path.join(
   path.dirname(fileURLToPath(import.meta.url)),
@@ -27,11 +28,14 @@ export function findHelpUiTarget(id, isAdmin) {
 
 export function targetToGoThere(row) {
   if (!row) return null;
-  const highlights = Array.isArray(row.highlights) ? row.highlights : [];
+  const highlights = Array.isArray(row.highlights) ? [...row.highlights] : [];
+  if (row.id === 'help:m365-sso' || row.id === 'help:github-sso') {
+    highlights.push('[data-help-target="sso-add-provider"]');
+  }
   const reveal = HELP_UI_REVEAL[row.id] || [];
   const extra = reveal.length ? { reveal } : {};
   if (row.kind === 'admin') {
-    return { kind: 'admin', hash: row.hash || '#admin', highlights, ...extra };
+    return { kind: 'admin', hash: refineAdminGoHash(row, row.hash || '#admin'), highlights, ...extra };
   }
   if (row.kind === 'page') {
     return { kind: 'page', page: row.page || 'reports', highlights, ...extra };

--- a/server/config/helpUiReveal.js
+++ b/server/config/helpUiReveal.js
@@ -3,7 +3,11 @@
  * closed panels (Filter, column dropdown, trash, profile tabs).
  */
 export const HELP_UI_REVEAL = {
+  'help:m365-sso': ['ssoAddMenu'],
+  'help:github-sso': ['ssoAddMenu'],
+  'help:sso-add-provider': ['ssoAddMenu'],
   'help:kanban-column-filter': ['boardToolbar', 'searchFilters', 'columnFilter'],
+  'help:calendar-column-filter': ['boardToolbar', 'searchFilters', 'columnFilter'],
   'tour:search-filter': ['boardToolbar', 'searchFilters'],
   'tour:board-trash-toggle': ['boardToolbar', 'trash'],
   'tour:column-visibility': ['boardToolbar', 'searchFilters', 'columnFilter']

--- a/server/utils/helpAssistantService.js
+++ b/server/utils/helpAssistantService.js
@@ -11,6 +11,22 @@ import { retrieveHelpUiScored, isWeakHelpUiRetrieval } from './helpUiRetrieve.js
 
 const MAX_HISTORY = 10;
 
+function looksLikeMicrosoftSsoQuestion(text) {
+  const f = String(text || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+  return /microsoft|m365|azure|entra/.test(f) && /oauth|sso|login|connexion|auth/.test(f);
+}
+
+function looksLikeGithubSsoQuestion(text) {
+  const f = String(text || '')
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase();
+  return /\bgithub\b/.test(f) && /oauth|sso|login|connexion|auth/.test(f);
+}
+
 function looksLikeTaskPageQuestion(text) {
   const f = String(text || '')
     .normalize('NFD')
@@ -165,6 +181,24 @@ export async function runHelpAssistantChat({ db, isAdmin, language, messages }) 
             : 'Open Filter, then the Columns menu to show archived columns.'
       }
     : null;
+  const m365Override = looksLikeMicrosoftSsoQuestion(lastUser.content)
+    ? {
+        targetId: 'help:m365-sso',
+        answer:
+          lang === 'fr'
+            ? 'Ouvrez Paramètres → Paramètres système → SSO, puis Ajouter un fournisseur → Microsoft 365, et renseignez l’application Azure (ID client, secret, URL de callback).'
+            : 'Open Settings → System Settings → SSO, then Add provider → Microsoft 365, and enter your Azure app (client ID, secret, callback URL).'
+      }
+    : null;
+  const githubSsoOverride = looksLikeGithubSsoQuestion(lastUser.content)
+    ? {
+        targetId: 'help:github-sso',
+        answer:
+          lang === 'fr'
+            ? 'Ouvrez Paramètres → Paramètres système → SSO, puis Ajouter un fournisseur → GitHub, et renseignez l’OAuth GitHub (ID client, secret, URL de callback).'
+            : 'Open Settings → System Settings → SSO, then Add provider → GitHub, and enter your GitHub OAuth app (client ID, secret, callback URL).'
+      }
+    : null;
   const taskPageOverride = looksLikeTaskPageQuestion(lastUser.content)
     ? {
         targetId: 'help:task-page-link',
@@ -174,7 +208,7 @@ export async function runHelpAssistantChat({ db, isAdmin, language, messages }) 
             : 'Click the ticket ID (e.g. TASK-00001) on the card, in list view, or at the top of the side panel to open the full task page. Clicking the card body only opens the side panel.'
       }
     : null;
-  const override = feedOverride || archiveOverride || taskPageOverride;
+  const override = feedOverride || archiveOverride || m365Override || githubSsoOverride || taskPageOverride;
 
   if (!override && weak) {
     const unsure = unsureReply(lang, isAdmin);

--- a/server/utils/helpUiRetrieve.js
+++ b/server/utils/helpUiRetrieve.js
@@ -30,6 +30,12 @@ function expandQuestion(question) {
   if (/full.?page|task.?page|entire task|whole task|page view|page tache|vue page/.test(f)) {
     extra.push('task-page-link', 'direct link', 'ticket');
   }
+  if (/microsoft|m365|azure|entra/.test(f)) {
+    extra.push('m365-sso', 'microsoft', 'oauth', 'sso', 'add provider');
+  }
+  if (/\bgithub\b/.test(f) && /oauth|sso|login|connexion/.test(f)) {
+    extra.push('github-sso', 'oauth', 'sso', 'add provider');
+  }
   return extra.length ? `${question} ${extra.join(' ')}` : question;
 }
 

--- a/src/components/admin/AdminSSOTab.tsx
+++ b/src/components/admin/AdminSSOTab.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import { onHelpReveal, takeHelpReveal } from '../../utils/helpGoThere';
 import { useTranslation } from 'react-i18next';
 import { CheckCircle2, Eye, EyeOff, Plus, Trash2 } from 'lucide-react';
 import { SsoLoginButton } from '../auth/SsoLoginButton';
@@ -175,6 +176,14 @@ const AdminSSOTab: React.FC<AdminSSOTabProps> = ({
   const closeAddMenu = () => setAddMenuOpen(false);
   useDismissible(Boolean(confirmDialog), closeConfirm, 'data-sso-confirm-dialog');
   useDismissible(addMenuOpen, closeAddMenu, 'data-sso-add-menu');
+
+  useEffect(() => {
+    return onHelpReveal(() => {
+      if (takeHelpReveal('ssoAddMenu') && availableProviders.length > 0) {
+        setAddMenuOpen(true);
+      }
+    });
+  }, [availableProviders.length]);
 
   const handleInputChange = (key: string, value: string) => {
     onSettingsChange({ ...editingSettings, [key]: value });
@@ -647,7 +656,7 @@ const AdminSSOTab: React.FC<AdminSSOTabProps> = ({
           </h3>
         </div>
         {availableProviders.length > 0 && (
-          <div className="relative shrink-0" data-sso-add-menu>
+          <div className="relative shrink-0" data-sso-add-menu data-help-target="sso-add-provider">
             <button
               type="button"
               onClick={() => setAddMenuOpen((open) => !open)}

--- a/src/utils/helpGoThere.ts
+++ b/src/utils/helpGoThere.ts
@@ -2,7 +2,7 @@
 
 export const HELP_GO_THERE_EVENT = 'agila:help-go-there';
 
-export type HelpRevealAction = 'boardToolbar' | 'searchFilters' | 'columnFilter' | 'trash';
+export type HelpRevealAction = 'boardToolbar' | 'searchFilters' | 'columnFilter' | 'trash' | 'ssoAddMenu';
 
 const pending = new Set<HelpRevealAction>();
 
@@ -12,7 +12,8 @@ export function queueHelpReveal(actions: readonly string[]): void {
       raw === 'boardToolbar' ||
       raw === 'searchFilters' ||
       raw === 'columnFilter' ||
-      raw === 'trash'
+      raw === 'trash' ||
+      raw === 'ssoAddMenu'
     ) {
       pending.add(raw);
     }


### PR DESCRIPTION
## Summary
- Help Go There now uses real Settings deep links (sprints, SSO, mail, storage, etc.) instead of `#admin` (Users).
- Harvest/check fails if a Settings target still uses a shallow or unknown hash.
- Microsoft/GitHub OAuth “create” questions open SSO and highlight Add provider when the provider card is not mounted yet.

## Test plan
- [ ] Restart the app, ask “Where can I manage sprints?” and use Go There → Project Settings → Sprints
- [ ] Ask “How can I create OAuth for Microsoft login?” and use Go There → SSO Add provider
- [ ] Confirm “Where can I manage users?” still lands on Users


Made with [Cursor](https://cursor.com)