### PR TITLE
Keep column moves on board switch and stop lone-card insert jump

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,6 +79,7 @@ import {
   stripMovedOffTasksFromColumns,
   boardsCacheFingerprint,
   boardTasksAreHydrated,
+  preferLocalColumnsForRecentlyTouchedBoards,
 } from './utils/mergeBoardFetch';
 import { applyLocalColumnReorder } from './utils/columnReorderingUtils';
 import { rolesForAppRole, sameRoleList, userCanMutate } from './utils/permissions';
@@ -1606,6 +1607,8 @@ function AppContent() {
   const recentlyDeletedTasksRef = useRef<Set<string>>(new Set());
   /** taskId → source board; hide on that board only so dest refresh can still show it. */
   const recentlyMovedOffBoardRef = useRef<Map<string, string>>(new Map());
+  /** boardId → Date.now(); keep optimistic column layout over a stale GET /full. */
+  const recentlyColumnMovedBoardRef = useRef<Map<string, number>>(new Map());
   /** Ignore getBoards() that started before a newer refresh or a local board move. */
   const refreshBoardDataGenRef = useRef(0);
   const crossBoardMoveSnapshotRef = useRef<{
@@ -1624,6 +1627,18 @@ function AppContent() {
   const onBulkMoveToBoardRef = useRef<
     ((taskIds: string[], boardId: string) => Promise<void>) | null
   >(null);
+  const syncKanbanColumnsToBoardCache = (next: Columns) => {
+    const boardId = selectedBoardRef.current;
+    if (!boardId) return;
+    columnsRef.current = next;
+    recentlyColumnMovedBoardRef.current.set(boardId, Date.now());
+    refreshBoardDataGenRef.current += 1;
+    const nextBoards = boardsRef.current.map((board) =>
+      board.id === boardId ? { ...board, columns: next, tasksHydrated: true } : board
+    );
+    boardsRef.current = nextBoards;
+    setBoards(nextBoards);
+  };
   const taskWebSocketRef = useRef<{
     handleTaskRestored?: (
       data: any,
@@ -3210,7 +3225,7 @@ function AppContent() {
     // CRITICAL: Skip refresh if we just updated from WebSocket to prevent overwriting real-time updates
     // This is especially important for batch position updates (259 tasks) where WebSocket updates
     // are processed together and should not be overwritten by a refresh
-    if (!options?.force && window.justUpdatedFromWebSocket) {
+    if (!options?.force && window.justUpdatedFromWebSocket && options?.forBoardId === undefined) {
       if (feDebug('FE_DEBUG_APP_CORE')) console.log('⏭️ [refreshBoardData] Skipping refresh - WebSocket update in progress');
       return;
     }
@@ -3246,6 +3261,11 @@ function AppContent() {
           board.id === hydratedBoard.id ? hydratedBoard : board
         );
       }
+      nextBoards = preferLocalColumnsForRecentlyTouchedBoards(
+        nextBoards,
+        boardsRef.current,
+        recentlyColumnMovedBoardRef.current
+      );
       const mergedBoards = mergeBoardFetchWithLocalMoves(
         nextBoards,
         boardsRef.current,
@@ -4410,7 +4430,8 @@ function AppContent() {
         setColumns,
         setDragCooldown,
         refreshBoardData,
-        taskFilters.setFilteredColumns
+        taskFilters.setFilteredColumns,
+        syncKanbanColumnsToBoardCache
       );
     } catch {
       toast.error(t('errors.moveTaskTitle'), t('errors.moveTaskMessage'));
@@ -4437,7 +4458,8 @@ function AppContent() {
         setColumns,
         setDragCooldown,
         refreshBoardData,
-        taskFilters.setFilteredColumns
+        taskFilters.setFilteredColumns,
+        syncKanbanColumnsToBoardCache
       );
     } catch {
       toast.error(t('errors.moveTaskTitle'), t('errors.moveTaskMessage'));
@@ -4456,7 +4478,8 @@ function AppContent() {
         setColumns,
         setDragCooldown,
         refreshBoardData,
-        taskFilters.setFilteredColumns
+        taskFilters.setFilteredColumns,
+        syncKanbanColumnsToBoardCache
       );
     } catch {
       toast.error(t('errors.moveTaskTitle'), t('errors.moveTaskMessage'));
@@ -4549,7 +4572,8 @@ function AppContent() {
           setColumns,
           setDragCooldown,
           refresh,
-          taskFilters.setFilteredColumns
+          taskFilters.setFilteredColumns,
+          syncKanbanColumnsToBoardCache
         );
       } else {
         await handleCrossColumnMove(
@@ -4561,7 +4585,8 @@ function AppContent() {
           setColumns,
           setDragCooldown,
           refresh,
-          taskFilters.setFilteredColumns
+          taskFilters.setFilteredColumns,
+          syncKanbanColumnsToBoardCache
         );
       }
       return true;
@@ -5029,7 +5054,8 @@ function AppContent() {
         setColumns,
         setDragCooldown,
         refresh,
-        taskFilters.setFilteredColumns
+        taskFilters.setFilteredColumns,
+        syncKanbanColumnsToBoardCache
       );
     },
     getArchiveColumnId: () => {
@@ -5168,7 +5194,8 @@ function AppContent() {
         setColumns,
         setDragCooldown,
         refreshBoardData,
-        taskFilters.setFilteredColumns
+        taskFilters.setFilteredColumns,
+        syncKanbanColumnsToBoardCache
       );
       const sourceSorted = sourceColumnId
         ? [...(liveColumns[sourceColumnId]?.tasks || [])].sort(

--- a/src/utils/dndInsertIndex.ts
+++ b/src/utils/dndInsertIndex.ts
@@ -71,6 +71,40 @@ function unshiftRowsByHole<T extends { index: number; top: number }>(
   });
 }
 
+/**
+ * Pointer/overlay Y is live; card midlines after unshiftRowsByHole are not.
+ * A hole above the only card drops that card by ~76px, so the visual middle
+ * sits below the unshifted midline and insert 0↔1 oscillates every frame.
+ */
+function unshiftY(
+  y: number,
+  hole: { index: number; top: number; bottom: number } | null
+): number {
+  if (!hole) return y;
+  const holeH = Math.max(0, hole.bottom - hole.top);
+  if (holeH < 8) return y;
+  if (y >= hole.bottom - 0.5) return y - holeH;
+  return y;
+}
+
+/**
+ * One remaining card: top band = before, bottom band = after, middle keeps
+ * the current slot so a tall card does not flip while the pointer wanders.
+ */
+function insertIndexForLoneCard(
+  card: { index: number; top: number; height: number },
+  y: number,
+  stickyInsert: number | null
+): number {
+  const frac = (y - card.top) / Math.max(1, card.height);
+  if (frac <= 0.28) return card.index;
+  if (frac >= 0.72) return card.index + 1;
+  if (stickyInsert === card.index || stickyInsert === card.index + 1) {
+    return stickyInsert;
+  }
+  return frac < 0.5 ? card.index : card.index + 1;
+}
+
 function overlayProbeY(overlay: DOMRectReadOnly, pointerY?: number): number {
   if (pointerY != null && Number.isFinite(pointerY)) return pointerY;
   return overlay.top + Math.min(28, overlay.height / 2);
@@ -484,6 +518,8 @@ export function resolveInsertAtColumnStackEnds(
   const lastIsColumnEnd = lastVisibleIsColumnEnd(last.index, end);
   const firstIsColumnStart = first.index === 0;
   const lastNaturalBottom = last.bottom;
+  const y = unshiftY(pointerY, hole);
+  const overlayTop = overlay ? unshiftY(overlay.top, hole) : null;
 
   const bottomZone = root.querySelector('[data-kanban-column-bottom]');
   if (bottomZone instanceof HTMLElement) {
@@ -492,19 +528,11 @@ export function resolveInsertAtColumnStackEnds(
   }
 
   // Only the real last card (not the last *visible* virtual row) is a stack end.
+  // Do not treat “below the hole” as past the last card: with one tall card the
+  // hole sits above it, so the whole card would snap to last+1 and oscillate.
   if (lastIsColumnEnd) {
-    // Hole is already before the last card — that card is shifted down by the
-    // hole. Crossing the hole’s bottom (onto the last card) is last+1.
-    if (hole && hole.index === last.index) {
-      if (
-        pointerY >= hole.bottom - 6 ||
-        (overlay != null && overlay.top >= hole.bottom - 4)
-      ) {
-        return end;
-      }
-    }
-    if (pointerY >= lastNaturalBottom - 4) return end;
-    if (overlay && overlay.top >= lastNaturalBottom - 8) return end;
+    if (y >= lastNaturalBottom - 4) return end;
+    if (overlayTop != null && overlayTop >= lastNaturalBottom - 8) return end;
   }
 
   const topZone = document.getElementById(`${columnId}-task-top`);
@@ -521,9 +549,9 @@ export function resolveInsertAtColumnStackEnds(
     }
   }
   if (firstIsColumnStart) {
-    if (overlay && overlayAtFirstCardTop(overlay, first, pointerY)) return 0;
-    if (pointerY <= first.top + 4) return 0;
-    if (overlay && overlay.bottom <= first.top + 8) return 0;
+    if (overlay && overlayAtFirstCardTop(overlay, first, y)) return 0;
+    if (y <= first.top + 4) return 0;
+    if (overlay && unshiftY(overlay.bottom, hole) <= first.top + 8) return 0;
   }
 
   return null;
@@ -704,12 +732,18 @@ export function resolveInsertIndexFromOverlay(
 
   const list = columnTaskList(root);
   const layoutCount = list ? layoutCountForList(list) : null;
-  const probeY = overlayProbeY(overlay, pointerY);
+  const probeY = unshiftY(overlayProbeY(overlay, pointerY), hole);
 
   if (rows.length === 0) {
     return remember(
       insertFromVirtualOrVisible(columnId, probeY, rows, layoutCount)
     );
+  }
+
+  if (rows.length === 1) {
+    const sticky =
+      insertHysteresis?.columnId === columnId ? insertHysteresis.insertIndex : null;
+    return remember(insertIndexForLoneCard(rows[0], probeY, sticky));
   }
 
   const lastRow = rows[rows.length - 1];
@@ -930,35 +964,42 @@ export function resolveInsertIndexUnderPointer(
 
   const list = columnTaskList(root);
   const layoutCount = list ? layoutCountForList(list) : null;
+  const y = unshiftY(pointerY, hole);
 
   if (rows.length === 0) {
-    return insertFromVirtualOrVisible(columnId, pointerY, rows, layoutCount);
+    return insertFromVirtualOrVisible(columnId, y, rows, layoutCount);
+  }
+
+  if (rows.length === 1) {
+    const sticky =
+      insertHysteresis?.columnId === columnId ? insertHysteresis.insertIndex : null;
+    return insertIndexForLoneCard(rows[0], y, sticky);
   }
 
   const first = rows[0];
   const last = rows[rows.length - 1];
 
-  if (pointerY < first.top) {
+  if (y < first.top) {
     if (first.index === 0) return first.index;
-    return insertFromVirtualOrVisible(columnId, pointerY, rows, layoutCount);
+    return insertFromVirtualOrVisible(columnId, y, rows, layoutCount);
   }
-  if (pointerY >= last.top + last.height) {
+  if (y >= last.top + last.height) {
     if (lastVisibleIsColumnEnd(last.index, layoutCount)) {
       return layoutCount != null ? layoutCount : last.index + 1;
     }
-    return insertFromVirtualOrVisible(columnId, pointerY, rows, layoutCount);
+    return insertFromVirtualOrVisible(columnId, y, rows, layoutCount);
   }
 
   for (const row of rows) {
     const rowBottom = row.top + row.height;
-    if (pointerY >= row.top && pointerY < rowBottom) {
-      return insertIndexOnCard(row, pointerY, columnId, origin);
+    if (y >= row.top && y < rowBottom) {
+      return insertIndexOnCard(row, y, columnId, origin);
     }
   }
 
   let insert = last.index + 1;
   for (const row of rows) {
-    if (pointerY < row.top) {
+    if (y < row.top) {
       insert = row.index;
       break;
     }

--- a/src/utils/mergeBoardFetch.ts
+++ b/src/utils/mergeBoardFetch.ts
@@ -112,6 +112,32 @@ export function stripMovedOffTasksFromColumns(
   return changed ? next : columns;
 }
 
+const LOCAL_COLUMN_MOVE_TTL_MS = 10000;
+
+/**
+ * Same-board DnD updates `columns` immediately, but a GET /full that started
+ * before COMMIT (or hit a lagging replica) can put the card back. Prefer the
+ * actor's cached columns for boards touched in the last few seconds.
+ */
+export function preferLocalColumnsForRecentlyTouchedBoards(
+  server: Board[],
+  local: Board[],
+  touchedAtByBoardId: Map<string, number>,
+  now = Date.now()
+): Board[] {
+  if (touchedAtByBoardId.size === 0) return server;
+  const localById = new Map(local.map((board) => [board.id, board]));
+  return server.map((board) => {
+    const touchedAt = touchedAtByBoardId.get(board.id);
+    if (touchedAt == null || now - touchedAt > LOCAL_COLUMN_MOVE_TTL_MS) {
+      return board;
+    }
+    const loc = localById.get(board.id);
+    if (!loc?.columns || !boardTasksAreHydrated(loc)) return board;
+    return { ...board, columns: loc.columns, tasksHydrated: true };
+  });
+}
+
 export function boardTasksAreHydrated(board?: Board | null): boolean {
   if (!board) return false;
   if (board.tasksHydrated === false) return false;

--- a/src/utils/taskReorderingUtils.ts
+++ b/src/utils/taskReorderingUtils.ts
@@ -16,6 +16,8 @@ import { DRAG_COOLDOWN_DURATION } from '../constants';
 import { dndLog } from './dndDebug';
 import type { Dispatch, SetStateAction } from 'react';
 
+export type OnColumnsApplied = (next: Columns) => void;
+
 // Helper to parse position as number
 const parsePos = (pos: any): number => typeof pos === 'number' ? pos : parseFloat(String(pos)) || 0;
 
@@ -707,7 +709,8 @@ export const restoreColumnTaskOrders = async (
   setColumns: Dispatch<SetStateAction<Columns>>,
   setDragCooldown: (value: boolean) => void,
   refreshBoardData: () => Promise<void>,
-  setFilteredColumns?: Dispatch<SetStateAction<Columns>>
+  setFilteredColumns?: Dispatch<SetStateAction<Columns>>,
+  onColumnsApplied?: OnColumnsApplied
 ): Promise<void> => {
   const preview = applyColumnOrderSnapshots(columns, orders);
   if (!preview) return;
@@ -729,6 +732,8 @@ export const restoreColumnTaskOrders = async (
     (window as any).reorderingInProgress = false;
     return;
   }
+
+  onColumnsApplied?.(applied.next);
 
   if (setFilteredColumns) {
     setFilteredColumns((prev) => {
@@ -812,7 +817,8 @@ export const moveTaskToIndex = async (
   setColumns: Dispatch<SetStateAction<Columns>>,
   setDragCooldown: (value: boolean) => void,
   refreshBoardData: () => Promise<void>,
-  setFilteredColumns?: Dispatch<SetStateAction<Columns>>
+  setFilteredColumns?: Dispatch<SetStateAction<Columns>>,
+  onColumnsApplied?: OnColumnsApplied
 ): Promise<void> => {
   // Pre-check against current snapshot (fast fail); authoritative apply uses prev
   const preview = applySameColumnMove(columns, task.id, columnId, targetIndex, task);
@@ -848,6 +854,8 @@ export const moveTaskToIndex = async (
     (window as any).reorderingInProgress = false;
     return;
   }
+
+  onColumnsApplied?.(applied.next);
 
   syncFilteredAfterSameColumnMove(setFilteredColumns, task.id, columnId, targetIndex, task);
 
@@ -899,7 +907,8 @@ export const handleCrossColumnMove = async (
   setColumns: Dispatch<SetStateAction<Columns>>,
   setDragCooldown: (value: boolean) => void,
   refreshBoardData: () => Promise<void>,
-  setFilteredColumns?: Dispatch<SetStateAction<Columns>>
+  setFilteredColumns?: Dispatch<SetStateAction<Columns>>,
+  onColumnsApplied?: OnColumnsApplied
 ): Promise<void> => {
   const preview = applyCrossColumnMove(columns, task.id, targetColumnId, targetIndex, task);
   if (!preview) {
@@ -931,6 +940,8 @@ export const handleCrossColumnMove = async (
     (window as any).reorderingInProgress = false;
     return;
   }
+
+  onColumnsApplied?.(applied.next);
 
   syncFilteredAfterCrossMove(setFilteredColumns, task.id, targetColumnId, targetIndex, task);
 
@@ -972,7 +983,8 @@ export const handleBulkMoveTasks = async (
   setColumns: Dispatch<SetStateAction<Columns>>,
   setDragCooldown: (value: boolean) => void,
   refreshBoardData: () => Promise<void>,
-  setFilteredColumns?: Dispatch<SetStateAction<Columns>>
+  setFilteredColumns?: Dispatch<SetStateAction<Columns>>,
+  onColumnsApplied?: OnColumnsApplied
 ): Promise<void> => {
   if (taskIds.length === 0) return;
   const preview = applyBulkMove(columns, taskIds, targetColumnId, targetIndex);
@@ -995,6 +1007,8 @@ export const handleBulkMoveTasks = async (
     (window as any).reorderingInProgress = false;
     return;
   }
+
+  onColumnsApplied?.(applied.next);
 
   if (setFilteredColumns) {
     setFilteredColumns((prev) => {


### PR DESCRIPTION
## Summary
- Mirror same-board column DnD into the boards[] cache and prefer that layout over a stale GET /full after a quick tab switch.
- Stop insert 0↔1 oscillation when dropping onto a column that has a single tall card (unshifted pointer Y + middle dead zone).

## Test plan
- [ ] Move a task to another column, switch boards immediately, switch back: card stays in the destination column without a full refresh.
- [ ] Drag onto a column with one tall card: top = before, bottom = after, middle does not jump.
- [ ] Existing multi-card and same-column DnD still feel smooth.


Made with [Cursor](https://cursor.com)