### PR TITLE
Upgrade nodemailer and js-yaml for npm audit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "marked": "15.0.12",
         "multer": "^1.4.5-lts.1",
         "node-cron": "4.2.1",
-        "nodemailer": "9.0.3",
+        "nodemailer": "9.1.1",
         "pg": "^8.11.3",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -7375,9 +7375,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {
@@ -8475,9 +8475,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
-      "integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.1.1.tgz",
+      "integrity": "sha512-izw9mVKFix6YSnC9eLgV6g1opl9DUlRio9ZNcq+Wu9Ujn2UwF+8Nl0B8nz22kEC+CTZCvinkxwJ0DeFbb6NwcQ==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "marked": "15.0.12",
     "multer": "^1.4.5-lts.1",
     "node-cron": "4.2.1",
-    "nodemailer": "9.0.3",
+    "nodemailer": "9.1.1",
     "pg": "^8.11.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
@@ -120,6 +120,7 @@
   "overrides": {
     "uuid": "^11.1.1",
     "browserslist": "4.28.8",
-    "pacote": "21.5.1"
+    "pacote": "21.5.1",
+    "js-yaml": "4.3.2"
   }
 }


### PR DESCRIPTION
## Summary
- Bump nodemailer to 9.1.1 and pin js-yaml to 4.3.2 so high-severity audit findings are gone.
- CI `npm audit --audit-level=high` passes; remaining TipTap findings stay moderate.

## Test plan
- [ ] CI npm audit job is green.
- [ ] Send a test email from Admin → Mail still works.


Made with [Cursor](https://cursor.com)