### PR TITLE
Apply role changes to the live session immediately

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,7 +74,7 @@ import { requestTaskJump } from './utils/taskJumpEvents';
 import { revealNewlyCreatedTask } from './utils/newTaskReveal';
 import { columnsContentFingerprint } from './utils/columnsFingerprint';
 import { applyLocalColumnReorder } from './utils/columnReorderingUtils';
-import { userCanMutate } from './utils/permissions';
+import { rolesForAppRole, sameRoleList, userCanMutate } from './utils/permissions';
 import { isDemoModeClient } from './utils/demoReset';
 import { useLoadingState } from './hooks/useLoadingState';
 import { useDebug } from './hooks/useDebug';
@@ -753,6 +753,14 @@ function AppContent() {
 
   useEffect(() => subscribePerfTestsPreference(setUserPerfTestsEnabled), []);
 
+  useEffect(() => {
+    if (isAdminUser || currentPage !== 'admin') return;
+    setCurrentPage('kanban');
+    if (window.location.hash.replace(/^#/, '').startsWith('admin')) {
+      window.location.hash = 'kanban';
+    }
+  }, [isAdminUser, currentPage]);
+
   const columnIdsKey = useMemo(
     () => Object.keys(columns).sort().join('|'),
     [columns]
@@ -1086,12 +1094,21 @@ function AppContent() {
       return;
     }
     
-    // Handle permission changes (soft updates) - only if we have a previous status to compare
     const prevCanMutate = previousStatus?.canMutate ?? previousStatus?.isAdmin;
     const nextCanMutate = newUserStatus.canMutate ?? !newUserStatus.isViewer;
+    const nextRoles = Array.isArray(newUserStatus.roles) && newUserStatus.roles.length
+      ? newUserStatus.roles
+      : rolesForAppRole(newUserStatus.isAdmin ? 'admin' : newUserStatus.isViewer ? 'viewer' : 'user');
+    let rolesChanged = false;
+    setCurrentUser((prev) => {
+      if (!prev || sameRoleList(prev.roles, nextRoles)) return prev;
+      rolesChanged = true;
+      return { ...prev, roles: nextRoles };
+    });
     if (
-      previousStatus !== null &&
-      (previousStatus.isAdmin !== newUserStatus.isAdmin || prevCanMutate !== nextCanMutate)
+      rolesChanged ||
+      (previousStatus !== null &&
+        (previousStatus.isAdmin !== newUserStatus.isAdmin || prevCanMutate !== nextCanMutate))
     ) {
       handleProfileUpdated().catch((error) => {
         console.error('Failed to refresh user profile after permission change:', error);

--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -930,7 +930,7 @@ export default function HelpModal({
     };
 
     return (
-      <section ref={sectionRef} className={sectionShellClass(hasMatch)}>
+      <section key={titleKey} ref={sectionRef} className={sectionShellClass(hasMatch)}>
         <h3 className={sectionTitleClass}>
           <span className={`inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${iconBg}`}>
             {React.createElement(icon, { className: iconColor, size: 18 })}
@@ -940,7 +940,7 @@ export default function HelpModal({
         </h3>
         <div className={`space-y-2.5 ${bodyTextClass}`}>
           {contents.map((content, index) => (
-            <p key={index}>{renderHelpContent(content, debouncedSearchTerm)}</p>
+            <p key={`${titleKey}-${index}`}>{renderHelpContent(content, debouncedSearchTerm)}</p>
           ))}
         </div>
       </section>
@@ -1000,7 +1000,7 @@ export default function HelpModal({
     );
 
     return (
-      <section ref={sectionRef} className={sectionShellClass(hasMatch)}>
+      <section key={titleKey} ref={sectionRef} className={sectionShellClass(hasMatch)}>
         {/* flow-root contains the floated aside so it cannot spill past the card */}
         {extras?.aside ? <div className="flow-root">{body}</div> : body}
       </section>
@@ -1030,7 +1030,7 @@ export default function HelpModal({
     };
 
     return (
-      <section ref={sectionRef} className={sectionShellClass(hasMatch)}>
+      <section key={titleKey} ref={sectionRef} className={sectionShellClass(hasMatch)}>
         <h3 className={sectionTitleClass}>
           <span className={`inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-lg ${iconBg}`}>
             {React.createElement(icon, { className: iconColor, size: 18 })}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -830,7 +830,7 @@ const Header: React.FC<HeaderProps> = ({
                         {currentPage === 'reports' && <Check size={14} className="text-blue-600" />}
                       </button>
                     )}
-                    {currentUser.roles?.includes('admin') && onInviteUser && (
+                    {isAdminAccount && onInviteUser && (
                       <>
                         <div className="my-1 border-t border-gray-200 dark:border-gray-700" />
                         <button
@@ -853,7 +853,7 @@ const Header: React.FC<HeaderProps> = ({
               </div>
 
               {/* Invite — desktop button; dropdown host for both breakpoints */}
-              {currentUser.roles?.includes('admin') && onInviteUser && (
+              {isAdminAccount && onInviteUser && (
                 <div className="relative" ref={inviteDropdownRef}>
                   <KanbanChromeTooltip label={t('navigation.inviteUser')} wrapperClassName="relative hidden lg:inline-flex">
                     <button

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef, useCallback, type Dispatch, type SetStateAction } from 'react';
 import { CurrentUser, SiteSettings } from '../types';
 import { DEFAULT_SITE_SETTINGS } from '../constants';
 import * as api from '../api';
@@ -178,7 +178,7 @@ interface UseAuthReturn {
   handleProfileUpdated: () => Promise<void>;
   refreshSiteSettings: () => Promise<void>;
   setSiteSettings: (settings: SiteSettings) => void;
-  setCurrentUser: (user: CurrentUser | null) => void;
+  setCurrentUser: Dispatch<SetStateAction<CurrentUser | null>>;
 }
 
 interface UseAuthCallbacks {
@@ -200,6 +200,8 @@ export const useAuth = (callbacks: UseAuthCallbacks): UseAuthReturn => {
   
   // Intended destination for redirecting after login
   const [intendedDestination, setIntendedDestination] = useState<string | null>(INITIAL_INTENDED_DESTINATION);
+  const callbacksRef = useRef(callbacks);
+  callbacksRef.current = callbacks;
 
   // Persist deep link for after login. Login UI already renders when logged out;
   // only leave /project|/task so chrome stays on `/` (OAuth callback expects that).
@@ -352,30 +354,22 @@ export const useAuth = (callbacks: UseAuthCallbacks): UseAuthReturn => {
     return () => window.clearTimeout(timer);
   }, [isAuthenticated, currentUser, handleLogout]);
 
-  const handleProfileUpdated = async () => {
+  const handleProfileUpdated = useCallback(async () => {
     try {
-      // Refresh current user data to get updated avatar and roles
       const response = await api.getCurrentUser();
       setCurrentUser(response.user);
-      
-      // If a fresh token is provided (for role updates), save it
       if (response.token) {
         localStorage.setItem('authToken', response.token);
-        console.log('🔑 Updated JWT token with fresh roles');
         void establishMediaSession();
       }
-      
-      // Also refresh members to get updated display names
-      await callbacks.onMembersRefresh();
-      
-      // If current user is admin, also refresh admin data to show updated display names
+      await callbacksRef.current.onMembersRefresh();
       if (response.user.roles?.includes('admin')) {
-        callbacks.onAdminRefresh();
+        callbacksRef.current.onAdminRefresh();
       }
     } catch (error) {
       console.error('Failed to refresh profile data:', error);
     }
-  };
+  }, []);
 
   // refreshSiteSettings removed - use SettingsContext.refreshSettings() instead
   const refreshSiteSettings = async () => {

--- a/src/hooks/useMemberWebSocket.ts
+++ b/src/hooks/useMemberWebSocket.ts
@@ -1,7 +1,9 @@
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { TeamMember, SavedFilterView } from '../types';
 import { getMembers, getCurrentUser } from '../api';
+import { establishMediaSession } from '../utils/mediaSession';
 import { normalizeTeamMemberFromEvent } from '../utils/memberUtils';
+import { rolesForAppRole, sameRoleList } from '../utils/permissions';
 
 interface UseMemberWebSocketProps {
   // State setters
@@ -34,6 +36,23 @@ export const useMemberWebSocket = ({
   taskFilters,
   currentUser,
 }: UseMemberWebSocketProps) => {
+  const currentUserIdRef = useRef(currentUser?.id);
+  currentUserIdRef.current = currentUser?.id;
+
+  const refreshSelfSession = useCallback(async () => {
+    try {
+      const response = await getCurrentUser();
+      if (response?.user) {
+        setCurrentUser(response.user);
+      }
+      if (response?.token) {
+        localStorage.setItem('authToken', response.token);
+        void establishMediaSession();
+      }
+    } catch (error) {
+      console.error('Failed to refresh current user after role change:', error);
+    }
+  }, [setCurrentUser]);
   
   const handleMemberCreated = useCallback((data: any) => {
     if (!data?.member) return;
@@ -52,8 +71,8 @@ export const useMemberWebSocket = ({
     });
   }, [setMembers]);
 
-  const handleUserRoleUpdated = useCallback((data: { userId?: string; role?: string }) => {
-    const userId = data?.userId;
+  const handleUserRoleUpdated = useCallback((data: { userId?: string; user?: { id?: string }; role?: string }) => {
+    const userId = data?.userId ?? data?.user?.id;
     const role = data?.role;
     if (!userId || !role) return;
     const isViewer = role === 'viewer';
@@ -65,7 +84,15 @@ export const useMemberWebSocket = ({
         return { ...member, isViewer };
       });
     });
-  }, [setMembers]);
+    if (String(currentUserIdRef.current) !== String(userId)) return;
+    const nextRoles = rolesForAppRole(role);
+    setCurrentUser((prev) => {
+      if (!prev || String(prev.id) !== String(userId)) return prev;
+      if (sameRoleList(prev.roles, nextRoles)) return prev;
+      return { ...prev, roles: nextRoles };
+    });
+    void refreshSelfSession();
+  }, [refreshSelfSession, setCurrentUser, setMembers]);
 
   const handleUserUpdated = useCallback((data: any) => {
     const user = data?.user;
@@ -154,10 +181,14 @@ export const useMemberWebSocket = ({
 
   const handleUserProfileUpdated = useCallback(async (data: any) => {
     // If this is the current user's profile update, refresh currentUser
-    if (data.userId === currentUser?.id) {
+    if (String(data.userId) === String(currentUserIdRef.current)) {
       try {
         const response = await getCurrentUser();
         setCurrentUser(response.user);
+        if (response.token) {
+          localStorage.setItem('authToken', response.token);
+          void establishMediaSession();
+        }
       } catch (error) {
         console.error('Failed to refresh current user after profile update:', error);
       }

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -26,6 +26,19 @@ export function userCanExport(user: CurrentUser | null | undefined): boolean {
 
 export type AppRole = 'admin' | 'user' | 'viewer';
 
+export function rolesForAppRole(role: string): string[] {
+  if (role === 'admin') return ['admin'];
+  if (role === 'viewer') return ['viewer'];
+  return ['user'];
+}
+
+export function sameRoleList(a?: string[] | null, b?: string[] | null): boolean {
+  const left = Array.isArray(a) ? a : [];
+  const right = Array.isArray(b) ? b : [];
+  if (left.length !== right.length) return false;
+  return left.every((role, index) => role === right[index]);
+}
+
 export function primaryAppRole(user: CurrentUser | null | undefined): AppRole {
   if (!user?.roles?.length) return 'user';
   if (user.roles.includes('admin')) return 'admin';


### PR DESCRIPTION
## Summary
- When an admin changes another user’s role, that user’s open tab now updates `currentUser.roles` and refreshes `/auth/me` from `user-role-updated` so Invite, the Administrator badge, and Settings drop without a reload.
- Status polling is a backup, not the only path; a demoted admin is bounced off Settings if they still have it open.
- Help UI index was regenerated and checked (`143` rows); no harvest changes.

## Test plan
- [ ] From admin A, set user B Admin → User while B’s tab stays open: Invite, Administrator badge, and Settings disappear immediately.
- [ ] Promote B back to Admin: chrome returns without a full reload.
- [ ] If B is on Settings when demoted, they leave `#admin`.
- [ ] `npm run help:ui-index:check` stays green.


Made with [Cursor](https://cursor.com)