### PR TITLE
fix: AuthZ gaps in agent work, tasks, and file serving

### DIFF
--- a/server/routes/agent.js
+++ b/server/routes/agent.js
@@ -7,6 +7,7 @@ import express from 'express';
 import crypto from 'crypto';
 import { authenticateToken } from '../middleware/auth.js';
 import { getRequestDatabase, getTenantId } from '../middleware/tenantRouting.js';
+import { assertTaskBoardAccess, userCanAccessBoard, userHasAdminRole } from '../middleware/boardAccess.js';
 import { requireAiEnabledMiddleware } from '../utils/aiEnabled.js';
 import {
   tasks as taskQueries,
@@ -29,6 +30,11 @@ import {
   agentPatchTaskBodySchema,
   agentUpdateWorkBodySchema
 } from '../utils/requestValidation.js';
+import {
+  redactWorkMapForClient,
+  sanitizeWorkEntries,
+  FORBIDDEN_AGENT_WORK_WRITE_KEYS
+} from '../utils/taskWorkPublic.js';
 
 const router = express.Router();
 const requireAi = requireAiEnabledMiddleware(getRequestDatabase);
@@ -43,7 +49,7 @@ async function publishTaskWork(req, taskId, work) {
     {
       taskId,
       boardId: task?.boardid || task?.boardId,
-      work,
+      work: redactWorkMapForClient(work),
       timestamp: new Date().toISOString()
     },
     tenantId
@@ -54,23 +60,45 @@ function dbOr(req) {
   return getRequestDatabase(req);
 }
 
-async function ensureAgentTask(db, taskId) {
+/**
+ * Ensure task exists, is assigned to Agent, and caller may access its board.
+ * On board denial, assertTaskBoardAccess already wrote the response — `sent: true`.
+ */
+async function ensureAgentTask(req, res, taskId) {
+  const db = dbOr(req);
   const task = await taskQueries.getTaskById(db, taskId);
   if (!task) return { error: 'Task not found', status: 404 };
   const memberId = task.memberid || task.memberId;
   if (memberId !== AGENT_MEMBER_ID) {
     return { error: 'Task is not assigned to the Agent', status: 400 };
   }
+  if (!(await assertTaskBoardAccess(req, res, taskId))) {
+    return { error: true, sent: true };
+  }
   return { task };
 }
 
-// Pending / claimable tasks
+function agentDenied(res, check) {
+  if (check.sent) return true;
+  if (check.error) {
+    res.status(check.status).json({ error: check.error });
+    return true;
+  }
+  return false;
+}
+
+// Pending / claimable tasks — scoped to boards the caller can access; secrets redacted.
 router.get('/tasks/pending', async (req, res) => {
   try {
     const db = dbOr(req);
     const rows = await taskWorkQueries.getPendingAgentTasks(db, ['queued']);
     const tasks = [];
+    const isAdmin = userHasAdminRole(req.user);
     for (const row of rows) {
+      if (!isAdmin) {
+        const allowed = await userCanAccessBoard(db, req.user, row.boardid);
+        if (!allowed) continue;
+      }
       const work = await taskWorkQueries.getWorkMapByTaskId(db, row.id);
       tasks.push({
         id: row.id,
@@ -79,7 +107,7 @@ router.get('/tasks/pending', async (req, res) => {
         boardId: row.boardid,
         columnId: row.columnid,
         priority: row.priority,
-        work
+        work: redactWorkMapForClient(work)
       });
     }
     res.json({ tasks });
@@ -92,8 +120,8 @@ router.get('/tasks/pending', async (req, res) => {
 router.post('/tasks/:id/claim', agentClaimLimiter, async (req, res) => {
   try {
     const db = dbOr(req);
-    const check = await ensureAgentTask(db, req.params.id);
-    if (check.error) return res.status(check.status).json({ error: check.error });
+    const check = await ensureAgentTask(req, res, req.params.id);
+    if (agentDenied(res, check)) return;
 
     const claimParsed = parseBody(agentClaimBodySchema, req.body || {});
     if (!claimParsed.success) {
@@ -110,7 +138,7 @@ router.post('/tasks/:id/claim', agentClaimLimiter, async (req, res) => {
     }
 
     await publishTaskWork(req, req.params.id, work);
-    res.json({ taskId: req.params.id, work });
+    res.json({ taskId: req.params.id, work: redactWorkMapForClient(work) });
   } catch (error) {
     console.error('Agent claim error:', error);
     res.status(500).json({ error: 'Failed to claim task' });
@@ -120,8 +148,8 @@ router.post('/tasks/:id/claim', agentClaimLimiter, async (req, res) => {
 router.get('/tasks/:id', async (req, res) => {
   try {
     const db = dbOr(req);
-    const check = await ensureAgentTask(db, req.params.id);
-    if (check.error) return res.status(check.status).json({ error: check.error });
+    const check = await ensureAgentTask(req, res, req.params.id);
+    if (agentDenied(res, check)) return;
 
     const full = await taskQueries.getTaskWithRelationships(db, req.params.id);
     const work = await taskWorkQueries.getWorkMapByTaskId(db, req.params.id);
@@ -134,7 +162,7 @@ router.get('/tasks/:id', async (req, res) => {
 
     res.json({
       task: full || check.task,
-      work,
+      work: redactWorkMapForClient(work),
       attachments
     });
   } catch (error) {
@@ -146,8 +174,8 @@ router.get('/tasks/:id', async (req, res) => {
 router.post('/tasks/:id/move', async (req, res) => {
   try {
     const db = dbOr(req);
-    const check = await ensureAgentTask(db, req.params.id);
-    if (check.error) return res.status(check.status).json({ error: check.error });
+    const check = await ensureAgentTask(req, res, req.params.id);
+    if (agentDenied(res, check)) return;
 
     const moveParsed = parseBody(agentMoveTaskBodySchema, req.body || {});
     if (!moveParsed.success) {
@@ -192,8 +220,8 @@ router.post('/tasks/:id/move', async (req, res) => {
 router.post('/tasks/:id/comments', async (req, res) => {
   try {
     const db = dbOr(req);
-    const check = await ensureAgentTask(db, req.params.id);
-    if (check.error) return res.status(check.status).json({ error: check.error });
+    const check = await ensureAgentTask(req, res, req.params.id);
+    if (agentDenied(res, check)) return;
 
     const commentParsed = parseBody(agentCommentBodySchema, req.body || {});
     if (!commentParsed.success) {
@@ -264,8 +292,8 @@ router.post('/tasks/:id/comments', async (req, res) => {
 router.post('/tasks/:id/attachments', async (req, res) => {
   try {
     const db = dbOr(req);
-    const check = await ensureAgentTask(db, req.params.id);
-    if (check.error) return res.status(check.status).json({ error: check.error });
+    const check = await ensureAgentTask(req, res, req.params.id);
+    if (agentDenied(res, check)) return;
 
     const attParsed = parseBody(agentAttachmentsBodySchema, req.body || {});
     if (!attParsed.success) {
@@ -304,8 +332,8 @@ router.post('/tasks/:id/attachments', async (req, res) => {
 router.patch('/tasks/:id', async (req, res) => {
   try {
     const db = dbOr(req);
-    const check = await ensureAgentTask(db, req.params.id);
-    if (check.error) return res.status(check.status).json({ error: check.error });
+    const check = await ensureAgentTask(req, res, req.params.id);
+    if (agentDenied(res, check)) return;
 
     const patchParsed = parseBody(agentPatchTaskBodySchema, req.body || {});
     if (!patchParsed.success) {
@@ -365,10 +393,10 @@ router.patch('/tasks/:id', async (req, res) => {
 router.get('/tasks/:id/work', async (req, res) => {
   try {
     const db = dbOr(req);
-    const check = await ensureAgentTask(db, req.params.id);
-    if (check.error) return res.status(check.status).json({ error: check.error });
+    const check = await ensureAgentTask(req, res, req.params.id);
+    if (agentDenied(res, check)) return;
     const work = await taskWorkQueries.getWorkMapByTaskId(db, req.params.id);
-    res.json({ work });
+    res.json({ work: redactWorkMapForClient(work) });
   } catch (error) {
     console.error('Agent get work error:', error);
     res.status(500).json({ error: 'Failed to get task work' });
@@ -378,8 +406,8 @@ router.get('/tasks/:id/work', async (req, res) => {
 router.put('/tasks/:id/work', async (req, res) => {
   try {
     const db = dbOr(req);
-    const check = await ensureAgentTask(db, req.params.id);
-    if (check.error) return res.status(check.status).json({ error: check.error });
+    const check = await ensureAgentTask(req, res, req.params.id);
+    if (agentDenied(res, check)) return;
 
     const workParsed = parseBody(agentUpdateWorkBodySchema, req.body || {});
     if (!workParsed.success) {
@@ -392,8 +420,7 @@ router.put('/tasks/:id/work', async (req, res) => {
     }
 
     const { appendLog, ...rest } = entries;
-    const toUpsert = { ...rest };
-    // Never allow arbitrary overwrite of reserved structure via empty body
+    const toUpsert = sanitizeWorkEntries(rest, FORBIDDEN_AGENT_WORK_WRITE_KEYS);
     delete toUpsert.appendLog;
     delete toUpsert.entries;
 
@@ -406,7 +433,7 @@ router.put('/tasks/:id/work', async (req, res) => {
 
     const work = await taskWorkQueries.getWorkMapByTaskId(db, req.params.id);
     await publishTaskWork(req, req.params.id, work);
-    res.json({ work });
+    res.json({ work: redactWorkMapForClient(work) });
   } catch (error) {
     console.error('Agent put work error:', error);
     res.status(500).json({ error: 'Failed to update task work' });
@@ -416,8 +443,8 @@ router.put('/tasks/:id/work', async (req, res) => {
 router.get('/control/:id', async (req, res) => {
   try {
     const db = dbOr(req);
-    const check = await ensureAgentTask(db, req.params.id);
-    if (check.error) return res.status(check.status).json({ error: check.error });
+    const check = await ensureAgentTask(req, res, req.params.id);
+    if (agentDenied(res, check)) return;
     const work = await taskWorkQueries.getWorkMapByTaskId(db, req.params.id);
     res.json({
       status: work.status || null,

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -399,6 +399,26 @@ router.get('/demo-credentials', async (req, res) => {
       return res.status(404).json({ error: 'Not found' });
     }
 
+    // Defense in depth: never expose cleartext admin passwords on production hosts,
+    // even if DEMO_ENABLED were mis-set on the shared image.
+    const host = String(req.get('x-forwarded-host') || req.get('host') || '')
+      .split(',')[0]
+      .trim()
+      .toLowerCase();
+    const hostname = host.split(':')[0];
+    const demoHostAllowlist = new Set(
+      String(process.env.DEMO_CREDENTIALS_HOSTS || 'kanban.demo.drenlia.com,localhost,127.0.0.1')
+        .split(',')
+        .map((h) => h.trim().toLowerCase())
+        .filter(Boolean)
+    );
+    if (
+      process.env.NODE_ENV === 'production' &&
+      (hostname === 'app.agila.dev' || !demoHostAllowlist.has(hostname))
+    ) {
+      return res.status(404).json({ error: 'Not found' });
+    }
+
     // Prevent browsers/proxies from caching passwords across demo resets
     res.set({
       'Cache-Control': 'no-store, no-cache, must-revalidate, private',

--- a/server/routes/columns.js
+++ b/server/routes/columns.js
@@ -324,6 +324,7 @@ router.post('/reorder', authenticateToken, async (req, res) => {
   try {
     const db = getRequestDatabase(req);
     const t = await getTranslator(db);
+    if (!(await assertBoardAccess(req, res, boardId))) return;
     
     // MIGRATED: Get column position using sqlManager
     const currentColumn = await helpers.getColumnPosition(db, columnId);
@@ -408,6 +409,7 @@ router.post('/renumber', authenticateToken, async (req, res) => {
   const { boardId } = parsed.data;
   try {
     const db = getRequestDatabase(req);
+    if (!(await assertBoardAccess(req, res, boardId))) return;
 
     let allColumns;
     await dbTransaction(db, async () => {

--- a/server/routes/files.js
+++ b/server/routes/files.js
@@ -77,14 +77,17 @@ async function assertActiveFileUser(req, token, via) {
     if (!userMayUseSession(userInDb)) {
       return { ok: false, status: 401, error: userInDb ? 'Invalid token' : 'Invalid token for this tenant' };
     }
+    return { ok: true, decoded, db, user: userInDb };
   } catch (dbError) {
     console.error('❌ Error checking user for file access:', dbError);
     return { ok: false, status: 401, error: 'Authentication failed' };
   }
-
-  return { ok: true, decoded, db };
 }
 
+/**
+ * Attachments require board membership for the owning task.
+ * Avatars remain tenant-visible to any active authenticated user (by design).
+ */
 async function serveAuthenticatedFile(req, res, kind) {
   const cred = resolveFileAccessCredential(req);
   if (!cred) {
@@ -97,8 +100,31 @@ async function serveAuthenticatedFile(req, res, kind) {
       return res.status(auth.status).json({ error: auth.error });
     }
 
+    // Media cookie / query tokens do not populate req.user — hydrate for AuthZ helpers.
+    if (!req.user) {
+      const roleNames = String(auth.user?.roles || '')
+        .split(',')
+        .map((r) => r.trim())
+        .filter(Boolean);
+      req.user = {
+        id: auth.decoded.id,
+        role: roleNames[0] || auth.decoded.role,
+        roles: roleNames.length ? roleNames : auth.decoded.roles,
+      };
+    }
+
     const storagePaths = getRequestStoragePaths(req);
     const safeName = path.basename(req.params.filename);
+
+    if (kind === 'attachments') {
+      const attachment = await fileQueries.getAttachmentByFilename(auth.db, safeName);
+      const taskId = attachment?.resolvedTaskId || attachment?.taskId || attachment?.taskid;
+      if (!taskId) {
+        return res.status(404).json({ error: 'File not found' });
+      }
+      if (!(await assertTaskBoardAccess(req, res, taskId))) return;
+    }
+
     const obj = await getObject(auth.db, storagePaths, kind, safeName);
 
     if (!obj) {

--- a/server/routes/taskWork.js
+++ b/server/routes/taskWork.js
@@ -6,6 +6,11 @@
 import express from 'express';
 import { authenticateToken } from '../middleware/auth.js';
 import { getRequestDatabase, getTenantId } from '../middleware/tenantRouting.js';
+import {
+  assertTaskBoardAccess,
+  userCanAccessBoard,
+  userHasAdminRole
+} from '../middleware/boardAccess.js';
 import { isAiEnabled } from '../utils/aiEnabled.js';
 import {
   tasks as taskQueries,
@@ -21,6 +26,7 @@ import {
   taskWorkControlBodySchema,
   workMapsBodySchema
 } from '../utils/requestValidation.js';
+import { redactWorkMapForClient } from '../utils/taskWorkPublic.js';
 
 const router = express.Router();
 
@@ -32,7 +38,7 @@ async function publishWork(req, taskId, work) {
     {
       taskId,
       boardId: task?.boardid || task?.boardId,
-      work,
+      work: redactWorkMapForClient(work),
       timestamp: new Date().toISOString()
     },
     getTenantId(req)
@@ -47,9 +53,10 @@ function dispatchCtx(req) {
 
 router.get('/:taskId/work', authenticateToken, async (req, res) => {
   try {
+    if (!(await assertTaskBoardAccess(req, res, req.params.taskId))) return;
     const db = getRequestDatabase(req);
     const work = await taskWorkQueries.getWorkMapByTaskId(db, req.params.taskId);
-    res.json({ work });
+    res.json({ work: redactWorkMapForClient(work) });
   } catch (error) {
     console.error('Get task work error:', error);
     res.status(500).json({ error: 'Failed to get task work' });
@@ -58,10 +65,12 @@ router.get('/:taskId/work', authenticateToken, async (req, res) => {
 
 /**
  * Bind repo / initialize agent work when assigning to Agent.
- * Body: { repoUrl, repoBranch?, status? }
+ * Body: { repoUrl, repoBranch?, status?, agentMode?, ... } — no free-form entries.
  */
 router.put('/:taskId/work', authenticateToken, async (req, res) => {
   try {
+    if (!(await assertTaskBoardAccess(req, res, req.params.taskId))) return;
+
     const db = getRequestDatabase(req);
     if (!(await isAiEnabled(db))) {
       return res.status(403).json({ error: 'AI features are disabled for this instance' });
@@ -83,6 +92,7 @@ router.put('/:taskId/work', authenticateToken, async (req, res) => {
     }
     const body = parsed.data;
 
+    // Only typed top-level fields — never accept arbitrary task_work keys from clients.
     const entries = {};
     if (body.repoUrl !== undefined) {
       // Empty string = assist-only (no code repo)
@@ -106,19 +116,14 @@ router.put('/:taskId/work', authenticateToken, async (req, res) => {
         : [];
       entries.automation_board_ids = JSON.stringify(ids.filter(Boolean));
     }
-    if (body.entries && typeof body.entries === 'object') {
-      Object.assign(entries, body.entries);
+
+    // Per-task LLM model override — admins only
+    if (isAdmin && body.llmModel !== undefined) {
+      entries.llm_model = String(body.llmModel || '').trim();
     }
 
-    // Per-task LLM model override — admins only (strip if sneaked via entries)
-    if (!isAdmin) {
-      delete entries.llm_model;
-      // Non-admins cannot launch automation
-      if (entries.agent_mode === 'automation') {
-        return res.status(403).json({ error: 'Only admins can run Automation jobs' });
-      }
-    } else if (body.llmModel !== undefined) {
-      entries.llm_model = String(body.llmModel || '').trim();
+    if (!isAdmin && entries.agent_mode === 'automation') {
+      return res.status(403).json({ error: 'Only admins can run Automation jobs' });
     }
 
     if (entries.agent_mode === 'automation' && entries.status === 'queued') {
@@ -154,15 +159,9 @@ router.put('/:taskId/work', authenticateToken, async (req, res) => {
       }
     }
 
-    // Bind coding/automation credentials to the assigning user (not admin/global PAT)
+    // Always bind credentials to the caller when queuing — never client-supplied owner.
     if (entries.status === 'queued' && req.user?.id) {
-      if (
-        body.repoUrl !== undefined ||
-        body.agentMode !== undefined ||
-        !existing.agent_owner_user_id
-      ) {
-        entries.agent_owner_user_id = req.user.id;
-      }
+      entries.agent_owner_user_id = req.user.id;
     }
 
     // Clear stale PR/branch outcomes when the linked repo changes
@@ -218,7 +217,7 @@ router.put('/:taskId/work', authenticateToken, async (req, res) => {
       }
     }
 
-    res.json({ work });
+    res.json({ work: redactWorkMapForClient(work) });
   } catch (error) {
     console.error('Put task work error:', error);
     res.status(500).json({ error: 'Failed to update task work' });
@@ -231,6 +230,8 @@ router.put('/:taskId/work', authenticateToken, async (req, res) => {
  */
 router.put('/:taskId/work/control', authenticateToken, async (req, res) => {
   try {
+    if (!(await assertTaskBoardAccess(req, res, req.params.taskId))) return;
+
     const db = getRequestDatabase(req);
     if (!(await isAiEnabled(db))) {
       return res.status(403).json({ error: 'AI features are disabled for this instance' });
@@ -289,6 +290,9 @@ router.put('/:taskId/work/control', authenticateToken, async (req, res) => {
           error: 'Task description is required before starting the agent'
         });
       }
+      // On resume/re-queue, credentials belong to the caller if no owner yet.
+      // Never accept a client-supplied owner; do not overwrite an existing owner
+      // (original assigner's PAT/SSH) unless missing.
       if (!workBefore.agent_owner_user_id && req.user?.id) {
         updates.agent_owner_user_id = req.user.id;
       }
@@ -355,7 +359,7 @@ router.put('/:taskId/work/control', authenticateToken, async (req, res) => {
       }
     }
 
-    res.json({ work });
+    res.json({ work: redactWorkMapForClient(work) });
   } catch (error) {
     console.error('Task work control error:', error);
     res.status(500).json({ error: 'Failed to update control' });
@@ -376,8 +380,20 @@ router.post('/work-maps', authenticateToken, async (req, res) => {
     }
     const taskIds = parsed.data.taskIds.slice(0, 500);
     const result = {};
+    const isAdmin = userHasAdminRole(req.user);
     for (const taskId of taskIds) {
-      result[taskId] = await taskWorkQueries.getWorkMapByTaskId(db, taskId);
+      // Skip inaccessible / unknown tasks rather than failing the whole batch.
+      if (!isAdmin) {
+        const boardId = await taskQueries.getTaskBoardId(db, taskId);
+        if (!boardId || !(await userCanAccessBoard(db, req.user, boardId))) {
+          continue;
+        }
+      } else {
+        const boardId = await taskQueries.getTaskBoardId(db, taskId);
+        if (!boardId) continue;
+      }
+      const work = await taskWorkQueries.getWorkMapByTaskId(db, taskId);
+      result[taskId] = redactWorkMapForClient(work);
     }
     res.json({ workByTaskId: result });
   } catch (error) {

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -3296,7 +3296,7 @@ router.post('/:taskId/collaborators/:memberId', authenticateToken, async (req, r
 });
 
 // Remove collaborator from task
-router.delete('/:taskId/collaborators/:memberId', async (req, res) => {
+router.delete('/:taskId/collaborators/:memberId', authenticateToken, async (req, res) => {
   try {
     const db = getRequestDatabase(req);
     const tTranslator = await getTranslator(db);

--- a/server/routes/tasks.js
+++ b/server/routes/tasks.js
@@ -451,7 +451,10 @@ router.get('/trash/search', authenticateToken, async (req, res) => {
       ? Math.min(Math.max(requestedLimit, 1), 50)
       : 20;
 
-    const tasks = await taskQueries.searchTrashedTasks(db, query, limit);
+    const tasks = await taskQueries.searchTrashedTasks(db, query, limit, {
+      userId: req.user.id,
+      isAdmin: userHasAdminRole(req.user),
+    });
     res.json({ tasks });
   } catch (error) {
     console.error('Error searching trashed tasks:', error);
@@ -1852,6 +1855,15 @@ router.post('/bulk-field-activity', authenticateToken, async (req, res) => {
       reason = null,
     } = parsed.data;
 
+    if (boardId && !(await assertBoardAccess(req, res, boardId))) return;
+    if (Array.isArray(taskIds) && taskIds.length) {
+      const existing = await taskQueries.getTasksByIdsBasic(db, taskIds);
+      for (const t of existing) {
+        const tidBoard = t.boardId || t.boardid;
+        if (tidBoard && !(await assertBoardAccess(req, res, tidBoard))) return;
+      }
+    }
+
     await logBulkTaskFieldActivity(
       userId,
       field,
@@ -1903,6 +1915,24 @@ router.post('/batch-update', authenticateToken, async (req, res) => {
     
     if (missingTasks.length > 0) {
       return res.status(404).json({ error: tTranslator('errors.taskNotFound') + `: ${missingTasks.join(', ')}` });
+    }
+
+    // AuthZ: caller must access each task's current board; boardId is immutable here.
+    for (const task of tasks) {
+      const current = existingTaskMap.get(task.id);
+      const currentBoardId = current?.boardId || current?.boardid;
+      if (currentBoardId && !(await assertBoardAccess(req, res, currentBoardId))) return;
+      const requestedBoardId = task.boardId || task.boardid;
+      if (
+        requestedBoardId &&
+        currentBoardId &&
+        String(requestedBoardId) !== String(currentBoardId)
+      ) {
+        return res.status(400).json({
+          error: 'boardId cannot be changed via batch-update; use move-to-board',
+          code: 'BOARD_ID_IMMUTABLE',
+        });
+      }
     }
 
     for (const task of tasks) {
@@ -1969,12 +1999,14 @@ router.post('/batch-update', authenticateToken, async (req, res) => {
       }
 
       const columnChanged = task.columnId && task.columnId !== previousColumnId;
+      // boardId is immutable on this route — always persist the existing board.
+      const boardIdToWrite = previousBoardId;
       if (columnChanged) {
         batchQueries.push({
           query: updateQueryCrossColumn,
           params: [
             task.title, task.description, task.memberId, task.requesterId, task.startDate,
-            task.dueDate, task.effort, priorityName, priorityId, task.columnId, task.boardId, task.position || 0,
+            task.dueDate, task.effort, priorityName, priorityId, task.columnId, boardIdToWrite, task.position || 0,
             task.sprintId || null, previousBoardId, previousColumnId, now, now, task.id
           ]
         });
@@ -1983,7 +2015,7 @@ router.post('/batch-update', authenticateToken, async (req, res) => {
           query: updateQuerySameColumn,
           params: [
             task.title, task.description, task.memberId, task.requesterId, task.startDate,
-            task.dueDate, task.effort, priorityName, priorityId, task.columnId, task.boardId, task.position || 0,
+            task.dueDate, task.effort, priorityName, priorityId, task.columnId, boardIdToWrite, task.position || 0,
             task.sprintId || null, previousBoardId, previousColumnId, now, task.id
           ]
         });
@@ -2116,6 +2148,7 @@ router.post('/:id/restore', authenticateToken, async (req, res) => {
     }
 
     const boardId = task.boardid || task.boardId;
+    if (boardId && !(await assertBoardAccess(req, res, boardId))) return;
     const board = await boardQueries.getBoardById(db, boardId);
     if (!board) {
       return res.status(409).json({
@@ -2363,6 +2396,11 @@ router.post('/batch-update-positions', authenticateToken, async (req, res) => {
     }
     
     const taskMap = new Map(currentTasks.map(t => [t.id, t]));
+
+    for (const currentTask of currentTasks) {
+      const boardId = currentTask.boardId || currentTask.boardid;
+      if (boardId && !(await assertBoardAccess(req, res, boardId))) return;
+    }
     
     // Group updates by column for efficient batch processing
     const updatesByColumn = new Map();
@@ -2688,6 +2726,9 @@ router.post('/reorder', authenticateToken, async (req, res) => {
     if (!currentTask) {
       return res.status(404).json({ error: tTranslator('errors.taskNotFound') });
     }
+
+    const reorderBoardId = currentTask.boardId || currentTask.boardid;
+    if (reorderBoardId && !(await assertBoardAccess(req, res, reorderBoardId))) return;
 
     // Ensure positions are numbers for comparison
     const currentPosition = typeof currentTask.position === 'number' 

--- a/server/utils/requestValidation.js
+++ b/server/utils/requestValidation.js
@@ -486,25 +486,18 @@ export const createTaskRelationshipBodySchema = z.object({
 
 // —— Task work / agent control ——
 
-export const updateTaskWorkBodySchema = z
-  .object({
-    repoUrl: z.string().max(2048).optional(),
-    repoBranch: z.string().max(256).optional(),
-    status: z.string().max(64).optional(),
-    agentMode: z.string().max(64).optional(),
-    automationScope: z.string().max(64).optional(),
-    automationBoardIds: z
-      .union([z.array(idSchema).max(100), z.string().max(4000)])
-      .optional(),
-    llmModel: z.string().max(128).optional(),
-    entries: z
-      .record(
-        z.string().max(128),
-        z.union([z.string().max(100_000), z.number(), z.boolean(), z.null()])
-      )
-      .optional()
-  })
-  .passthrough();
+export const updateTaskWorkBodySchema = z.object({
+  repoUrl: z.string().max(2048).optional(),
+  repoBranch: z.string().max(256).optional(),
+  status: z.string().max(64).optional(),
+  agentMode: z.string().max(64).optional(),
+  automationScope: z.string().max(64).optional(),
+  automationBoardIds: z
+    .union([z.array(idSchema).max(100), z.string().max(4000)])
+    .optional(),
+  llmModel: z.string().max(128).optional()
+  // Free-form `entries` removed — clients must use typed fields only (A-1).
+});
 
 export const taskWorkControlBodySchema = z.object({
   control: z.preprocess(

--- a/server/utils/sqlManager/files.js
+++ b/server/utils/sqlManager/files.js
@@ -27,6 +27,34 @@ export async function getAttachmentById(db, attachmentId) {
 }
 
 /**
+ * Resolve an attachment row by stored public URL ending with the given filename.
+ * Used to authorize authenticated file downloads by board membership.
+ */
+export async function getAttachmentByFilename(db, filename) {
+  const safe = String(filename || '').replace(/\\/g, '/').split('/').pop();
+  if (!safe) return null;
+  const query = `
+    SELECT a.id,
+           a.taskid as "taskId",
+           a.commentid as "commentId",
+           a.url,
+           COALESCE(a.taskid, c.taskid) as "resolvedTaskId"
+    FROM attachments a
+    LEFT JOIN comments c ON c.id = a.commentid
+    WHERE a.url LIKE $1
+       OR a.url LIKE $2
+       OR a.url LIKE $3
+    LIMIT 1
+  `;
+  const stmt = wrapQuery(db.prepare(query), 'SELECT');
+  return await stmt.get(
+    `%/attachments/${safe}`,
+    `%/api/files/attachments/${safe}`,
+    `%/${safe}`
+  );
+}
+
+/**
  * Get user by ID (for file access verification)
  * 
  * @param {Database} db - Database connection
@@ -35,8 +63,13 @@ export async function getAttachmentById(db, attachmentId) {
  */
 export async function getUserByIdForFileAccess(db, userId) {
   const query = `
-    SELECT id, email, is_active, force_logout FROM users 
-    WHERE id = $1
+    SELECT u.id, u.email, u.is_active, u.force_logout,
+           COALESCE(string_agg(r.name, ','), '') as roles
+    FROM users u
+    LEFT JOIN user_roles ur ON u.id = ur.user_id
+    LEFT JOIN roles r ON ur.role_id = r.id
+    WHERE u.id = $1
+    GROUP BY u.id, u.email, u.is_active, u.force_logout
   `;
   
   const stmt = wrapQuery(db.prepare(query), 'SELECT');

--- a/server/utils/sqlManager/tasks.js
+++ b/server/utils/sqlManager/tasks.js
@@ -1569,11 +1569,14 @@ export async function getLifecycleDeletedTasks(db, boardId = null, search = null
 
 /**
  * Soft-deleted tasks matching a text query, for the header search dropdown.
- * Board-agnostic like the live corpus the client already holds, so trashed work
- * stays findable; capped because this runs per keystroke batch.
+ * Scoped to boards the caller can access (admins see all), matching getAllTasks.
  */
-export async function searchTrashedTasks(db, search, limit = 20) {
+export async function searchTrashedTasks(db, search, limit = 20, access = null) {
   const needle = `%${String(search).trim().toLowerCase()}%`;
+  const accessSql =
+    access && !access.isAdmin && access.userId
+      ? `AND t.boardid IN (SELECT board_id FROM board_participants WHERE user_id = $3)`
+      : '';
   const query = `
     SELECT t.id, t.title, t.ticket, t.description,
            t.memberid as "memberId", t.requesterid as "requesterId",
@@ -1594,10 +1597,14 @@ export async function searchTrashedTasks(db, search, limit = 20) {
         OR LOWER(t.title) LIKE $1
         OR LOWER(COALESCE(t.description, '')) LIKE $1
       )
+      ${accessSql}
     ORDER BY t.deleted_at DESC
     LIMIT $2
   `;
   const stmt = wrapQuery(db.prepare(query), 'SELECT');
+  if (access && !access.isAdmin && access.userId) {
+    return await stmt.all(needle, limit, access.userId);
+  }
   return await stmt.all(needle, limit);
 }
 

--- a/server/utils/taskWorkPublic.js
+++ b/server/utils/taskWorkPublic.js
@@ -1,0 +1,70 @@
+/**
+ * Client-safe views of task_work maps.
+ * Secrets used by the runner/dispatcher must never leave user-facing HTTP/WS.
+ */
+
+const REDACTED_KEYS = new Set([
+  'callback_token',
+  'runner_job_id',
+  'automation_pending_plan',
+  'automation_plan_hash',
+  'automation_apply_hash',
+]);
+
+/**
+ * Keys users must never write (A-1). Agent/runner API uses a narrower forbid list.
+ */
+export const FORBIDDEN_CLIENT_WORK_WRITE_KEYS = new Set([
+  'callback_token',
+  'runner_job_id',
+  'agent_owner_user_id',
+  'automation_pending_plan',
+  'automation_plan_hash',
+  'automation_apply_hash',
+  'awaiting_apply',
+  'log',
+  'pr_url',
+  'agent_branch',
+  'progress',
+]);
+
+/** Keys even the agent/runner HTTP API must not overwrite (dispatcher-owned / identity). */
+export const FORBIDDEN_AGENT_WORK_WRITE_KEYS = new Set([
+  'callback_token',
+  'runner_job_id',
+  'agent_owner_user_id',
+]);
+
+/** @deprecated use FORBIDDEN_CLIENT_WORK_WRITE_KEYS */
+export const FORBIDDEN_WORK_WRITE_KEYS = FORBIDDEN_CLIENT_WORK_WRITE_KEYS;
+
+/**
+ * @param {Record<string, unknown>|null|undefined} work
+ * @returns {Record<string, unknown>}
+ */
+export function redactWorkMapForClient(work) {
+  if (!work || typeof work !== 'object') return {};
+  const out = {};
+  for (const [key, value] of Object.entries(work)) {
+    if (REDACTED_KEYS.has(key)) continue;
+    out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Strip forbidden keys from a free-form entries object.
+ * @param {Record<string, unknown>|null|undefined} entries
+ * @param {Iterable<string>} [forbidden]
+ * @returns {Record<string, unknown>}
+ */
+export function sanitizeWorkEntries(entries, forbidden = FORBIDDEN_CLIENT_WORK_WRITE_KEYS) {
+  if (!entries || typeof entries !== 'object') return {};
+  const blocked = forbidden instanceof Set ? forbidden : new Set(forbidden);
+  const out = {};
+  for (const [key, value] of Object.entries(entries)) {
+    if (blocked.has(key)) continue;
+    out[key] = value;
+  }
+  return out;
+}


### PR DESCRIPTION
## Summary
- Close critical agent `agent_owner_user_id` hijack and related High IDOR issues: allowlist `task_work` writes, always bind owner on queue, redact callback/runner secrets from user-facing work maps.
- Enforce board membership on agent/taskWork/batch/trash/attachment routes; make `boardId` immutable on batch-update; harden demo-credentials host checks.
- Add missing `authenticateToken` on collaborator delete.

## Test plan
- [ ] Assign Agent / queue a job — runs with the assigner's git credentials
- [ ] Confirm work map / WS payload has no `callback_token` or `runner_job_id`
- [ ] As non-admin, trash search only returns boards you can access
- [ ] Attachment download works for board members; foreign filename → 403/404
- [ ] Demo credentials still 404 on production hosts when `DEMO_ENABLED` is mis-set
- [ ] Deploy to kanban.agila.dev after merge


Made with [Cursor](https://cursor.com)