### PR TITLE
Fix kanban drop-here at the top of a column

### DIFF
--- a/src/components/dnd/SimpleDragDropManager.tsx
+++ b/src/components/dnd/SimpleDragDropManager.tsx
@@ -382,8 +382,6 @@ export const SimpleDragDropManager: React.FC<SimpleDragDropManagerProps> = React
   const liveCheckedIds = (): Set<string> | undefined =>
     checkedTaskIdsRef?.current ?? liveCheckedRef.current;
   const rafHandleRef = useRef<number | null>(null);
-  const lastProcessTimeRef = useRef<number>(0);
-  const THROTTLE_MS = 16; // ~60fps max
 
   const publishKeyboardSlot = () => {
     const slot = keyboardSlotRef.current;
@@ -461,6 +459,157 @@ export const SimpleDragDropManager: React.FC<SimpleDragDropManagerProps> = React
   const capturePendingCommitRef = useRef(capturePendingCommit);
   capturePendingCommitRef.current = capturePendingCommit;
 
+  const applyTaskDragPreviewFromPointer = () => {
+    if (!isDraggingTaskRef.current || isKeyboardDragRef.current) return;
+    const taskId = draggedTaskIdRef.current;
+    if (!taskId) return;
+
+    const bounds = tabAreaBoundsRef.current;
+    const isInTabArea =
+      pointerInBoardTabStrip(mouseXRef.current, mouseYRef.current) ||
+      (mouseXRef.current >= bounds.left &&
+        mouseXRef.current <= bounds.right &&
+        mouseYRef.current >= bounds.top &&
+        mouseYRef.current <= bounds.bottom);
+
+    if (isInTabArea && !isHoveringBoardTabRef.current) {
+      isHoveringBoardTabRef.current = true;
+      onBoardTabHover?.(true);
+      lastPreviewRef.current = null;
+      onDragPreviewChange?.(null);
+    } else if (!isInTabArea && isHoveringBoardTabRef.current) {
+      isHoveringBoardTabRef.current = false;
+      onBoardTabHover?.(false);
+    }
+    if (isHoveringBoardTabRef.current) return;
+
+    const origin = dragOriginRef.current;
+    const excludeIds = excludeIdsForDrag(taskId, activeBulkTaskIdsRef.current);
+    const overlay = getTaskDragOverlayRect() || overlayRectRef.current;
+    if (overlay) {
+      overlayRectRef.current = overlay;
+      if (overlayStartTopRef.current == null) {
+        overlayStartTopRef.current = overlay.top;
+        overlayStartLeftRef.current = overlay.left;
+      }
+    }
+    const hit = resolveKanbanDropTarget({
+      pointerX: mouseXRef.current,
+      pointerY: mouseYRef.current,
+      overlay,
+      origin,
+      excludeTaskIds: excludeIds,
+      overlayStartLeft: overlayStartLeftRef.current,
+    });
+    const columnId = hit?.columnId || null;
+    if (!columnId || !columnsRef.current[columnId] || hit == null) return;
+    const insertIndex = hit.insertIndex;
+    if (insertIndex == null) return;
+    const originColumnId = origin?.columnId || '';
+    let nextColumnId = columnId;
+    let nextInsert = insertIndex;
+    if (nextColumnId !== originColumnId) {
+      lastDestPreviewRef.current = { columnId: nextColumnId, insertIndex: nextInsert };
+      setTaskDropLock(taskId, originColumnId, lastDestPreviewRef.current);
+    } else if (lastDestPreviewRef.current) {
+      const last = lastDestPreviewRef.current;
+      const pointerCol = resolveColumnIdUnderPointer(
+        mouseXRef.current,
+        mouseYRef.current
+      );
+      const overlayCol = overlay
+        ? resolveColumnIdUnderRect(
+            overlay,
+            originColumnId,
+            overlayStartLeftRef.current
+          )
+        : null;
+      const sideways =
+        overlay != null &&
+        overlayStartLeftRef.current != null &&
+        Math.abs(overlay.left - overlayStartLeftRef.current) >= OVERLAY_SIDEWAYS_PX;
+      const pointerInOrigin = pointerCol === originColumnId;
+      const pointerDest =
+        pointerCol && pointerCol !== originColumnId ? pointerCol : null;
+      const overlayDest =
+        overlayCol && overlayCol !== originColumnId ? overlayCol : null;
+      const destInsertFor = (destColumnId: string, fallback: number) =>
+        (overlay
+          ? resolveInsertIndexFromOverlay(
+              destColumnId,
+              overlay,
+              excludeIds,
+              origin
+            )
+          : resolveInsertIndexUnderPointer(
+              destColumnId,
+              mouseYRef.current,
+              excludeIds,
+              mouseXRef.current,
+              null,
+              origin
+            )) ?? fallback;
+      if (pointerInOrigin) {
+        lastDestPreviewRef.current = null;
+      } else if (pointerDest && pointerDest !== last.columnId) {
+        const destInsert = destInsertFor(pointerDest, nextInsert);
+        lastDestPreviewRef.current = {
+          columnId: pointerDest,
+          insertIndex: destInsert,
+        };
+        nextColumnId = pointerDest;
+        nextInsert = destInsert;
+        setTaskDropLock(taskId, originColumnId, lastDestPreviewRef.current);
+      } else if (overlayDest && overlayDest !== last.columnId && sideways) {
+        const destInsert = destInsertFor(overlayDest, nextInsert);
+        lastDestPreviewRef.current = {
+          columnId: overlayDest,
+          insertIndex: destInsert,
+        };
+        nextColumnId = overlayDest;
+        nextInsert = destInsert;
+        setTaskDropLock(taskId, originColumnId, lastDestPreviewRef.current);
+      } else if (pointerDest) {
+        const destInsert = destInsertFor(pointerDest, last.insertIndex);
+        nextColumnId = pointerDest;
+        nextInsert = destInsert;
+        lastDestPreviewRef.current = {
+          columnId: pointerDest,
+          insertIndex: destInsert,
+        };
+        setTaskDropLock(taskId, originColumnId, lastDestPreviewRef.current);
+      } else {
+        lastDestPreviewRef.current = null;
+      }
+    }
+    const newPreview = {
+      targetColumnId: nextColumnId,
+      insertIndex: nextInsert,
+      isCrossColumn: originColumnId !== nextColumnId,
+    };
+    if (
+      !lastPreviewRef.current ||
+      lastPreviewRef.current.targetColumnId !== newPreview.targetColumnId ||
+      lastPreviewRef.current.insertIndex !== newPreview.insertIndex ||
+      lastPreviewRef.current.isCrossColumn !== newPreview.isCrossColumn
+    ) {
+      lastPreviewRef.current = newPreview;
+      onDragPreviewChange?.(newPreview);
+    }
+  };
+  const applyTaskDragPreviewFromPointerRef = useRef(applyTaskDragPreviewFromPointer);
+  applyTaskDragPreviewFromPointerRef.current = applyTaskDragPreviewFromPointer;
+
+  const scheduleTaskPreviewFromPointer = () => {
+    if (rafHandleRef.current !== null) return;
+    rafHandleRef.current = requestAnimationFrame(() => {
+      rafHandleRef.current = null;
+      applyTaskDragPreviewFromPointerRef.current();
+    });
+  };
+  const scheduleTaskPreviewFromPointerRef = useRef(scheduleTaskPreviewFromPointer);
+  scheduleTaskPreviewFromPointerRef.current = scheduleTaskPreviewFromPointer;
+
   /** Pointer is in the tab strip — in-board insert must not commit. */
   const pointerOnBoardTabStrip = () =>
     !isKeyboardDragRef.current &&
@@ -519,7 +668,8 @@ export const SimpleDragDropManager: React.FC<SimpleDragDropManagerProps> = React
   const dragOverSkippedCountRef = useRef<number>(0);
   const dragOverProcessedCountRef = useRef<number>(0);
 
-  // Track pointer for board-tab / column-top drop recovery without React re-renders
+  // Preview must follow the pointer even over the column header — dnd-kit
+  // dragOver often does not fire there, so the hole would stay between cards.
   useEffect(() => {
     const handleMove = (e: MouseEvent | PointerEvent) => {
       mouseYRef.current = e.clientY;
@@ -528,6 +678,7 @@ export const SimpleDragDropManager: React.FC<SimpleDragDropManagerProps> = React
       if (!isDraggingTaskRef.current) return;
       const overlay = getTaskDragOverlayRect();
       if (overlay) overlayRectRef.current = overlay;
+      scheduleTaskPreviewFromPointerRef.current();
     };
 
     document.addEventListener('pointermove', handleMove, { passive: true });
@@ -817,207 +968,21 @@ export const SimpleDragDropManager: React.FC<SimpleDragDropManagerProps> = React
 
   const handleDragOver = (event: DragOverEvent) => {
     const { active } = event;
-    
     dragOverCallCountRef.current++;
-    
-    // PERFORMANCE: Throttle to max 60fps (16ms between updates)
-    const now = performance.now();
-    if (now - lastProcessTimeRef.current < THROTTLE_MS) {
-      // Skip this update - too soon since last one
-      dragOverSkippedCountRef.current++;
-      return;
-    }
-    
-    dragOverProcessedCountRef.current++;
-    
-    // PERFORMANCE: Cancel any pending RAF to avoid queuing multiple updates
-    if (rafHandleRef.current !== null) {
-      cancelAnimationFrame(rafHandleRef.current);
-    }
-    
-    // PERFORMANCE: Defer expensive operations to next animation frame
-    rafHandleRef.current = requestAnimationFrame(() => {
-      rafHandleRef.current = null;
-      lastProcessTimeRef.current = performance.now();
-      if (!isDraggingTaskRef.current && active.data?.current?.type === 'task') {
-        return;
-      }
-      
-      // FIRST: Check for mouse-based tab area detection (before any other logic)
-      const isTaskDrag = active.data?.current?.type === 'task';
-
-      if (isTaskDrag && isKeyboardDragRef.current) {
+    const isTaskDrag = active.data?.current?.type === 'task';
+    if (isTaskDrag) {
+      if (isKeyboardDragRef.current) {
         publishKeyboardSlotRef.current();
         return;
       }
-      
-      if (isTaskDrag) {
-        // Pure Y-coordinate based detection using dynamic tab bounds
-        const bounds = tabAreaBoundsRef.current;
-        const isInTabArea =
-          pointerInBoardTabStrip(mouseXRef.current, mouseYRef.current) ||
-          (mouseXRef.current >= bounds.left &&
-            mouseXRef.current <= bounds.right &&
-            mouseYRef.current >= bounds.top &&
-            mouseYRef.current <= bounds.bottom);
-        
-        if (isInTabArea && !isHoveringBoardTabRef.current) {
-          isHoveringBoardTabRef.current = true;
-          onBoardTabHover?.(true);
-          lastPreviewRef.current = null;
-          onDragPreviewChange?.(null);
-        } else if (!isInTabArea && isHoveringBoardTabRef.current) {
-          isHoveringBoardTabRef.current = false;
-          onBoardTabHover?.(false);
-        }
-      }
-      
-      if (isTaskDrag && isHoveringBoardTabRef.current) {
-        return;
-      }
-
-      const draggedTask = active.data?.current?.task as Task | undefined;
-      if (isTaskDrag && draggedTask) {
-        const origin = dragOriginRef.current;
-        const excludeIds = excludeIdsForDrag(
-          draggedTask.id,
-          activeBulkTaskIdsRef.current
-        );
-        const overlay = getTaskDragOverlayRect();
-        if (overlay) {
-          overlayRectRef.current = overlay;
-          if (overlayStartTopRef.current == null) {
-            overlayStartTopRef.current = overlay.top;
-            overlayStartLeftRef.current = overlay.left;
-          }
-        }
-        const hit = resolveKanbanDropTarget({
-          pointerX: mouseXRef.current,
-          pointerY: mouseYRef.current,
-          overlay,
-          origin,
-          excludeTaskIds: excludeIds,
-          overlayStartLeft: overlayStartLeftRef.current,
-        });
-        const columnId = hit?.columnId || null;
-        if (!columnId || !columnsRef.current[columnId] || hit == null) {
-          return;
-        }
-        const insertIndex = hit.insertIndex;
-        if (insertIndex == null) return;
-        const originColumnId = origin?.columnId || draggedTask.columnId;
-        let nextColumnId = columnId;
-        let nextInsert = insertIndex;
-        if (nextColumnId !== originColumnId) {
-          lastDestPreviewRef.current = { columnId: nextColumnId, insertIndex: nextInsert };
-          setTaskDropLock(draggedTask.id, originColumnId, lastDestPreviewRef.current);
-        } else if (lastDestPreviewRef.current) {
-          const last = lastDestPreviewRef.current;
-          const pointerCol = resolveColumnIdUnderPointer(
-            mouseXRef.current,
-            mouseYRef.current
-          );
-          const overlayCol = overlay
-            ? resolveColumnIdUnderRect(
-                overlay,
-                originColumnId,
-                overlayStartLeftRef.current
-              )
-            : null;
-          const sideways =
-            overlay != null &&
-            overlayStartLeftRef.current != null &&
-            Math.abs(overlay.left - overlayStartLeftRef.current) >= OVERLAY_SIDEWAYS_PX;
-          const pointerInOrigin = pointerCol === originColumnId;
-          const pointerDest =
-            pointerCol && pointerCol !== originColumnId ? pointerCol : null;
-          const overlayDest =
-            overlayCol && overlayCol !== originColumnId ? overlayCol : null;
-          const destInsertFor = (columnId: string, fallback: number) =>
-            (overlay
-              ? resolveInsertIndexFromOverlay(
-                  columnId,
-                  overlay,
-                  excludeIds,
-                  origin
-                )
-              : resolveInsertIndexUnderPointer(
-                  columnId,
-                  mouseYRef.current,
-                  excludeIds,
-                  mouseXRef.current,
-                  null,
-                  origin
-                )) ?? fallback;
-          // Pointer still in the source column: stay there. Overlay sliver
-          // used to keep dest locked and freeze insert index.
-          if (pointerInOrigin) {
-            lastDestPreviewRef.current = null;
-          } else if (pointerDest && pointerDest !== last.columnId) {
-            const destInsert = destInsertFor(pointerDest, nextInsert);
-            lastDestPreviewRef.current = {
-              columnId: pointerDest,
-              insertIndex: destInsert,
-            };
-            nextColumnId = pointerDest;
-            nextInsert = destInsert;
-            setTaskDropLock(
-              draggedTask.id,
-              originColumnId,
-              lastDestPreviewRef.current
-            );
-          } else if (overlayDest && overlayDest !== last.columnId && sideways) {
-            const destInsert = destInsertFor(overlayDest, nextInsert);
-            lastDestPreviewRef.current = {
-              columnId: overlayDest,
-              insertIndex: destInsert,
-            };
-            nextColumnId = overlayDest;
-            nextInsert = destInsert;
-            setTaskDropLock(
-              draggedTask.id,
-              originColumnId,
-              lastDestPreviewRef.current
-            );
-          } else if (pointerDest) {
-            const destInsert = destInsertFor(pointerDest, last.insertIndex);
-            nextColumnId = pointerDest;
-            nextInsert = destInsert;
-            lastDestPreviewRef.current = {
-              columnId: pointerDest,
-              insertIndex: destInsert,
-            };
-            setTaskDropLock(
-              draggedTask.id,
-              originColumnId,
-              lastDestPreviewRef.current
-            );
-          } else {
-            lastDestPreviewRef.current = null;
-          }
-        }
-        const newPreview = {
-          targetColumnId: nextColumnId,
-          insertIndex: nextInsert,
-          isCrossColumn: originColumnId !== nextColumnId,
-        };
-        if (
-          !lastPreviewRef.current ||
-          lastPreviewRef.current.targetColumnId !== newPreview.targetColumnId ||
-          lastPreviewRef.current.insertIndex !== newPreview.insertIndex ||
-          lastPreviewRef.current.isCrossColumn !== newPreview.isCrossColumn
-        ) {
-          lastPreviewRef.current = newPreview;
-          onDragPreviewChange?.(newPreview);
-        }
-        return;
-      }
-
-      if (!isTaskDrag && lastPreviewRef.current !== null) {
-        lastPreviewRef.current = null;
-        onDragPreviewChange?.(null);
-      }
-    });
+      dragOverProcessedCountRef.current++;
+      scheduleTaskPreviewFromPointer();
+      return;
+    }
+    if (lastPreviewRef.current !== null) {
+      lastPreviewRef.current = null;
+      onDragPreviewChange?.(null);
+    }
   };
 
   const handleDragEnd = async (event: DragEndEvent) => {

--- a/src/components/dnd/SimpleDragOverlay.tsx
+++ b/src/components/dnd/SimpleDragOverlay.tsx
@@ -276,7 +276,7 @@ const TaskDragPreview: React.FC<{
         })}
       <div
         data-kanban-drag-overlay
-        className="relative z-10 bg-white rounded-lg shadow-2xl border border-gray-200 p-4 w-80 transform rotate-3 scale-105 opacity-90 ring-2 ring-blue-400"
+        className="relative z-10 bg-white rounded-lg shadow-2xl border border-gray-200 p-4 w-80 opacity-90 ring-2 ring-blue-400"
       >
         {isMultiDrag && (
           <div className="absolute -top-2 -right-2 z-20 flex h-6 min-w-[1.5rem] items-center justify-center rounded-full bg-blue-600 px-1.5 text-xs font-bold text-white shadow">

--- a/src/utils/dndInsertIndex.ts
+++ b/src/utils/dndInsertIndex.ts
@@ -19,6 +19,8 @@ import { insertIndexFromColumnLayout } from './columnVirtualLayout';
 const INSERT_HYSTERESIS_PX = 6;
 /** Ghost past the task-list edge by this much snaps to top/bottom. */
 const COLUMN_EDGE_MAGNET_PX = 12;
+/** Ignore midY jitter smaller than this when deciding up vs down. */
+const DIRECTION_DEADZONE_PX = 2;
 /** Overlay width in a second column that counts as “straddling”. */
 const STRADDLE_COLUMN_MIN_WIDTH = 24;
 
@@ -26,7 +28,16 @@ type InsertHysteresis = {
   columnId: string;
   insertIndex: number;
   midY: number;
+  movingDown: boolean;
 };
+
+/** Ghost top edge at the first card’s top — slot 0, independent of drag speed. */
+function overlayAtFirstCardTop(
+  overlay: DOMRectReadOnly,
+  first: { index: number; top: number }
+): boolean {
+  return first.index === 0 && overlay.top <= first.top + COLUMN_EDGE_MAGNET_PX;
+}
 
 let insertHysteresis: InsertHysteresis | null = null;
 
@@ -466,7 +477,16 @@ export function resolveInsertAtColumnStackEnds(
     const tr = topZone.getBoundingClientRect();
     if (pointerY >= tr.top && pointerY <= tr.bottom + 4) return 0;
   }
+  const header = root.querySelector('[data-column-header]');
+  if (header instanceof HTMLElement) {
+    const hr = header.getBoundingClientRect();
+    if (pointerY >= hr.top - 4 && pointerY <= hr.bottom + 8) return 0;
+    if (overlay && overlay.top <= hr.bottom + 8 && overlay.top + 24 >= hr.top) {
+      return 0;
+    }
+  }
   if (firstIsColumnStart) {
+    if (overlay && overlayAtFirstCardTop(overlay, first)) return 0;
     if (pointerY <= first.top + 4) return 0;
     if (overlay && overlay.bottom <= first.top + 8) return 0;
   }
@@ -477,6 +497,10 @@ export function resolveInsertAtColumnStackEnds(
 /**
  * Leading-edge vs card midlines. Down: ghost bottom crosses next midline →
  * increment. Up: ghost top crosses previous midline → decrement.
+ *
+ * A title-only stack can be shorter than the ghost. overlay.bottom past the
+ * last card is then true even when the ghost still sits on the first card —
+ * that must not snap to the end (the hole would vanish at the top).
  */
 function insertIndexFromOverlayEdges(
   rows: LayoutRow[],
@@ -489,10 +513,22 @@ function insertIndexFromOverlayEdges(
   if (overlay.bottom <= first.top + COLUMN_EDGE_MAGNET_PX) {
     return first.index;
   }
-  // Past the last *mounted* card’s midline → end only when that card is last.
+
+  // Top of column: ghost top vs first card top. Do not require “moving up”
+  // — slow drags otherwise sit on the first card with midY ticking down and
+  // never open slot 0.
+  if (overlayAtFirstCardTop(overlay, first)) {
+    return 0;
+  }
+
+  const topOnFirstCard = overlay.top < rowMidline(first);
+
+  // Past the last *mounted* card only when the ghost has actually moved down
+  // off the first card (not merely because the ghost is taller than the stack).
   if (
-    overlay.top >= rowMidline(last) - 2 ||
-    overlay.bottom >= last.top + last.height - 4
+    !topOnFirstCard &&
+    (overlay.top >= rowMidline(last) - 2 ||
+      overlay.bottom >= last.top + last.height - 4)
   ) {
     if (lastVisibleIsColumnEnd(last.index, layoutCount)) {
       return layoutCount != null ? layoutCount : last.index + 1;
@@ -516,33 +552,45 @@ function applyInsertHysteresis(
   columnId: string,
   rows: LayoutRow[],
   overlay: DOMRectReadOnly,
-  raw: number
+  raw: number,
+  movingDown: boolean
 ): number {
   const midY = overlay.top + overlay.height / 2;
+  const remember = (insertIndex: number) => {
+    insertHysteresis = { columnId, insertIndex, midY, movingDown };
+    return insertIndex;
+  };
+  const first = rows[0];
+  if (first && overlayAtFirstCardTop(overlay, first)) {
+    return remember(0);
+  }
+  if (
+    first &&
+    insertHysteresis?.columnId === columnId &&
+    insertHysteresis.insertIndex === 0 &&
+    overlay.top <= first.top + COLUMN_EDGE_MAGNET_PX + INSERT_HYSTERESIS_PX
+  ) {
+    return remember(0);
+  }
   const last = insertHysteresis?.columnId === columnId ? insertHysteresis : null;
   if (!last) {
-    insertHysteresis = { columnId, insertIndex: raw, midY };
-    return raw;
+    return remember(raw);
   }
   if (raw === last.insertIndex) {
-    insertHysteresis = { columnId, insertIndex: raw, midY };
-    return raw;
+    return remember(raw);
   }
   if (raw > last.insertIndex) {
     const crossed = rows.find((r) => r.index === last.insertIndex);
     if (crossed && overlay.bottom < rowMidline(crossed) + INSERT_HYSTERESIS_PX) {
-      insertHysteresis = { columnId, insertIndex: last.insertIndex, midY };
-      return last.insertIndex;
+      return remember(last.insertIndex);
     }
   } else {
     const prev = rows.find((r) => r.index === last.insertIndex - 1);
     if (prev && overlay.top > rowMidline(prev) - INSERT_HYSTERESIS_PX) {
-      insertHysteresis = { columnId, insertIndex: last.insertIndex, midY };
-      return last.insertIndex;
+      return remember(last.insertIndex);
     }
   }
-  insertHysteresis = { columnId, insertIndex: raw, midY };
-  return raw;
+  return remember(raw);
 }
 
 /**
@@ -593,8 +641,8 @@ export function resolveInsertIndexFromOverlay(
   if (!root) return null;
 
   const midY = overlay.top + overlay.height / 2;
-  const remember = (insertIndex: number) => {
-    insertHysteresis = { columnId, insertIndex, midY };
+  const remember = (insertIndex: number, movingDown = false) => {
+    insertHysteresis = { columnId, insertIndex, midY, movingDown };
     return insertIndex;
   };
 
@@ -606,10 +654,14 @@ export function resolveInsertIndexFromOverlay(
     .filter((row) => !rowIsExcluded(row, exclude))
     .map((row) => {
       const index = Number(row.dataset.layoutIndex);
-      const rect = row.getBoundingClientRect();
+      const card =
+        row.firstElementChild instanceof HTMLElement
+          ? row.firstElementChild
+          : row;
+      const rect = card.getBoundingClientRect();
       return { index, top: rect.top, height: rect.height };
     })
-    .filter((r) => Number.isFinite(r.index) && r.index >= 0 && r.height > 0)
+    .filter((r) => Number.isFinite(r.index) && r.index >= 0 && r.height > 8)
     .sort((a, b) => a.index - b.index);
 
   const list = columnTaskList(root);
@@ -624,9 +676,11 @@ export function resolveInsertIndexFromOverlay(
   const lastRow = rows[rows.length - 1];
   const y = pointerY ?? midY;
   const lastIsColumnEnd = lastVisibleIsColumnEnd(lastRow.index, layoutCount);
+  const topOnFirstCard = overlay.top < rowMidline(rows[0]);
 
   if (
     lastIsColumnEnd &&
+    !topOnFirstCard &&
     ((pointerY != null && pointerY >= lastRow.top + lastRow.height - 8) ||
       overlay.top >= rowMidline(lastRow))
   ) {
@@ -638,9 +692,18 @@ export function resolveInsertIndexFromOverlay(
   }
 
   const last = insertHysteresis?.columnId === columnId ? insertHysteresis : null;
-  const movingDown = last == null || midY >= last.midY;
-  const raw = insertIndexFromOverlayEdges(rows, overlay, movingDown, layoutCount);
-  return applyInsertHysteresis(columnId, rows, overlay, raw);
+  let movingDown = last?.movingDown ?? !topOnFirstCard;
+  if (last) {
+    if (midY > last.midY + DIRECTION_DEADZONE_PX) movingDown = true;
+    else if (midY < last.midY - DIRECTION_DEADZONE_PX) movingDown = false;
+  }
+  const raw = insertIndexFromOverlayEdges(
+    rows,
+    overlay,
+    movingDown,
+    layoutCount
+  );
+  return applyInsertHysteresis(columnId, rows, overlay, raw, movingDown);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Keep the Drop here hole at the top of a column when the ghost sits on the header or first card (pointer-driven preview, not only dnd-kit dragOver).
- Treat the ghost top edge / column title as slot 0 so short title-only stacks no longer snap the hole to the end.
- Also includes board membership, acceptance criteria, and demo seed work already on `dev`.

## Test plan
- [ ] 3+ title-only cards in one column: drag the first card down, then back to the top (slow and fast). Hole opens above the first remaining card.
- [ ] Hold the ghost on the column title: “Drop here” is at the top, not between cards 1 and 2.
- [ ] Same-column reorder and add-to-bottom still work.


Made with [Cursor](https://cursor.com)