### PR TITLE
Seed demo boards with members, sprint goals, and acceptance criteria

### DIFF
--- a/Documentation.md
+++ b/Documentation.md
@@ -72,6 +72,8 @@ When running in **demo mode** (`DEMO_ENABLED=true`), the application seeds an ad
 - `sarah.johnson@demo.local`
 - `mike.davis@demo.local`
 
+English and French demo boards include those people as **board members**, a sprint with a **goal**, and sample **acceptance criteria** on a few tasks.
+
 Passwords for sample users are stored as `DEMO_PASSWORD_<email>` settings (not shown on the login page by default). The login page surfaces the admin credentials when demo mode is enabled.
 
 #### Production Mode

--- a/server/config/database.js
+++ b/server/config/database.js
@@ -15,8 +15,14 @@ import {
   AGENT_DEFAULT_COLOR
 } from '../constants/agentIdentity.js';
 import { initializeDemoData, installDemoSeedAvatar, ensureDemoMemberDisplayFirstNames } from './demoData.js';
-import { ensureDemoBacklogTasksUnassigned } from './demoDataSeed.js';
+import {
+  ensureDemoAcceptanceCriteria,
+  ensureDemoBacklogTasksUnassigned,
+  ensureDemoBoardParticipants,
+  ensureDemoSprintGoals,
+} from './demoDataSeed.js';
 import { seedWelcomeTasks } from './welcomeTasks.js';
+import { boardParticipants } from '../utils/sqlManager/index.js';
 import { wrapQuery } from '../utils/queryLogger.js';
 import { dbExec, dbGet, dbAll, dbRun } from '../utils/dbAsync.js';
 import * as settingsQueries from '../utils/sqlManager/settings.js';
@@ -1420,6 +1426,11 @@ const initializeDefaultData = async (db, tenantId = null) => {
       } catch (error) {
         console.error('❌ Welcome task seed failed (continuing startup):', error);
       }
+      try {
+        await boardParticipants.addActiveUsersAsParticipants(db, boardId);
+      } catch (error) {
+        console.error('❌ Default board participants seed failed (continuing startup):', error);
+      }
     }
   } else if (process.env.DEMO_ENABLED === 'true') {
     // Existing demo volume: keep claimable backlog tasks unassigned after code deploys
@@ -1432,6 +1443,21 @@ const initializeDefaultData = async (db, tenantId = null) => {
       await ensureDemoMemberDisplayFirstNames(db);
     } catch (error) {
       console.error('❌ Demo member display-name ensure failed (continuing startup):', error);
+    }
+    try {
+      await ensureDemoBoardParticipants(db);
+    } catch (error) {
+      console.error('❌ Demo board participants ensure failed (continuing startup):', error);
+    }
+    try {
+      await ensureDemoSprintGoals(db);
+    } catch (error) {
+      console.error('❌ Demo sprint goal ensure failed (continuing startup):', error);
+    }
+    try {
+      await ensureDemoAcceptanceCriteria(db);
+    } catch (error) {
+      console.error('❌ Demo acceptance criteria ensure failed (continuing startup):', error);
     }
   }
 

--- a/server/config/demoCopy.js
+++ b/server/config/demoCopy.js
@@ -16,6 +16,10 @@ export const DEMO_SPRINT = {
     en: 'Complete initial project setup and core features',
     fr: 'Terminer la mise en place du projet et les fonctionnalités de base',
   },
+  goal: {
+    en: 'Ship a secure login path and a documented API so we can demo the board to stakeholders.',
+    fr: 'Livrer une connexion sécurisée et une API documentée pour présenter le tableau aux parties prenantes.',
+  },
 };
 
 export const DEMO_ADMIN_BIO = {
@@ -140,6 +144,74 @@ export const DEMO_TASK_COPY = {
   old_docs_cleanup: {
     en: { title: 'Old documentation cleanup', description: 'Archived outdated documentation and updated references to current versions.' },
     fr: { title: 'Nettoyage de l’ancienne documentation', description: 'Archiver la doc périmée et mettre à jour les références.' },
+  },
+};
+
+/** Checklist items for a few showcase tasks (seeded on both locale boards). */
+export const DEMO_ACCEPTANCE_CRITERIA = {
+  user_auth: {
+    en: [
+      { text: 'Users can sign in with email and password', done: true },
+      { text: 'Invalid credentials show a clear error', done: true },
+      { text: 'Sessions expire and can be refreshed without losing work', done: false },
+    ],
+    fr: [
+      { text: 'Les utilisateurs peuvent se connecter avec e-mail et mot de passe', done: true },
+      { text: 'Des identifiants invalides affichent une erreur claire', done: true },
+      { text: 'Les sessions expirent et peuvent être renouvelées sans perdre le travail', done: false },
+    ],
+  },
+  project_docs: {
+    en: [
+      { text: 'README covers local setup and first login', done: false },
+      { text: 'API reference lists auth and task endpoints', done: false },
+      { text: 'A short user guide explains boards, sprints, and filters', done: false },
+    ],
+    fr: [
+      { text: 'Le README décrit l’installation locale et la première connexion', done: false },
+      { text: 'La référence API liste les endpoints d’auth et de tâches', done: false },
+      { text: 'Un court guide explique les tableaux, sprints et filtres', done: false },
+    ],
+  },
+  ui_mockups: {
+    en: [
+      { text: 'Dashboard wireframes cover list, kanban, and empty states', done: true },
+      { text: 'High-fidelity mockups match the current color tokens', done: false },
+    ],
+    fr: [
+      { text: 'Les wireframes couvrent liste, kanban et états vides', done: true },
+      { text: 'Les maquettes haute fidélité suivent les jetons de couleur actuels', done: false },
+    ],
+  },
+  db_schema: {
+    en: [
+      { text: 'Users, members, boards, and tasks have foreign keys', done: true },
+      { text: 'Indexes exist for board id and sprint id on tasks', done: false },
+    ],
+    fr: [
+      { text: 'Users, members, boards et tasks ont des clés étrangères', done: true },
+      { text: 'Des index existent sur board id et sprint id des tâches', done: false },
+    ],
+  },
+  security_audit: {
+    en: [
+      { text: 'Parameterized queries are used on all write paths', done: true },
+      { text: 'Known SQL injection findings are fixed or ticketed', done: false },
+    ],
+    fr: [
+      { text: 'Les écritures passent par des requêtes paramétrées', done: true },
+      { text: 'Les injections SQL connues sont corrigées ou ticketées', done: false },
+    ],
+  },
+  cicd: {
+    en: [
+      { text: 'Pull requests run lint and unit tests', done: false },
+      { text: 'Main deploys only after checks are green', done: false },
+    ],
+    fr: [
+      { text: 'Les pull requests lancent lint et tests unitaires', done: false },
+      { text: 'Main n’est déployé que si les contrôles sont verts', done: false },
+    ],
   },
 };
 

--- a/server/config/demoDataSeed.js
+++ b/server/config/demoDataSeed.js
@@ -3,9 +3,10 @@
  */
 import crypto from 'crypto';
 import { wrapQuery } from '../utils/queryLogger.js';
-import { boards as boardQueries } from '../utils/sqlManager/index.js';
+import { boards as boardQueries, boardParticipants } from '../utils/sqlManager/index.js';
 import { getDefaultBoardColumns } from '../utils/defaultBoardColumns.js';
 import {
+  DEMO_ACCEPTANCE_CRITERIA,
   DEMO_ACTIVITY,
   DEMO_ADMIN_BIO,
   DEMO_BOARD_SETTING,
@@ -100,11 +101,13 @@ async function seedOneBoard(db, { lang, members, tagIds, position, writeLeaderbo
     'INSERT'
   ).run(DEMO_BOARD_SETTING[lang], boardId);
 
+  await boardParticipants.addActiveUsersAsParticipants(db, boardId);
+
   const sprintId = crypto.randomUUID();
   await wrapQuery(
     db.prepare(`
-      INSERT INTO planning_periods (id, name, start_date, end_date, description, is_active, board_id, created_at, updated_at)
-      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+      INSERT INTO planning_periods (id, name, start_date, end_date, description, goal, is_active, board_id, created_at, updated_at)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
     `),
     'INSERT'
   ).run(
@@ -113,6 +116,7 @@ async function seedOneBoard(db, { lang, members, tagIds, position, writeLeaderbo
     sprintStartDate,
     sprintEndDate,
     DEMO_SPRINT.description[lang],
+    DEMO_SPRINT.goal[lang],
     1,
     boardId,
     now,
@@ -192,6 +196,28 @@ async function seedOneBoard(db, { lang, members, tagIds, position, writeLeaderbo
       priority: meta.priority,
       description: copy.description,
     };
+  }
+
+  const acStmt = db.prepare(`
+    INSERT INTO acceptance_criteria (id, task_id, text, is_done, position, created_at, updated_at)
+    VALUES ($1, $2, $3, $4, $5, $6, $6)
+  `);
+  for (const [key, byLang] of Object.entries(DEMO_ACCEPTANCE_CRITERIA)) {
+    const task = createdByKey[key];
+    const items = byLang?.[lang];
+    if (!task || !Array.isArray(items)) continue;
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      if (!item?.text) continue;
+      await wrapQuery(acStmt, 'INSERT').run(
+        crypto.randomUUID(),
+        task.id,
+        item.text,
+        item.done === true,
+        i + 1,
+        now
+      );
+    }
   }
 
   const taskTagStmt = db.prepare('INSERT INTO task_tags (taskid, tagid) VALUES ($1, $2)');
@@ -456,6 +482,98 @@ export async function ensureDemoBacklogTasksUnassigned(db) {
   const cleared = Number(result?.rowCount ?? result?.changes ?? 0);
   if (cleared > 0) {
     console.log(`✅ Demo backlog: cleared assignee on ${cleared} task(s) (EN+FR claimable work)`);
+  }
+}
+
+async function demoBoardIds(db) {
+  const ids = [];
+  for (const key of Object.values(DEMO_BOARD_SETTING)) {
+    const row = await wrapQuery(
+      db.prepare('SELECT value FROM settings WHERE key = $1'),
+      'SELECT'
+    ).get(key);
+    if (row?.value) ids.push(row.value);
+  }
+  return ids;
+}
+
+/** Existing demo volumes: add all active users if a demo board has no (or incomplete) members. */
+export async function ensureDemoBoardParticipants(db) {
+  if (process.env.DEMO_ENABLED !== 'true') return;
+  const boardIds = await demoBoardIds(db);
+  for (const boardId of boardIds) {
+    await boardParticipants.addActiveUsersAsParticipants(db, boardId);
+  }
+  if (boardIds.length > 0) {
+    console.log(`✅ Demo boards: ensured participants on ${boardIds.length} board(s)`);
+  }
+}
+
+/** Existing demo volumes: fill sprint goal when the seeded sprint has none. */
+export async function ensureDemoSprintGoals(db) {
+  if (process.env.DEMO_ENABLED !== 'true') return;
+  for (const lang of ['en', 'fr']) {
+    const result = await wrapQuery(
+      db.prepare(`
+        UPDATE planning_periods
+        SET goal = $1, updated_at = CURRENT_TIMESTAMP
+        WHERE name = $2
+          AND (goal IS NULL OR TRIM(goal) = '')
+      `),
+      'UPDATE'
+    ).run(DEMO_SPRINT.goal[lang], DEMO_SPRINT.name[lang]);
+    const n = Number(result?.rowCount ?? result?.changes ?? 0);
+    if (n > 0) {
+      console.log(`✅ Demo sprint: set goal on ${n} ${lang} sprint(s)`);
+    }
+  }
+}
+
+/** Existing demo volumes: add sample acceptance criteria when a showcase task has none. */
+export async function ensureDemoAcceptanceCriteria(db) {
+  if (process.env.DEMO_ENABLED !== 'true') return;
+  const now = new Date().toISOString();
+  const acStmt = db.prepare(`
+    INSERT INTO acceptance_criteria (id, task_id, text, is_done, position, created_at, updated_at)
+    VALUES ($1, $2, $3, $4, $5, $6, $6)
+  `);
+  let added = 0;
+  for (const [key, byLang] of Object.entries(DEMO_ACCEPTANCE_CRITERIA)) {
+    for (const lang of ['en', 'fr']) {
+      const title = DEMO_TASK_COPY[key]?.[lang]?.title;
+      const items = byLang?.[lang];
+      if (!title || !Array.isArray(items) || items.length === 0) continue;
+      const tasks = await wrapQuery(
+        db.prepare(`
+          SELECT id FROM tasks
+          WHERE deleted_at IS NULL AND title = $1
+        `),
+        'SELECT'
+      ).all(title);
+      for (const task of tasks || []) {
+        const existing = await wrapQuery(
+          db.prepare('SELECT COUNT(*)::int AS count FROM acceptance_criteria WHERE task_id = $1'),
+          'SELECT'
+        ).get(task.id);
+        if (Number(existing?.count || 0) > 0) continue;
+        for (let i = 0; i < items.length; i++) {
+          const item = items[i];
+          if (!item?.text) continue;
+          await wrapQuery(acStmt, 'INSERT').run(
+            crypto.randomUUID(),
+            task.id,
+            item.text,
+            item.done === true,
+            i + 1,
+            now
+          );
+          added += 1;
+        }
+      }
+    }
+  }
+  if (added > 0) {
+    console.log(`✅ Demo tasks: added ${added} acceptance criterion row(s)`);
   }
 }
 

--- a/server/utils/sqlManager/boardParticipants.js
+++ b/server/utils/sqlManager/boardParticipants.js
@@ -111,6 +111,22 @@ export async function replaceParticipants(db, boardId, userIds) {
   return listParticipants(db, boardId);
 }
 
+/** Add every active human user to a board without dropping existing members. */
+export async function addActiveUsersAsParticipants(db, boardId) {
+  const rows = await wrapQuery(
+    db.prepare(`
+      SELECT id FROM users
+      WHERE is_active = true
+        AND COALESCE(email, '') NOT IN ('agent@local', 'system@local')
+    `),
+    'SELECT'
+  ).all();
+  const userIds = (rows || []).map((row) => row.id).filter(Boolean);
+  if (userIds.length === 0) return [];
+  const existing = await listParticipantUserIds(db, boardId);
+  return replaceParticipants(db, boardId, [...existing, ...userIds]);
+}
+
 export async function getAccessibleBoardIds(db, userId) {
   const rows = await wrapQuery(
     db.prepare('SELECT board_id FROM board_participants WHERE user_id = $1'),


### PR DESCRIPTION
## Summary
- Add all demo users as board members on the English and French sample boards.
- Seed a sprint goal and bilingual acceptance criteria on a few showcase tasks.
- Backfill existing demo volumes on startup so the next reset is not required.

## Test plan
- [ ] Fresh demo (or hourly reset): both boards list participants and do not show the empty-members hint.
- [ ] Hover the sprint (i) and confirm a goal is present in EN and FR.
- [ ] Open Implement user authentication / Project documentation and confirm acceptance criteria in the matching locale.


Made with [Cursor](https://cursor.com)