### PR TITLE
Keep board tab counts in sync and stop short-card drag jump

### DIFF
--- a/docs/WEBSOCKET_PUBLISH_ENDPOINTS.md
+++ b/docs/WEBSOCKET_PUBLISH_ENDPOINTS.md
@@ -78,10 +78,10 @@ This document lists endpoints that publish for real-time WebSocket updates, orga
    - **Optimization**: ⚠️ Send only position change
 
 8. **POST `/tasks/move-to-board`** - Move task to different board
-   - Channel: `task-updated` (2 publishes - source and target boards)
-   - Lines: 1989, 1998
-   - Payload: `{ boardId, task: fullTaskWithRelationships, timestamp }`
-   - **Size**: ~5-30KB × 2
+   - Channels: `task-updated` (source + dest board rooms), then `task-deleted` (source) + `task-created` (dest) tenant-wide for tab counters
+   - Payload (updated): `{ boardId, task: fullTaskWithRelationships, timestamp }`
+   - Payload (deleted): `{ boardId: sourceBoardId, taskId, movedToBoardId, timestamp }`
+   - **Size**: ~5-30KB × 2 updates + compact membership events
    - **Optimization**: ⚠️ Send only boardId, columnId, position changes
 
 ### Task Collaboration Operations

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -2986,6 +2986,23 @@ router.post('/move-to-board', authenticateToken, async (req, res) => {
       },
       timestamp: new Date().toISOString()
     }, tenantId);
+
+    // Tenant-wide membership so tab counters update for sessions that only
+    // joined the board they are viewing (task-updated stays board-scoped).
+    await notificationService.publish('task-deleted', {
+      boardId: originalBoardId,
+      taskId,
+      movedToBoardId: targetBoardId,
+      timestamp: new Date().toISOString()
+    }, tenantId);
+    await notificationService.publish('task-created', {
+      boardId: targetBoardId,
+      task: {
+        ...taskResponse,
+        updatedBy: userId
+      },
+      timestamp: new Date().toISOString()
+    }, tenantId);
     
     res.json({ 
       success: true, 

--- a/server/services/websocketService.js
+++ b/server/services/websocketService.js
@@ -340,11 +340,20 @@ class WebSocketService {
       this.io?.to(adminRoom).emit(event, data);
       return;
     }
+    this.emitTenantWide(event, data, tenantId);
+  }
+
+  /**
+   * Every connected session joins `tenant-${tenantId}` (or the default io
+   * namespace in single-tenant). Use for tab-count membership — not for
+   * high-volume task-updated / position streams.
+   */
+  emitTenantWide(event, data, tenantId) {
     if (tenantId) {
       this.io?.to(`tenant-${tenantId}`).emit(event, data);
-    } else {
-      this.io?.emit(event, data);
+      return;
     }
+    this.io?.emit(event, data);
   }
 
   // Get tenant-prefixed room name (for multi-tenant isolation)
@@ -379,7 +388,7 @@ class WebSocketService {
       const timestamp = new Date().toISOString();
       wsVerboseLog(`📡 [${timestamp}] WebSocket received task-created (tenant: ${tenantId || 'single'})`);
       
-      this.emitBoardScoped('task-created', data, tenantId);
+      this.emitTenantWide('task-created', data, tenantId);
     });
 
     // Agent task_work updates (status / log / control)
@@ -396,7 +405,7 @@ class WebSocketService {
       const timestamp = new Date().toISOString();
       wsVerboseLog(`📡 [${timestamp}] WebSocket broadcasting task-deleted (tenant: ${tenantId || 'single'})`);
       
-      this.emitBoardScoped('task-deleted', data, tenantId);
+      this.emitTenantWide('task-deleted', data, tenantId);
     });
 
     // Soft-deleted task restored to live board

--- a/src/components/BoardTabs.tsx
+++ b/src/components/BoardTabs.tsx
@@ -550,9 +550,9 @@ const SortableBoardTab: React.FC<{
               {board.title}
             </div>
             {(() => {
-              const deletedTaskCount = deleteConfirmTaskCount ?? totalTaskCount ?? taskCount ?? 0;
-              return deletedTaskCount > 0
-                ? t('boardTabs.moveBoardToTrashAndTasks', { count: deletedTaskCount })
+              const liveTaskCount = deleteConfirmTaskCount ?? totalTaskCount ?? 0;
+              return liveTaskCount > 0
+                ? t('boardTabs.moveBoardToTrashAndTasks', { count: liveTaskCount })
                 : t('boardTabs.moveBoardToTrash');
             })()}
           </div>
@@ -968,12 +968,14 @@ export default function BoardTabs({
       } catch {
         trashCountForBoard = 0;
       }
-      const total = liveCount + trashCountForBoard;
-      if (total === 0) {
+      // Trash tasks are already in trash — do not add them to the "move N
+      // tasks to trash" copy. Still confirm (do not auto-purge) when only
+      // trash remains, because deleteBoard keeps that trash with the board.
+      if (liveCount === 0 && trashCountForBoard === 0) {
         confirmDeleteBoard(boardId);
         return;
       }
-      setDeleteConfirmTaskCount(total);
+      setDeleteConfirmTaskCount(liveCount);
       setShowDeleteConfirm(boardId);
     })();
   };

--- a/src/hooks/useTaskWebSocket.ts
+++ b/src/hooks/useTaskWebSocket.ts
@@ -655,19 +655,20 @@ export const useTaskWebSocket = ({
       pendingTaskRefreshesRef.current.delete(data.task.id);
     }
     
-    // Always update boards state for task count updates (for all boards)
+    // Tab pills count tasks in every cached board. Tenant-wide create (and
+    // cross-board move) must strip the id everywhere, then add only on boards
+    // this session already has — never invent a board the user cannot access.
+    const createdTaskId = data.task.id;
+    const createdColumnId = data.task.columnId;
     setBoards(prevBoards => {
-      const targetColumnId = data.task.columnId;
-      const boardExists = prevBoards.some(b => b.id === data.boardId);
+      const destKnown = prevBoards.some((b) => b.id === data.boardId);
 
-      // Lifecycle "restore board then tasks" can deliver task-restored before board-restored
-      // is applied. Dropping the task here left peers with an empty restored board until refresh.
       const ensureColumn = (columns: Columns): Columns => {
         const next = { ...columns };
-        if (!targetColumnId) return next;
-        if (!next[targetColumnId]) {
-          next[targetColumnId] = {
-            id: targetColumnId,
+        if (!createdColumnId) return next;
+        if (!next[createdColumnId]) {
+          next[createdColumnId] = {
+            id: createdColumnId,
             boardId: data.boardId,
             title: 'Unknown Column',
             tasks: [],
@@ -676,12 +677,12 @@ export const useTaskWebSocket = ({
             is_archived: false,
           };
         }
-        const existingTasks = next[targetColumnId].tasks || [];
-        const taskExists = existingTasks.some((t) => t.id === data.task.id);
-        next[targetColumnId] = {
-          ...next[targetColumnId],
+        const existingTasks = next[createdColumnId].tasks || [];
+        const taskExists = existingTasks.some((t) => t.id === createdTaskId);
+        next[createdColumnId] = {
+          ...next[createdColumnId],
           tasks: taskExists
-            ? existingTasks.map((t) => (t.id === data.task.id ? data.task : t))
+            ? existingTasks.map((t) => (t.id === createdTaskId ? { ...t, ...data.task } : t))
             : [...existingTasks, data.task].sort(
                 (a, b) => (a.position || 0) - (b.position || 0)
               ),
@@ -689,34 +690,33 @@ export const useTaskWebSocket = ({
         return next;
       };
 
-      if (!boardExists) {
-        return [
-          ...prevBoards,
-          {
-            id: data.boardId,
-            title: data.boardTitle || data.task?.boardTitle || 'Board',
-            columns: ensureColumn({}),
-            deletedAt: null,
-          } as Board,
-        ];
-      }
-
       return prevBoards.map((board) => {
-        if (board.id !== data.boardId) return board;
-        return {
-          ...board,
-          deletedAt: null,
-          columns: ensureColumn(board.columns || {}),
-        };
+        const stripped = stripTaskFromAllColumns(board.columns || {}, createdTaskId, {
+          renumber: false,
+        });
+        if (destKnown && board.id === data.boardId) {
+          return {
+            ...board,
+            deletedAt: null,
+            columns: ensureColumn(stripped),
+          };
+        }
+        if (stripped === board.columns) return board;
+        return { ...board, columns: stripped };
       });
     });
     
-    // Only update columns/filteredColumns if the task is for the currently selected board
-    if (data.boardId === selectedBoardRef.current) {
-      // Optimized: Add the specific task instead of full refresh
-      setColumns(prevColumns => {
-        const updatedColumns = { ...prevColumns };
-        const targetColumnId = data.task.columnId;
+    // Visible board: always drop a stale copy (move-from-here), then insert if dest.
+    setColumns((prevColumns) => {
+      const stripped = stripTaskFromAllColumns(prevColumns, createdTaskId, {
+        exceptColumnId: data.boardId === selectedBoardRef.current ? createdColumnId : undefined,
+        renumber: false,
+      });
+      if (data.boardId !== selectedBoardRef.current) {
+        return stripped;
+      }
+      const updatedColumns = { ...stripped };
+      const targetColumnId = createdColumnId;
         
         if (!updatedColumns[targetColumnId] && targetColumnId) {
           // Column doesn't exist yet - create it (similar to boards handler)
@@ -781,7 +781,7 @@ export const useTaskWebSocket = ({
           }
         }
         // Ensure created task isn't also lingering in another column
-        return stripTaskFromAllColumns(updatedColumns, data.task.id, {
+        return stripTaskFromAllColumns(updatedColumns, createdTaskId, {
           exceptColumnId: targetColumnId,
           renumber: false,
         });
@@ -789,7 +789,6 @@ export const useTaskWebSocket = ({
       
       // DON'T update filteredColumns here - let the filtering useEffect handle it
       // This prevents duplicate tasks when the effect runs after columns change
-    }
   }, [setBoards, setColumns, selectedBoardRef, pendingTaskRefreshesRef, recentlyDeletedTasksRef]);
 
   const handleTaskUpdated = useCallback((data: any) => {
@@ -824,32 +823,16 @@ export const useTaskWebSocket = ({
   const handleTaskDeleted = useCallback((data: any) => {
     if (!data.taskId || !data.boardId) return;
     
-    // Always update boards state for task count updates (for all boards)
+    // Only the named board (source on a cross-board move). Do not strip every
+    // board — a later task-created may already have placed the card on dest.
     setBoards(prevBoards => {
       return prevBoards.map(board => {
-        if (board.id === data.boardId) {
-          const updatedBoard = { ...board };
-          const updatedColumns = { ...updatedBoard.columns };
-          
-          // Find and remove the task from the appropriate column
-          Object.keys(updatedColumns).forEach(columnId => {
-            const column = updatedColumns[columnId];
-            const taskIndex = column.tasks.findIndex(t => t.id === data.taskId);
-            if (taskIndex !== -1) {
-              // Keep position gaps (matches server soft-delete) so restore can reclaim its slot
-              const remainingTasks = column.tasks.filter(task => task.id !== data.taskId);
-              
-              updatedColumns[columnId] = {
-                ...column,
-                tasks: remainingTasks
-              };
-            }
-          });
-          
-          updatedBoard.columns = updatedColumns;
-          return updatedBoard;
-        }
-        return board;
+        if (board.id !== data.boardId) return board;
+        const updatedColumns = stripTaskFromAllColumns(board.columns || {}, data.taskId, {
+          renumber: false,
+        });
+        if (updatedColumns === board.columns) return board;
+        return { ...board, columns: updatedColumns };
       });
     });
     

--- a/src/utils/columnVirtualLayout.ts
+++ b/src/utils/columnVirtualLayout.ts
@@ -52,10 +52,11 @@ export function insertIndexFromColumnLayout(
   const listTop = layout.listEl.getBoundingClientRect().top;
   const yIn = viewportY - listTop;
   if (yIn < 0) return 0;
+  let acc = 0;
   for (let i = 0; i < layout.layoutCount; i++) {
-    const top = layout.offsetOfLayoutIndex(i);
     const h = Math.max(1, layout.heightOfLayoutIndex(i));
-    if (yIn < top + h / 2) return i;
+    if (yIn < acc + h / 2) return i;
+    acc += h;
   }
   return layout.layoutCount;
 }

--- a/src/utils/dndInsertIndex.ts
+++ b/src/utils/dndInsertIndex.ts
@@ -31,12 +31,49 @@ type InsertHysteresis = {
   movingDown: boolean;
 };
 
-/** Ghost top edge at the first card’s top — slot 0, independent of drag speed. */
+/**
+ * Ghost top edge at the first card’s top — slot 0.
+ * Pointer below the first-card magnet must not force slot 0: a tall ghost on a
+ * short card used to flip 0↔1 every frame as the 76px hole shoved the stack.
+ */
 function overlayAtFirstCardTop(
   overlay: DOMRectReadOnly,
-  first: { index: number; top: number }
+  first: { index: number; top: number },
+  pointerY?: number
 ): boolean {
-  return first.index === 0 && overlay.top <= first.top + COLUMN_EDGE_MAGNET_PX;
+  if (first.index !== 0) return false;
+  if (
+    pointerY != null &&
+    Number.isFinite(pointerY) &&
+    pointerY > first.top + COLUMN_EDGE_MAGNET_PX + 8
+  ) {
+    return false;
+  }
+  return overlay.top <= first.top + COLUMN_EDGE_MAGNET_PX;
+}
+
+/** Live card boxes include the Drop here hole; targeting must not. */
+function unshiftRowsByHole<T extends { index: number; top: number }>(
+  rows: T[],
+  hole: { index: number; top: number; bottom: number } | null
+): T[] {
+  if (!hole || rows.length === 0) return rows;
+  const holeH = Math.max(0, hole.bottom - hole.top);
+  if (holeH < 8) return rows;
+  return rows.map((row) => {
+    if (row.index < hole.index) return row;
+    const next = { ...row, top: row.top - holeH };
+    if ('bottom' in row && typeof (row as { bottom?: number }).bottom === 'number') {
+      (next as T & { bottom: number }).bottom =
+        (row as T & { bottom: number }).bottom - holeH;
+    }
+    return next;
+  });
+}
+
+function overlayProbeY(overlay: DOMRectReadOnly, pointerY?: number): number {
+  if (pointerY != null && Number.isFinite(pointerY)) return pointerY;
+  return overlay.top + Math.min(28, overlay.height / 2);
 }
 
 let insertHysteresis: InsertHysteresis | null = null;
@@ -436,18 +473,17 @@ export function resolveInsertAtColumnStackEnds(
 ): number | null {
   const root = columnRootById(columnId);
   if (!root) return null;
-  const cards = visibleCardBoxes(root, excludeTaskIds);
-  const end = stackEndIndex(root, cards);
-  if (cards.length === 0) return end;
+  const rawCards = visibleCardBoxes(root, excludeTaskIds);
+  const end = stackEndIndex(root, rawCards);
+  if (rawCards.length === 0) return end;
 
+  const hole = paintedHoleInColumn(root);
+  const cards = unshiftRowsByHole(rawCards, hole);
   const first = cards[0];
   const last = cards[cards.length - 1];
   const lastIsColumnEnd = lastVisibleIsColumnEnd(last.index, end);
   const firstIsColumnStart = first.index === 0;
-  const hole = paintedHoleInColumn(root);
-  const holeShiftsLast = hole != null && hole.index <= last.index;
-  const holeH = holeShiftsLast ? Math.max(0, hole.bottom - hole.top) : 0;
-  const lastNaturalBottom = last.bottom - holeH;
+  const lastNaturalBottom = last.bottom;
 
   const bottomZone = root.querySelector('[data-kanban-column-bottom]');
   if (bottomZone instanceof HTMLElement) {
@@ -462,8 +498,7 @@ export function resolveInsertAtColumnStackEnds(
     if (hole && hole.index === last.index) {
       if (
         pointerY >= hole.bottom - 6 ||
-        (overlay != null &&
-          (overlay.top >= hole.bottom - 4 || overlay.bottom >= hole.bottom + 12))
+        (overlay != null && overlay.top >= hole.bottom - 4)
       ) {
         return end;
       }
@@ -486,7 +521,7 @@ export function resolveInsertAtColumnStackEnds(
     }
   }
   if (firstIsColumnStart) {
-    if (overlay && overlayAtFirstCardTop(overlay, first)) return 0;
+    if (overlay && overlayAtFirstCardTop(overlay, first, pointerY)) return 0;
     if (pointerY <= first.top + 4) return 0;
     if (overlay && overlay.bottom <= first.top + 8) return 0;
   }
@@ -505,8 +540,9 @@ export function resolveInsertAtColumnStackEnds(
 function insertIndexFromOverlayEdges(
   rows: LayoutRow[],
   overlay: DOMRectReadOnly,
-  movingDown: boolean,
-  layoutCount: number | null
+  probeY: number,
+  layoutCount: number | null,
+  pointerY?: number
 ): number {
   const first = rows[0];
   const last = rows[rows.length - 1];
@@ -517,29 +553,24 @@ function insertIndexFromOverlayEdges(
   // Top of column: ghost top vs first card top. Do not require “moving up”
   // — slow drags otherwise sit on the first card with midY ticking down and
   // never open slot 0.
-  if (overlayAtFirstCardTop(overlay, first)) {
+  if (overlayAtFirstCardTop(overlay, first, pointerY)) {
     return 0;
   }
 
   const topOnFirstCard = overlay.top < rowMidline(first);
 
-  // Past the last *mounted* card only when the ghost has actually moved down
+  // Past the last *mounted* card only when the probe has actually moved down
   // off the first card (not merely because the ghost is taller than the stack).
-  if (
-    !topOnFirstCard &&
-    (overlay.top >= rowMidline(last) - 2 ||
-      overlay.bottom >= last.top + last.height - 4)
-  ) {
+  if (!topOnFirstCard && probeY >= last.top + last.height - 4) {
     if (lastVisibleIsColumnEnd(last.index, layoutCount)) {
       return layoutCount != null ? layoutCount : last.index + 1;
     }
     return last.index + 1;
   }
 
-  const edge = movingDown ? overlay.bottom : overlay.top;
   let insert = last.index + 1;
   for (const row of rows) {
-    if (edge < rowMidline(row)) {
+    if (probeY < rowMidline(row)) {
       insert = row.index;
       break;
     }
@@ -553,7 +584,9 @@ function applyInsertHysteresis(
   rows: LayoutRow[],
   overlay: DOMRectReadOnly,
   raw: number,
-  movingDown: boolean
+  movingDown: boolean,
+  probeY: number,
+  pointerY?: number
 ): number {
   const midY = overlay.top + overlay.height / 2;
   const remember = (insertIndex: number) => {
@@ -561,14 +594,15 @@ function applyInsertHysteresis(
     return insertIndex;
   };
   const first = rows[0];
-  if (first && overlayAtFirstCardTop(overlay, first)) {
+  if (first && overlayAtFirstCardTop(overlay, first, pointerY)) {
     return remember(0);
   }
   if (
     first &&
     insertHysteresis?.columnId === columnId &&
     insertHysteresis.insertIndex === 0 &&
-    overlay.top <= first.top + COLUMN_EDGE_MAGNET_PX + INSERT_HYSTERESIS_PX
+    overlay.top <= first.top + COLUMN_EDGE_MAGNET_PX + INSERT_HYSTERESIS_PX &&
+    (pointerY == null || pointerY <= first.top + COLUMN_EDGE_MAGNET_PX + INSERT_HYSTERESIS_PX + 8)
   ) {
     return remember(0);
   }
@@ -581,12 +615,12 @@ function applyInsertHysteresis(
   }
   if (raw > last.insertIndex) {
     const crossed = rows.find((r) => r.index === last.insertIndex);
-    if (crossed && overlay.bottom < rowMidline(crossed) + INSERT_HYSTERESIS_PX) {
+    if (crossed && probeY < rowMidline(crossed) + INSERT_HYSTERESIS_PX) {
       return remember(last.insertIndex);
     }
   } else {
     const prev = rows.find((r) => r.index === last.insertIndex - 1);
-    if (prev && overlay.top > rowMidline(prev) - INSERT_HYSTERESIS_PX) {
+    if (prev && probeY > rowMidline(prev) - INSERT_HYSTERESIS_PX) {
       return remember(last.insertIndex);
     }
   }
@@ -650,45 +684,48 @@ export function resolveInsertIndexFromOverlay(
   if (outside != null) return remember(outside);
 
   const exclude = toExcludeSet(excludeTaskIds);
-  const rows = Array.from(root.querySelectorAll<HTMLElement>('[data-kanban-task-row]'))
-    .filter((row) => !rowIsExcluded(row, exclude))
-    .map((row) => {
-      const index = Number(row.dataset.layoutIndex);
-      const card =
-        row.firstElementChild instanceof HTMLElement
-          ? row.firstElementChild
-          : row;
-      const rect = card.getBoundingClientRect();
-      return { index, top: rect.top, height: rect.height };
-    })
-    .filter((r) => Number.isFinite(r.index) && r.index >= 0 && r.height > 8)
-    .sort((a, b) => a.index - b.index);
+  const hole = paintedHoleInColumn(root);
+  const rows = unshiftRowsByHole(
+    Array.from(root.querySelectorAll<HTMLElement>('[data-kanban-task-row]'))
+      .filter((row) => !rowIsExcluded(row, exclude))
+      .map((row) => {
+        const index = Number(row.dataset.layoutIndex);
+        const card =
+          row.firstElementChild instanceof HTMLElement
+            ? row.firstElementChild
+            : row;
+        const rect = card.getBoundingClientRect();
+        return { index, top: rect.top, height: rect.height };
+      })
+      .filter((r) => Number.isFinite(r.index) && r.index >= 0 && r.height > 8)
+      .sort((a, b) => a.index - b.index),
+    hole
+  );
 
   const list = columnTaskList(root);
   const layoutCount = list ? layoutCountForList(list) : null;
+  const probeY = overlayProbeY(overlay, pointerY);
 
   if (rows.length === 0) {
     return remember(
-      insertFromVirtualOrVisible(columnId, pointerY ?? midY, rows, layoutCount)
+      insertFromVirtualOrVisible(columnId, probeY, rows, layoutCount)
     );
   }
 
   const lastRow = rows[rows.length - 1];
-  const y = pointerY ?? midY;
   const lastIsColumnEnd = lastVisibleIsColumnEnd(lastRow.index, layoutCount);
   const topOnFirstCard = overlay.top < rowMidline(rows[0]);
 
   if (
     lastIsColumnEnd &&
     !topOnFirstCard &&
-    ((pointerY != null && pointerY >= lastRow.top + lastRow.height - 8) ||
-      overlay.top >= rowMidline(lastRow))
+    probeY >= lastRow.top + lastRow.height - 8
   ) {
     return remember(layoutCount != null ? layoutCount : lastRow.index + 1);
   }
 
-  if (!yInVisibleRowCluster(y, rows, overlay)) {
-    return remember(insertFromVirtualOrVisible(columnId, y, rows, layoutCount));
+  if (!yInVisibleRowCluster(probeY, rows, overlay)) {
+    return remember(insertFromVirtualOrVisible(columnId, probeY, rows, layoutCount));
   }
 
   const last = insertHysteresis?.columnId === columnId ? insertHysteresis : null;
@@ -700,10 +737,19 @@ export function resolveInsertIndexFromOverlay(
   const raw = insertIndexFromOverlayEdges(
     rows,
     overlay,
-    movingDown,
-    layoutCount
+    probeY,
+    layoutCount,
+    pointerY
   );
-  return applyInsertHysteresis(columnId, rows, overlay, raw, movingDown);
+  return applyInsertHysteresis(
+    columnId,
+    rows,
+    overlay,
+    raw,
+    movingDown,
+    probeY,
+    pointerY
+  );
 }
 
 /**
@@ -864,19 +910,23 @@ export function resolveInsertIndexUnderPointer(
   if (outside != null) return outside;
 
   const exclude = toExcludeSet(excludeTaskIds);
-  const rows = Array.from(root.querySelectorAll<HTMLElement>('[data-kanban-task-row]'))
-    .filter((row) => !rowIsExcluded(row, exclude))
-    .map((row) => {
-      const index = Number(row.dataset.layoutIndex);
-      const rect = row.getBoundingClientRect();
-      return {
-        index,
-        top: rect.top,
-        height: rect.height,
-      };
-    })
-    .filter((r) => Number.isFinite(r.index) && r.index >= 0 && r.height > 0)
-    .sort((a, b) => a.index - b.index);
+  const hole = paintedHoleInColumn(root);
+  const rows = unshiftRowsByHole(
+    Array.from(root.querySelectorAll<HTMLElement>('[data-kanban-task-row]'))
+      .filter((row) => !rowIsExcluded(row, exclude))
+      .map((row) => {
+        const index = Number(row.dataset.layoutIndex);
+        const rect = row.getBoundingClientRect();
+        return {
+          index,
+          top: rect.top,
+          height: rect.height,
+        };
+      })
+      .filter((r) => Number.isFinite(r.index) && r.index >= 0 && r.height > 0)
+      .sort((a, b) => a.index - b.index),
+    hole
+  );
 
   const list = columnTaskList(root);
   const layoutCount = list ? layoutCountForList(list) : null;


### PR DESCRIPTION
## Summary
- Broadcast task create/delete (and cross-board move membership) tenant-wide so board tab pills update in every session without joining every board room.
- Board-delete confirm counts only live tasks, not cards already in trash.
- Kanban insert uses unshifted layout and the pointer so slim/Minimal cards do not oscillate while held over a column.

## Test plan
- [ ] Two sessions on different boards: create, delete, and multi-move tasks; both tab counts update.
- [ ] Delete a board that is empty but has trash: confirm says move the board, not N tasks.
- [ ] Kanban Minimal / title-only cards: drag and hold over the same column and an adjacent column; hole stays put.


Made with [Cursor](https://cursor.com)