### PR TITLE
Stop stale full-board fetches from flashing old cards

### DIFF
--- a/server/routes/boards.js
+++ b/server/routes/boards.js
@@ -1,5 +1,4 @@
 import express from 'express';
-import { wrapQuery } from '../utils/queryLogger.js';
 import notificationService from '../services/notificationService.js';
 import { authenticateToken, requireRole } from '../middleware/auth.js';
 import { assertBoardAccess, userHasAdminRole } from '../middleware/boardAccess.js';
@@ -12,6 +11,7 @@ import { boards as boardQueries, tasks as taskQueries, helpers, boardParticipant
 import { notifyBoardWebhook } from '../services/taskEmailNotificationService.js';
 import { purgeBoardCompletely } from '../services/taskPurgeService.js';
 import { serverDebug } from '../utils/serverDebug.js';
+import { assembleBoardsPayload } from '../utils/assembleBoardsPayload.js';
 import {
   parseBody,
   createBoardBodySchema,
@@ -22,160 +22,44 @@ import {
 
 const router = express.Router();
 
-// Get all boards with columns and tasks (including tags)
+// Get all boards with columns. Default includes full task payloads (login / reports).
+// ?tasks=summary returns empty task arrays + taskCount for cheap background reconcile.
 router.get('/', authenticateToken, async (req, res) => {
   try {
     const db = getRequestDatabase(req);
     const isAdmin = userHasAdminRole(req.user);
     const boards = await boardQueries.getAllBoards(db, { userId: req.user.id, isAdmin });
-
-    // OPTIMIZATION: Batch fetch all columns for all boards first
-    const allBoardIds = boards.map(b => b.id);
-    const allColumns = allBoardIds.length > 0 
-      ? await helpers.getColumnsForAllBoards(db, allBoardIds)
-      : [];
-    
-    // Group columns by boardid
-    const columnsByBoardId = {};
-    allColumns.forEach(column => {
-      if (!columnsByBoardId[column.boardId]) {
-        columnsByBoardId[column.boardId] = [];
-      }
-      columnsByBoardId[column.boardId].push(column);
-    });
-    
-    // OPTIMIZATION: Batch fetch all tasks for all columns
-    const allColumnIds = allColumns.map(c => c.id);
-    const allTasks = allColumnIds.length > 0
-      ? await taskQueries.getTasksForColumns(db, allColumnIds)
-      : [];
-    
-    // Group tasks by columnid
-    const tasksByColumnId = {};
-    allTasks.forEach(task => {
-      if (!tasksByColumnId[task.columnId]) {
-        tasksByColumnId[task.columnId] = [];
-      }
-      tasksByColumnId[task.columnId].push(task);
-    });
-    
-    // Collect all comment IDs for batch attachment fetch
-    const allCommentIds = allTasks.flatMap(task => {
-      const parseJsonField = (field) => {
-        if (!field || field === '[]' || field === '[null]') return [];
-        if (Array.isArray(field)) return field.filter(Boolean);
-        if (typeof field === 'string') {
-          try {
-            const parsed = JSON.parse(field);
-            return Array.isArray(parsed) ? parsed.filter(Boolean) : (parsed ? [parsed] : []);
-          } catch {
-            return [];
-          }
-        }
-        return [];
-      };
-      const comments = parseJsonField(task.comments);
-      return comments.map(c => c.id).filter(Boolean);
-    });
-    
-    // OPTIMIZATION: Batch fetch all attachments for all comments in one query
-    const allAttachments = allCommentIds.length > 0
-      ? await helpers.getAttachmentsForComments(db, allCommentIds)
-      : [];
-    
-    // Group attachments by commentid
-    const attachmentsByCommentId = {};
-    allAttachments.forEach(att => {
-      const commentId = att.commentId || att.commentid;
-      if (!attachmentsByCommentId[commentId]) {
-        attachmentsByCommentId[commentId] = [];
-      }
-      attachmentsByCommentId[commentId].push(att);
-    });
-    
-    // Helper functions for processing
-    const parseJsonField = (field) => {
-      if (field === null || field === undefined || field === '' || field === '[null]' || field === 'null') {
-        return [];
-      }
-      if (Array.isArray(field)) {
-        return field.filter(Boolean);
-      }
-      if (typeof field === 'object') {
-        return Array.isArray(field) ? field.filter(Boolean) : [field].filter(Boolean);
-      }
-      if (typeof field === 'string') {
-        const trimmed = field.trim();
-        if (!trimmed || trimmed === '[]' || trimmed === '[null]' || trimmed === 'null') {
-          return [];
-        }
-        try {
-          const parsed = JSON.parse(trimmed);
-          return Array.isArray(parsed) ? parsed.filter(Boolean) : (parsed ? [parsed] : []);
-        } catch (e) {
-          console.warn('Failed to parse JSON field:', e.message, 'Value:', field);
-          return [];
-        }
-      }
-      return [];
-    };
-    
-    const deduplicateById = (arr) => {
-      const seen = new Set();
-      return arr.filter(item => {
-        if (!item || !item.id) return false;
-        if (seen.has(item.id)) return false;
-        seen.add(item.id);
-        return true;
-      });
-    };
-    
-    // Process boards with pre-fetched data
-    const boardsWithData = boards.map(board => {
-      const columns = columnsByBoardId[board.id] || [];
-      const columnsObj = {};
-      
-      columns.forEach(column => {
-        const tasksRaw = tasksByColumnId[column.id] || [];
-        
-        const tasks = tasksRaw.map(task => ({
-          ...task,
-          priority: task.priorityName || null,
-          priorityId: task.priorityId || null,
-          priorityName: task.priorityName || null,
-          priorityColor: task.priorityColor || null,
-          sprintId: task.sprint_id || null,
-          createdAt: task.created_at,
-          updatedAt: task.updated_at,
-          columnEnteredAt: task.columnEnteredAt || task.column_entered_at || null,
-          isBlocked: Boolean(task.isBlocked ?? task.is_blocked),
-          blockedReason: task.blockedReason || task.blocked_reason || null,
-          comments: deduplicateById(parseJsonField(task.comments)).map(comment => ({
-            ...comment,
-            attachments: attachmentsByCommentId[comment.id] || []
-          })),
-          tags: deduplicateById(parseJsonField(task.tags)),
-          watchers: deduplicateById(parseJsonField(task.watchers)),
-          collaborators: deduplicateById(parseJsonField(task.collaborators))
-        }));
-        
-        columnsObj[column.id] = {
-          ...column,
-          tasks: tasks
-        };
-      });
-      
-      return {
-        ...board,
-        participantCount: Number(board.participant_count ?? board.participantCount ?? 0),
-        columns: columnsObj
-      };
-    });
-
-
+    const tasksMode = String(req.query.tasks || 'full').toLowerCase();
+    const includeTasks = tasksMode !== 'summary' && tasksMode !== 'lite';
+    const boardsWithData = await assembleBoardsPayload(db, boards, { includeTasks });
     res.json(boardsWithData);
   } catch (error) {
     console.error('Error fetching boards:', error);
+    const db = getRequestDatabase(req);
+    const t = await getTranslator(db);
+    res.status(500).json({ error: t('errors.failedToFetch', { resource: 'boards' }) });
+  }
+});
+
+// One board with full task payloads (visible board hydrate after a summary list fetch).
+router.get('/:boardId/full', authenticateToken, async (req, res) => {
+  const { boardId } = req.params;
+  try {
+    const db = getRequestDatabase(req);
+    const t = await getTranslator(db);
+    if (!(await assertBoardAccess(req, res, boardId))) return;
+
+    const isAdmin = userHasAdminRole(req.user);
+    const boards = await boardQueries.getAllBoards(db, { userId: req.user.id, isAdmin });
+    const board = boards.find((b) => b.id === boardId);
+    if (!board) {
+      return res.status(404).json({ error: t('errors.boardNotFound') });
+    }
+
+    const [assembled] = await assembleBoardsPayload(db, [board], { includeTasks: true });
+    res.json(assembled);
+  } catch (error) {
+    console.error('Error fetching board:', error);
     const db = getRequestDatabase(req);
     const t = await getTranslator(db);
     res.status(500).json({ error: t('errors.failedToFetch', { resource: 'boards' }) });
@@ -380,7 +264,15 @@ router.post('/', authenticateToken, checkBoardLimit, async (req, res) => {
       }, tenantId);
     }
     
-    const newBoard = { id, title, project: projectIdentifier, position, columns: columnsObj };
+    const newBoard = {
+      id,
+      title,
+      project: projectIdentifier,
+      position,
+      columns: columnsObj,
+      tasksHydrated: true,
+      taskCount: 0,
+    };
     
     // Publish to Redis for real-time updates
     notificationService.publish('board-created', {

--- a/server/utils/assembleBoardsPayload.js
+++ b/server/utils/assembleBoardsPayload.js
@@ -1,0 +1,168 @@
+/**
+ * Assemble boards with columns (and optionally full task payloads).
+ * Shared by GET /api/boards and GET /api/boards/:boardId/full.
+ */
+import { tasks as taskQueries, helpers } from './sqlManager/index.js';
+
+function parseJsonField(field) {
+  if (field === null || field === undefined || field === '' || field === '[null]' || field === 'null') {
+    return [];
+  }
+  if (Array.isArray(field)) {
+    return field.filter(Boolean);
+  }
+  if (typeof field === 'object') {
+    return Array.isArray(field) ? field.filter(Boolean) : [field].filter(Boolean);
+  }
+  if (typeof field === 'string') {
+    const trimmed = field.trim();
+    if (!trimmed || trimmed === '[]' || trimmed === '[null]' || trimmed === 'null') {
+      return [];
+    }
+    try {
+      const parsed = JSON.parse(trimmed);
+      return Array.isArray(parsed) ? parsed.filter(Boolean) : (parsed ? [parsed] : []);
+    } catch (e) {
+      console.warn('Failed to parse JSON field:', e.message, 'Value:', field);
+      return [];
+    }
+  }
+  return [];
+}
+
+function deduplicateById(arr) {
+  const seen = new Set();
+  return arr.filter((item) => {
+    if (!item || !item.id) return false;
+    if (seen.has(item.id)) return false;
+    seen.add(item.id);
+    return true;
+  });
+}
+
+function isArchivedColumn(column) {
+  return Boolean(column.is_archived ?? column.isArchived);
+}
+
+/**
+ * @param {object} db
+ * @param {Array} boards
+ * @param {{ includeTasks: boolean }} options
+ */
+export async function assembleBoardsPayload(db, boards, { includeTasks }) {
+  const allBoardIds = boards.map((b) => b.id);
+  const allColumns = allBoardIds.length > 0
+    ? await helpers.getColumnsForAllBoards(db, allBoardIds)
+    : [];
+
+  const columnsByBoardId = {};
+  allColumns.forEach((column) => {
+    if (!columnsByBoardId[column.boardId]) {
+      columnsByBoardId[column.boardId] = [];
+    }
+    columnsByBoardId[column.boardId].push(column);
+  });
+
+  const allColumnIds = allColumns.map((c) => c.id);
+
+  let tasksByColumnId = {};
+  let attachmentsByCommentId = {};
+
+  if (includeTasks) {
+    const allTasks = allColumnIds.length > 0
+      ? await taskQueries.getTasksForColumns(db, allColumnIds)
+      : [];
+
+    allTasks.forEach((task) => {
+      if (!tasksByColumnId[task.columnId]) {
+        tasksByColumnId[task.columnId] = [];
+      }
+      tasksByColumnId[task.columnId].push(task);
+    });
+
+    const allCommentIds = allTasks.flatMap((task) => {
+      const comments = parseJsonField(task.comments);
+      return comments.map((c) => c.id).filter(Boolean);
+    });
+
+    const allAttachments = allCommentIds.length > 0
+      ? await helpers.getAttachmentsForComments(db, allCommentIds)
+      : [];
+
+    allAttachments.forEach((att) => {
+      const commentId = att.commentId || att.commentid;
+      if (!attachmentsByCommentId[commentId]) {
+        attachmentsByCommentId[commentId] = [];
+      }
+      attachmentsByCommentId[commentId].push(att);
+    });
+  }
+
+  const countsByColumnId = {};
+  if (!includeTasks) {
+    const rows = allColumnIds.length > 0
+      ? await taskQueries.countLiveTasksByColumnIds(db, allColumnIds)
+      : [];
+    rows.forEach((row) => {
+      countsByColumnId[row.columnId] = row.count;
+    });
+  }
+
+  return boards.map((board) => {
+    const columns = columnsByBoardId[board.id] || [];
+    const columnsObj = {};
+    let taskCount = 0;
+
+    columns.forEach((column) => {
+      if (includeTasks) {
+        const tasksRaw = tasksByColumnId[column.id] || [];
+        const tasks = tasksRaw.map((task) => ({
+          ...task,
+          priority: task.priorityName || null,
+          priorityId: task.priorityId || null,
+          priorityName: task.priorityName || null,
+          priorityColor: task.priorityColor || null,
+          sprintId: task.sprint_id || null,
+          createdAt: task.created_at,
+          updatedAt: task.updated_at,
+          columnEnteredAt: task.columnEnteredAt || task.column_entered_at || null,
+          isBlocked: Boolean(task.isBlocked ?? task.is_blocked),
+          blockedReason: task.blockedReason || task.blocked_reason || null,
+          comments: deduplicateById(parseJsonField(task.comments)).map((comment) => ({
+            ...comment,
+            attachments: attachmentsByCommentId[comment.id] || []
+          })),
+          tags: deduplicateById(parseJsonField(task.tags)),
+          watchers: deduplicateById(parseJsonField(task.watchers)),
+          collaborators: deduplicateById(parseJsonField(task.collaborators))
+        }));
+
+        if (!isArchivedColumn(column)) {
+          taskCount += tasks.length;
+        }
+
+        columnsObj[column.id] = {
+          ...column,
+          tasks
+        };
+      } else {
+        const count = countsByColumnId[column.id] || 0;
+        if (!isArchivedColumn(column)) {
+          taskCount += count;
+        }
+        columnsObj[column.id] = {
+          ...column,
+          tasks: []
+        };
+      }
+    });
+
+    return {
+      ...board,
+      participantCount: Number(board.participant_count ?? board.participantCount ?? 0),
+      taskCount,
+      tasksHydrated: includeTasks,
+      columns: columnsObj
+    };
+  });
+}

--- a/server/utils/sqlManager/tasks.js
+++ b/server/utils/sqlManager/tasks.js
@@ -376,6 +376,25 @@ export async function getTasksForColumns(db, columnIds) {
 }
 
 /**
+ * Live (non-deleted) task counts grouped by column. Used for tab pills without
+ * loading every task payload.
+ */
+export async function countLiveTasksByColumnIds(db, columnIds) {
+  if (!columnIds || columnIds.length === 0) {
+    return [];
+  }
+  const placeholders = columnIds.map((_, index) => `$${index + 1}`).join(', ');
+  const query = `
+    SELECT columnid AS "columnId", COUNT(*)::int AS count
+    FROM tasks
+    WHERE columnid IN (${placeholders}) AND deleted_at IS NULL
+    GROUP BY columnid
+  `;
+  const stmt = wrapQuery(db.prepare(query), 'SELECT');
+  return await stmt.all(...columnIds);
+}
+
+/**
  * Get all tasks (simple list)
  * 
  * @param {Database} db - Database connection

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -61,7 +61,7 @@ import TaskLinkingOverlay from './components/TaskLinkingOverlay';
 import NetworkStatusIndicator from './components/NetworkStatusIndicator';
 import VersionUpdateBanner from './components/VersionUpdateBanner';
 import { useTaskDeleteConfirmation } from './hooks/useTaskDeleteConfirmation';
-import api, { getMembers, getBoards, deleteTask, updateTask, reorderTasks, reorderColumns, reorderBoards, updateColumn, updateBoard, createTaskAtTop, createTask, copyTask, createColumn, createBoard, deleteColumn, deleteBoard, getBoardTrashCount, purgeBoard, getUserSettings, createUser, getUserStatus, getActivityFeed, ACTIVITY_FEED_DEFAULT_LIMIT, updateSavedFilterView, getCurrentUser, updateAppUrl, restoreTask, purgeTask, getTaskById, hashHasOAuthToken } from './api';
+import api, { getMembers, getBoards, getBoardFull, deleteTask, updateTask, reorderTasks, reorderColumns, reorderBoards, updateColumn, updateBoard, createTaskAtTop, createTask, copyTask, createColumn, createBoard, deleteColumn, deleteBoard, getBoardTrashCount, purgeBoard, getUserSettings, createUser, getUserStatus, getActivityFeed, ACTIVITY_FEED_DEFAULT_LIMIT, updateSavedFilterView, getCurrentUser, updateAppUrl, restoreTask, purgeTask, getTaskById, hashHasOAuthToken } from './api';
 import { toast, ToastContainer } from './utils/toast';
 import { getWipStatus, hasWipLimit, getBoardWipTaskCount, getBoardWipTasks, isBoardWipActiveColumn } from './utils/kanbanFlowUtils';
 import { applyActiveColumnFilters } from './utils/columnFilters';
@@ -73,6 +73,13 @@ import {
 import { requestTaskJump } from './utils/taskJumpEvents';
 import { revealNewlyCreatedTask } from './utils/newTaskReveal';
 import { columnsContentFingerprint } from './utils/columnsFingerprint';
+import {
+  mergeBoardFetchWithLocalMoves,
+  overlayBoardListKeepingTaskCache,
+  stripMovedOffTasksFromColumns,
+  boardsCacheFingerprint,
+  boardTasksAreHydrated,
+} from './utils/mergeBoardFetch';
 import { applyLocalColumnReorder } from './utils/columnReorderingUtils';
 import { rolesForAppRole, sameRoleList, userCanMutate } from './utils/permissions';
 import { isDemoModeClient } from './utils/demoReset';
@@ -184,6 +191,7 @@ function AppContent() {
   const { t: tCommon } = useTranslation('common');
   const [members, setMembers] = useState<TeamMember[]>([]);
   const [boards, setBoards] = useState<Board[]>([]);
+  const boardsRef = useRef<Board[]>([]);
   const [selectedBoard, setSelectedBoard] = useState<string | null>(null);
   const selectedBoardRef = useRef<string | null>(null); // Initialize as null, will be set after auth
   const columnsRef = useRef<Columns>({});
@@ -196,6 +204,9 @@ function AppContent() {
   useEffect(() => {
     columnsRef.current = columns;
   }, [columns]);
+  useEffect(() => {
+    boardsRef.current = boards;
+  }, [boards]);
   // Use SettingsContext instead of local state
   const { systemSettings, siteSettings, isLoading: settingsLoading, refreshSettings: refreshContextSettings } = useSettings();
   const [kanbanColumnWidth, setKanbanColumnWidth] = useState<number>(300); // Default 300px
@@ -1595,6 +1606,8 @@ function AppContent() {
   const recentlyDeletedTasksRef = useRef<Set<string>>(new Set());
   /** taskId → source board; hide on that board only so dest refresh can still show it. */
   const recentlyMovedOffBoardRef = useRef<Map<string, string>>(new Map());
+  /** Ignore getBoards() that started before a newer refresh or a local board move. */
+  const refreshBoardDataGenRef = useRef(0);
   const crossBoardMoveSnapshotRef = useRef<{
     task: Task;
     sourceBoardId: string;
@@ -2900,6 +2913,7 @@ function AppContent() {
           
           const [loadedMembers, loadedBoards, loadedPriorities, loadedTags, loadedSprints, loadedActivities] = await Promise.all([
             loadMembersWithRetry(),
+          // Full task payloads once so every tab can paint instantly from boards[] cache.
           getBoards(),
           getAllPriorities(),
           getAllTags(),
@@ -3100,17 +3114,27 @@ function AppContent() {
       const boardIdBeingOpened = selectedBoard;
       const boardInState = boards.find((b) => b.id === selectedBoard);
 
-      if (boardInState && boardInState.columns && Object.keys(boardInState.columns).length > 0) {
-        const newColumns: Columns = {};
-        Object.keys(boardInState.columns || {}).forEach((columnId) => {
-          const column = boardInState.columns[columnId];
-          if (column) {
-            newColumns[columnId] = {
-              ...column,
-              tasks: [...(column.tasks || [])],
-            };
-          }
-        });
+      if (
+        boardInState &&
+        boardTasksAreHydrated(boardInState) &&
+        boardInState.columns &&
+        Object.keys(boardInState.columns).length > 0
+      ) {
+        const newColumns: Columns = stripMovedOffTasksFromColumns(
+          Object.keys(boardInState.columns || {}).reduce((acc, columnId) => {
+            const column = boardInState.columns[columnId];
+            if (column) {
+              acc[columnId] = {
+                ...column,
+                tasks: [...(column.tasks || [])],
+              };
+            }
+            return acc;
+          }, {} as Columns),
+          boardIdBeingOpened,
+          recentlyMovedOffBoardRef.current,
+          recentlyDeletedTasksRef.current
+        );
         setColumns(newColumns);
         // Seed with active filters applied (sprint/search/etc.) so board switch does not
         // briefly paint every card before useTaskFilters re-runs.
@@ -3182,6 +3206,7 @@ function AppContent() {
   // TODO: Implement simpler real-time solution (polling or SSE)
 
   const refreshBoardData = useCallback(async (options?: { force?: boolean; forBoardId?: string }) => {
+    const gen = ++refreshBoardDataGenRef.current;
     // CRITICAL: Skip refresh if we just updated from WebSocket to prevent overwriting real-time updates
     // This is especially important for batch position updates (259 tasks) where WebSocket updates
     // are processed together and should not be overwritten by a refresh
@@ -3191,12 +3216,45 @@ function AppContent() {
     }
     
     try {
-      const loadedBoards = await getBoards();
-      setBoards(loadedBoards);
-      
       // Hydrate columns for a specific board (e.g. newly created) before selectedBoard state updates,
       // or for the current selectedBoard when forBoardId is omitted.
       const boardIdToHydrate = options?.forBoardId !== undefined ? options.forBoardId : selectedBoard;
+
+      const summaryPromise = getBoards({ tasks: 'summary' });
+      const fullPromise = boardIdToHydrate
+        ? getBoardFull(boardIdToHydrate)
+        : Promise.resolve(null);
+      const [summaryResult, fullResult] = await Promise.allSettled([summaryPromise, fullPromise]);
+      if (gen !== refreshBoardDataGenRef.current) return;
+
+      if (summaryResult.status === 'rejected') {
+        throw summaryResult.reason;
+      }
+      const summaryBoards = summaryResult.value;
+      const hydratedBoard =
+        fullResult.status === 'fulfilled' ? fullResult.value : null;
+      if (fullResult.status === 'rejected') {
+        const status = (fullResult.reason as { response?: { status?: number } })?.response?.status;
+        if (status !== 404) {
+          console.error('Failed to hydrate board:', fullResult.reason);
+        }
+      }
+
+      let nextBoards = overlayBoardListKeepingTaskCache(summaryBoards, boardsRef.current);
+      if (hydratedBoard) {
+        nextBoards = nextBoards.map((board) =>
+          board.id === hydratedBoard.id ? hydratedBoard : board
+        );
+      }
+      const mergedBoards = mergeBoardFetchWithLocalMoves(
+        nextBoards,
+        boardsRef.current,
+        recentlyMovedOffBoardRef.current,
+        recentlyDeletedTasksRef.current
+      );
+      if (boardsCacheFingerprint(mergedBoards) !== boardsCacheFingerprint(boardsRef.current)) {
+        setBoards(mergedBoards);
+      }
 
       // If this refresh was for a specific board and the user has already switched away, still
       // update boards[] (above) but do not clobber the currently visible columns.
@@ -3208,9 +3266,9 @@ function AppContent() {
         return;
       }
       
-      if (loadedBoards.length > 0) {
+      if (mergedBoards.length > 0) {
         if (boardIdToHydrate) {
-          const board = loadedBoards.find(b => b.id === boardIdToHydrate);
+          const board = mergedBoards.find(b => b.id === boardIdToHydrate);
           if (board) {
             // Force a deep clone to ensure React detects the change at all levels
             // OPTIMIZED: Use shallow copy instead of expensive JSON.parse(JSON.stringify())
@@ -4679,6 +4737,7 @@ function AppContent() {
     if (movedTask && sourceBoardId && !existingSnap) {
       recentlyMovedOffBoardRef.current.set(taskId, sourceBoardId);
       recentlyDeletedTasksRef.current.add(taskId);
+      refreshBoardDataGenRef.current += 1;
       setTimeout(() => {
         recentlyDeletedTasksRef.current.delete(taskId);
         recentlyMovedOffBoardRef.current.delete(taskId);
@@ -4787,6 +4846,7 @@ function AppContent() {
           return board;
         })
       );
+      refreshBoardDataGenRef.current += 1;
 
       if (selectedTask?.id === taskId && selectedBoardRef.current === targetBoardId) {
         handleSelectTask(patched);
@@ -5985,6 +6045,14 @@ function AppContent() {
       return lastTaskCountsRef.current[board.id];
     }
 
+    if (!boardTasksAreHydrated(board) && !activeFilters) {
+      const fromServer = board.taskCount;
+      if (typeof fromServer === 'number') {
+        lastTaskCountsRef.current[board.id] = fromServer;
+        return fromServer;
+      }
+    }
+
     const boardColumnsRaw: Columns =
       board.id === selectedBoard ? columns : (board.columns || {});
     const boardColumns = dedupeTasksInColumns(boardColumnsRaw);
@@ -6004,6 +6072,9 @@ function AppContent() {
   // Every live task on the board, ignoring search/member/sprint filters. Deleting a board
   // removes tasks that the current filters hide, so confirmations must count all of them.
   const getTotalTaskCountForBoard = (board: Board) => {
+    if (!boardTasksAreHydrated(board) && typeof board.taskCount === 'number') {
+      return board.taskCount;
+    }
     const boardColumnsRaw: Columns =
       board.id === selectedBoard ? columns : (board.columns || {});
     const boardColumns = dedupeTasksInColumns(boardColumnsRaw);

--- a/src/api.ts
+++ b/src/api.ts
@@ -314,8 +314,14 @@ export const deleteMember = async (id: string) => {
 };
 
 // Boards
-export const getBoards = async () => {
-  const { data } = await api.get<Board[]>('/boards');
+export const getBoards = async (options?: { tasks?: 'full' | 'summary' }) => {
+  const params = options?.tasks === 'summary' ? { tasks: 'summary' } : undefined;
+  const { data } = await api.get<Board[]>('/boards', { params });
+  return data;
+};
+
+export const getBoardFull = async (boardId: string) => {
+  const { data } = await api.get<Board>(`/boards/${boardId}/full`);
   return data;
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -135,8 +135,13 @@ export interface Board {
   /** Soft-delete timestamp (ISO). Soft-deleted boards are hidden from tabs. */
   deletedAt?: string | null;
   deletedBy?: string | null;
-  /** Total tasks on board (lifecycle deleted-boards list). */
+  /** Total live tasks on non-archived columns (list / pills). */
   taskCount?: number;
+  /**
+   * True when `columns[].tasks` is a full snapshot (login hydrate or GET /boards/:id/full).
+   * False on `GET /boards?tasks=summary` (empty task arrays; keep client cache).
+   */
+  tasksHydrated?: boolean;
   /** Soft-deleted tasks on board (lifecycle deleted-boards list). */
   trashTaskCount?: number;
   /** Users listed as board participants. Empty = hidden from users/viewers. */

--- a/src/utils/mergeBoardFetch.ts
+++ b/src/utils/mergeBoardFetch.ts
@@ -1,0 +1,167 @@
+import type { Board, Columns, Task } from '../types';
+import { columnsContentFingerprint } from './columnsFingerprint';
+
+/**
+ * Server board snapshots can lag a cross-board move on multi-pod / high-latency
+ * clusters (in-flight GET started before COMMIT, or a later GET overwriting
+ * optimistic state). Keep the mover's local membership until the snapshot agrees.
+ */
+export function mergeBoardFetchWithLocalMoves(
+  server: Board[],
+  local: Board[],
+  movedFromByTaskId: Map<string, string>,
+  recentlyDeletedIds: Set<string>
+): Board[] {
+  if (movedFromByTaskId.size === 0 && recentlyDeletedIds.size === 0) {
+    return server;
+  }
+
+  const localPlacement = new Map<string, { boardId: string; task: Task }>();
+  for (const board of local) {
+    for (const column of Object.values(board.columns || {})) {
+      for (const task of column.tasks || []) {
+        if (!task?.id) continue;
+        localPlacement.set(task.id, { boardId: board.id, task });
+      }
+    }
+  }
+
+  return server.map((board) => {
+    const columns: Columns = { ...(board.columns || {}) };
+    let changed = false;
+
+    Object.keys(columns).forEach((columnId) => {
+      const column = columns[columnId];
+      if (!column?.tasks?.length) return;
+      const tasks = column.tasks.filter((task) => {
+        if (!task?.id) return true;
+        if (recentlyDeletedIds.has(task.id) && !movedFromByTaskId.has(task.id)) {
+          changed = true;
+          return false;
+        }
+        const sourceBoardId = movedFromByTaskId.get(task.id);
+        if (sourceBoardId && sourceBoardId === board.id) {
+          changed = true;
+          return false;
+        }
+        return true;
+      });
+      if (tasks.length !== column.tasks.length) {
+        columns[columnId] = { ...column, tasks };
+      }
+    });
+
+    for (const [taskId, sourceBoardId] of movedFromByTaskId) {
+      const placed = localPlacement.get(taskId);
+      if (!placed || placed.boardId !== board.id || placed.boardId === sourceBoardId) {
+        continue;
+      }
+      const columnId = placed.task.columnId;
+      if (!columnId) continue;
+      const column = columns[columnId] || {
+        id: columnId,
+        boardId: board.id,
+        title: '',
+        tasks: [],
+        position: 0,
+        is_finished: false,
+        is_archived: false,
+      };
+      if (column.tasks.some((t) => t.id === taskId)) continue;
+      changed = true;
+      columns[columnId] = {
+        ...column,
+        tasks: [...column.tasks, placed.task].sort(
+          (a, b) => (a.position || 0) - (b.position || 0)
+        ),
+      };
+    }
+
+    return changed ? { ...board, columns } : board;
+  });
+}
+
+export function stripMovedOffTasksFromColumns(
+  columns: Columns,
+  boardId: string,
+  movedFromByTaskId: Map<string, string>,
+  recentlyDeletedIds: Set<string>
+): Columns {
+  if (movedFromByTaskId.size === 0 && recentlyDeletedIds.size === 0) {
+    return columns;
+  }
+  let changed = false;
+  const next: Columns = { ...columns };
+  Object.keys(next).forEach((columnId) => {
+    const column = next[columnId];
+    if (!column?.tasks?.length) return;
+    const tasks = column.tasks.filter((task) => {
+      if (!task?.id) return true;
+      if (recentlyDeletedIds.has(task.id) && !movedFromByTaskId.has(task.id)) {
+        return false;
+      }
+      const sourceBoardId = movedFromByTaskId.get(task.id);
+      if (sourceBoardId && sourceBoardId === boardId) return false;
+      return true;
+    });
+    if (tasks.length !== column.tasks.length) {
+      changed = true;
+      next[columnId] = { ...column, tasks };
+    }
+  });
+  return changed ? next : columns;
+}
+
+export function boardTasksAreHydrated(board?: Board | null): boolean {
+  if (!board) return false;
+  if (board.tasksHydrated === false) return false;
+  if (board.tasksHydrated === true) return true;
+  return Object.keys(board.columns || {}).length > 0;
+}
+
+/**
+ * Summary GET overwrites titles, positions, WIP, and taskCount, but must not
+ * replace cached `columns.tasks` with empty arrays.
+ */
+export function overlayBoardListKeepingTaskCache(summary: Board[], local: Board[]): Board[] {
+  const localById = new Map(local.map((board) => [board.id, board]));
+  return summary.map((remote) => {
+    const loc = localById.get(remote.id);
+    if (!loc || !boardTasksAreHydrated(loc)) {
+      return remote;
+    }
+    const remoteCols = remote.columns || {};
+    const localCols = loc.columns || {};
+    const columns: Columns = {};
+    Object.keys(remoteCols).forEach((columnId) => {
+      const remoteCol = remoteCols[columnId];
+      const localCol = localCols[columnId];
+      columns[columnId] = localCol
+        ? { ...remoteCol, tasks: localCol.tasks || [] }
+        : { ...remoteCol, tasks: [] };
+    });
+    return {
+      ...remote,
+      tasksHydrated: true,
+      columns,
+    };
+  });
+}
+
+export function boardsCacheFingerprint(boards: Board[]): string {
+  return boards
+    .map((board) => {
+      const chrome = [
+        board.id,
+        board.title,
+        board.position ?? '',
+        board.wip_limit ?? '',
+        board.participantCount ?? '',
+        board.taskCount ?? '',
+        board.tasksHydrated ? '1' : '0',
+        Object.keys(board.columns || {}).sort().join(','),
+      ].join(':');
+      return `${chrome}#${columnsContentFingerprint(board.columns)}`;
+    })
+    .join(';;');
+}


### PR DESCRIPTION
## Summary
- Keep instant board-tab switches from the in-memory cache after login.
- Background refresh uses a cheap board list plus a full fetch of the visible board only, then merges with local moves so a slow multi-pod GET cannot resurrect cards.

## Test plan
- [ ] Login, switch boards: first paint should be instant from cache.
- [ ] Move tasks across boards, switch away and back: destination should stay correct; source should not briefly show the moved cards.
- [ ] Create a new board and open it: columns/tasks still load.


Made with [Cursor](https://cursor.com)