### PR TITLE
Fix Cannot GET / on all tenant hosts

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -306,6 +306,14 @@ app.use(express.urlencoded({ limit: '100mb', extended: true }));
 // Note: In production, Vite preview serves static files from dist and proxies API requests
 // Express no longer needs to serve static files when Vite preview is running
 // This code is kept for backward compatibility but won't be used when vite preview is active
+const workspaceUnavailablePath = path.join(__dirname, 'public/workspace-unavailable');
+if (fs.existsSync(workspaceUnavailablePath)) {
+  app.use(
+    '/workspace-unavailable',
+    express.static(workspaceUnavailablePath, { index: false, maxAge: 0 })
+  );
+}
+
 if (process.env.NODE_ENV === 'production' && !process.env.VITE_PREVIEW_RUNNING) {
   const distPath = path.join(__dirname, '../dist');
   const assetsPath = path.join(distPath, 'assets');
@@ -543,9 +551,7 @@ app.get('/api/version', async (req, res) => {
 // SPA FALLBACK FOR CLIENT-SIDE ROUTING
 // ================================
 
-// Serve the React app for all non-API routes
-// Express 5: catch-all route requires named wildcard parameter
-app.get('/*splat', (req, res) => {
+const sendSpaIndex = (req, res) => {
   // Skip API routes, file serving routes, and source file requests
   // NOTE: /assets/ should NOT be blocked - it's served by express.static middleware above
   // Missing hashed chunks must 404 — never fall through to index.html (breaks debugging and confuses import()).
@@ -564,7 +570,11 @@ app.get('/*splat', (req, res) => {
   const htmlPath = path.join(__dirname, '../dist/index.html');
   res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, private');
   res.sendFile(htmlPath);
-});
+};
+
+// Express 5: /*splat does not match GET /
+app.get('/', sendSpaIndex);
+app.get('/*splat', sendSpaIndex);
 
 // ================================
 // START SERVER

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,6 @@
+import fs from 'fs';
 import http from 'http';
+import path from 'path';
 import { defineConfig, type Plugin, type PreviewServer, type ViteDevServer } from 'vite';
 import react from '@vitejs/plugin-react';
 
@@ -56,14 +58,54 @@ function withForwardedHostProxyConfigure(
 }
 
 const HTML_GATE_SKIP =
-  /^\/(api|health|ready|assets|attachments|avatars|socket\.io|src|node_modules|@vite|@react-refresh|@fs)\b/;
+  /^\/(api|health|ready|assets|attachments|avatars|socket\.io|workspace-unavailable|src|node_modules|@vite|@react-refresh|@fs)\b/;
 
 /**
- * Multi-tenant: Vite preview owns port 3010 (K8s/EKS NodePort). Document
- * requests must hit Express tenantRouting so unknown Hosts get the parked page
- * instead of the SPA login.
+ * Multi-tenant preview (port 3010): keep Vite serving the SPA for real
+ * tenants. Only swap in the parked page when Express says the Host has no schema.
+ * Do not proxy all HTML to Express — GET / is not a Vite-preview Express route.
  */
-function agilaHtmlWorkspaceGate(): Plugin {
+function agilaUnknownWorkspacePage(): Plugin {
+  const parkedHtmlPath = () =>
+    path.join(process.cwd(), 'server/public/workspace-unavailable/index.html');
+
+  const incomingHost = (req: { headers: http.IncomingHttpHeaders }) => {
+    const forwarded = req.headers['x-forwarded-host'];
+    const raw = (Array.isArray(forwarded) ? forwarded[0] : forwarded) || req.headers.host || '';
+    return String(raw).split(',')[0].trim();
+  };
+
+  const workspaceMissing = (host: string): Promise<boolean> =>
+    new Promise((resolve) => {
+      if (!host) {
+        resolve(false);
+        return;
+      }
+      const check = http.request(
+        {
+          hostname: '127.0.0.1',
+          port: 3222,
+          path: '/api/settings',
+          method: 'GET',
+          headers: {
+            host,
+            'x-forwarded-host': host,
+            accept: 'application/json'
+          }
+        },
+        (pres) => {
+          const chunks: Buffer[] = [];
+          pres.on('data', (c) => chunks.push(c));
+          pres.on('end', () => {
+            const body = Buffer.concat(chunks).toString('utf8');
+            resolve(pres.statusCode === 404 && body.includes('WORKSPACE_UNAVAILABLE'));
+          });
+        }
+      );
+      check.on('error', () => resolve(false));
+      check.end();
+    });
+
   const attach = (middlewares: ViteDevServer['middlewares']) => {
     middlewares.use((req, res, next) => {
       if (process.env.MULTI_TENANT !== 'true') {
@@ -79,28 +121,30 @@ function agilaHtmlWorkspaceGate(): Plugin {
         next();
         return;
       }
-      const headers = { ...req.headers };
-      delete headers.connection;
-      const upstream = http.request(
-        {
-          hostname: '127.0.0.1',
-          port: 3222,
-          path: req.url,
-          method: req.method,
-          headers
-        },
-        (pres) => {
-          res.writeHead(pres.statusCode || 502, pres.headers);
-          pres.pipe(res);
-        }
-      );
-      upstream.on('error', () => next());
-      req.pipe(upstream);
+      const host = incomingHost(req);
+      workspaceMissing(host)
+        .then((missing) => {
+          if (!missing) {
+            next();
+            return;
+          }
+          const htmlPath = parkedHtmlPath();
+          if (!fs.existsSync(htmlPath)) {
+            next();
+            return;
+          }
+          res.statusCode = 404;
+          res.setHeader('Content-Type', 'text/html; charset=utf-8');
+          res.setHeader('Cache-Control', 'no-store');
+          res.setHeader('X-Robots-Tag', 'noindex, nofollow');
+          fs.createReadStream(htmlPath).pipe(res);
+        })
+        .catch(() => next());
     });
   };
 
   return {
-    name: 'agila-html-workspace-gate',
+    name: 'agila-unknown-workspace-page',
     configureServer(server: ViteDevServer) {
       attach(server.middlewares);
     },
@@ -134,7 +178,7 @@ function agilaDevFavicon(): Plugin {
 }
 
 export default defineConfig({
-  plugins: [agilaHtmlWorkspaceGate(), react(), agilaDevFavicon(), ignoreBenignSocketErrors()],
+  plugins: [agilaUnknownWorkspacePage(), react(), agilaDevFavicon(), ignoreBenignSocketErrors()],
   envPrefix: ['VITE_', 'DEMO_', 'MULTI_'] as string[],
   // A second React copy makes every hook call fail ("dispatcher is null")
   resolve: {
@@ -245,6 +289,11 @@ export default defineConfig({
         changeOrigin: false,
         configure: withForwardedHostProxyConfigure,
       },
+      '/workspace-unavailable': {
+        target: 'http://localhost:3222',
+        changeOrigin: false,
+        configure: withForwardedHostProxyConfigure,
+      },
       '/attachments': {
         target: 'http://localhost:3222',
         changeOrigin: false,
@@ -298,6 +347,11 @@ export default defineConfig({
         configure: withForwardedHostProxyConfigure,
       },
       '/health': {
+        target: 'http://localhost:3222',
+        changeOrigin: false,
+        configure: withForwardedHostProxyConfigure,
+      },
+      '/workspace-unavailable': {
         target: 'http://localhost:3222',
         changeOrigin: false,
         configure: withForwardedHostProxyConfigure,


### PR DESCRIPTION
## Summary
- The workspace gate proxied every document request to Express. Express 5 has no GET / (Vite preview used to serve it), so **all** hosts returned Cannot GET /.
- Vite again serves the SPA for real tenants. The parked page is used only when `/api/settings` returns WORKSPACE_UNAVAILABLE.

## Test plan
- [ ] drenlia.agila.dev (or any live tenant) loads the app
- [ ] sdfsdf.agila.dev shows the parked workspace page, not Cannot GET /


Made with [Cursor](https://cursor.com)