### PR TITLE
Fix Kanban width, trash counts, and new-task language

### DIFF
--- a/.cursor/rules/npm-audit-high.mdc
+++ b/.cursor/rules/npm-audit-high.mdc
@@ -1,0 +1,29 @@
+---
+description: High-severity npm audit before commit, push, merge, or test01 deploy
+alwaysApply: true
+---
+
+# High-severity npm audit before ship
+
+Before **commit**, **push**, **merge** to `main`/`dev`, or finishing work for **test01**, fail closed on **high+** npm advisories.
+
+## Which trees
+
+- If `package.json` or `package-lock.json` changed: audit that repo.
+- If the work is for **test01** (local Docker, auth-dev, test01 host): audit **agila**, **agila-web**, and **agila-admin** even when only one tree changed.
+
+Skip `agila-mobile` unless its lockfile changed.
+
+## How
+
+From each repo root (after install / lockfile updates):
+
+```
+npm audit --audit-level=high
+```
+
+Prefer `node scripts/ci-npm-audit.js` when that file exists (skips if the registry audit API is down).
+
+- **Pass:** exit 0; moderate/low findings may remain.
+- **Fail:** high or critical — upgrade or pin via `overrides` to a patched version, update the lockfile, re-run audit. Do **not** `npm audit fix --force` when that forces a breaking major (e.g. TipTap 2 → 3).
+- **Registry down:** do not block (same as CI).

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3649,7 +3649,7 @@ function AppContent() {
 
     const newTask: Task = {
       id: generateUUID(),
-      title: t('taskCard.newTask'),
+      title: i18n.t('taskCard.newTask', { ns: 'tasks' }),
       description: '',
       memberId: null,
       startDate: taskStartDate,

--- a/src/components/BoardTrashView.tsx
+++ b/src/components/BoardTrashView.tsx
@@ -356,9 +356,8 @@ export default function BoardTrashView({
       const columnId = task.columnId || (task as any).columnid;
       if (columnId && map.has(columnId)) {
         map.get(columnId)!.push(task);
-      } else if (columnId && columns[columnId]) {
-        // Column exists but is filtered from display — skip to keep alignment with live
       } else {
+        // Unknown / deleted column — keep in a virtual bucket so the header count matches.
         // Orphan: park under first display column so nothing is lost, or a virtual bucket
         const orphanKey = '__orphan__';
         if (!map.has(orphanKey)) map.set(orphanKey, []);

--- a/src/components/Column.tsx
+++ b/src/components/Column.tsx
@@ -60,6 +60,8 @@ interface KanbanColumnProps {
     isCrossColumn?: boolean;
   } | null;
   onAddTask: (columnId: string) => void;
+  /** Forces a column re-render when the UI language changes (memo skips onAddTask). */
+  uiLanguage?: string;
   columnWarnings?: Record<string, ColumnVisibilityWarning>;
   onDismissColumnWarning?: (columnId: string) => void;
   onClearFiltersForHiddenTask?: () => void;
@@ -2123,6 +2125,7 @@ function areKanbanColumnPropsEqual(
   if (prev.selectedMembers !== next.selectedMembers) return false;
   if (prev.selectedBoardId !== next.selectedBoardId) return false;
   if (prev.columnHeaderStickyTopPx !== next.columnHeaderStickyTopPx) return false;
+  if (prev.uiLanguage !== next.uiLanguage) return false;
 
   return true;
 }

--- a/src/components/layout/KanbanPage.tsx
+++ b/src/components/layout/KanbanPage.tsx
@@ -57,6 +57,8 @@ import {
   writeBoardTrashOpenPreference,
 } from '../../utils/boardTrashEvents';
 import { getTaskSprintId, taskMatchesSelectedSprint } from '../../utils/columnFilters';
+import { calculateGridStyle } from '../../utils/dragDropUtils';
+import { MIN_COLUMN_WIDTH } from '../../constants';
 import { isArchivedColumnFlag, applyFinishedColumnVisibility, isFinishedColumnFlag } from '../../utils/columnUtils';
 import { isKanbanPageScrolledDown, scrollKanbanPageToTopFastSmooth } from '../../utils/kanbanScroll';
 import { onHelpReveal, takeHelpReveal } from '../../utils/helpGoThere';
@@ -1057,6 +1059,22 @@ const KanbanPage: React.FC<KanbanPageProps> = ({
     return filtered;
   }, [visibleColumnsForCurrentBoard, columns]);
 
+  const visibleKanbanGridStyle = useMemo(() => {
+    const count = Object.values(getFilteredColumnsForDisplay).filter(
+      (column) => column && column.id
+    ).length;
+    return calculateGridStyle(count, kanbanColumnWidth || MIN_COLUMN_WIDTH);
+  }, [getFilteredColumnsForDisplay, kanbanColumnWidth]);
+
+  /** Trash lists every status so counts match the badge, including hidden Archive/Done. */
+  const allBoardColumnsForTrash = useMemo(
+    () =>
+      Object.values(columns)
+        .filter((column) => column && column.id)
+        .sort((a, b) => (a.position || 0) - (b.position || 0)),
+    [columns]
+  );
+
   // Get fully filtered columns (search filters + column visibility)
   const getFullyFilteredColumns = useMemo(() => {
     const visibleColumnIds = getVisibleColumns(selectedBoard);
@@ -1360,13 +1378,22 @@ const KanbanPage: React.FC<KanbanPageProps> = ({
     }
   }, [viewMode]);
 
-  // Keep the trash grid and live Kanban grid on the same horizontal position.
+  // Keep trash and live Kanban on the same horizontal position when they share
+  // the same column set. If the board hides statuses, trash stays independently
+  // scrollable so hidden-column cards (e.g. Archive) remain reachable.
   useEffect(() => {
     if (!trashOpen || viewMode !== 'kanban' || trashLoading) return;
 
     const boardScroller = columnsContainerRef.current;
     const trashScroller = trashScrollContainerRef.current;
     if (!boardScroller || !trashScroller) return;
+
+    const boardColumnCount = Object.values(getFilteredColumnsForDisplay).filter(
+      (column) => column && column.id
+    ).length;
+    if (allBoardColumnsForTrash.length !== boardColumnCount) {
+      return;
+    }
 
     const syncScroll = (source: HTMLDivElement, target: HTMLDivElement) => {
       if (syncingHorizontalScrollRef.current) return;
@@ -1405,7 +1432,7 @@ const KanbanPage: React.FC<KanbanPageProps> = ({
       }
       syncingHorizontalScrollRef.current = false;
     };
-  }, [trashOpen, trashLoading, viewMode, selectedBoard, gridStyle]);
+  }, [trashOpen, trashLoading, viewMode, selectedBoard, gridStyle, getFilteredColumnsForDisplay, allBoardColumnsForTrash]);
 
   // Keyboard navigation
   useEffect(() => {
@@ -1608,9 +1635,7 @@ const KanbanPage: React.FC<KanbanPageProps> = ({
               tasks={trashTasks.filter((task) =>
                 taskMatchesSelectedSprint(task, selectedSprintId)
               )}
-              displayColumns={Object.values(getFilteredColumnsForDisplay)
-                .filter((column) => column && column.id)
-                .sort((a, b) => (a.position || 0) - (b.position || 0))}
+              displayColumns={allBoardColumnsForTrash}
               columns={columns}
               members={members}
               isAdmin={isAdmin && canMutate}
@@ -1927,7 +1952,7 @@ const KanbanPage: React.FC<KanbanPageProps> = ({
                   They intentionally live outside each column header/count slot. */}
               {canMutate && (
               <div
-                style={gridStyle}
+                style={visibleKanbanGridStyle}
                 className="h-5 items-center"
                 data-kanban-selection-strip
               >
@@ -1961,7 +1986,7 @@ const KanbanPage: React.FC<KanbanPageProps> = ({
                 }
                 strategy={rectSortingStrategy}
               >
-                <BoardDropArea selectedBoard={selectedBoard} style={gridStyle}>
+                <BoardDropArea selectedBoard={selectedBoard} style={visibleKanbanGridStyle}>
                   {Object.values(getFilteredColumnsForDisplay)
                     .filter(column => column && column.id) // Filter out null/undefined columns
                     .sort((a, b) => (a.position || 0) - (b.position || 0))
@@ -1979,6 +2004,7 @@ const KanbanPage: React.FC<KanbanPageProps> = ({
                             draggedColumn={draggedColumn}
                             dragPreview={dragPreview}
                             onAddTask={onAddTask}
+                            uiLanguage={i18n.resolvedLanguage || i18n.language}
                             columnWarnings={columnWarnings}
                             onDismissColumnWarning={onDismissColumnWarning}
                             onClearFiltersForHiddenTask={onClearFiltersForHiddenTask}
@@ -2076,7 +2102,7 @@ const KanbanPage: React.FC<KanbanPageProps> = ({
               </SortableContext>
             ) : (
               /* Regular user view */
-              <BoardDropArea selectedBoard={selectedBoard} style={gridStyle}>
+              <BoardDropArea selectedBoard={selectedBoard} style={visibleKanbanGridStyle}>
                 {Object.values(getFilteredColumnsForDisplay)
                   .filter(column => column && column.id) // Filter out null/undefined columns
                   .sort((a, b) => (a.position || 0) - (b.position || 0))
@@ -2094,6 +2120,7 @@ const KanbanPage: React.FC<KanbanPageProps> = ({
                       draggedColumn={draggedColumn}
                       dragPreview={dragPreview}
                       onAddTask={onAddTask}
+                      uiLanguage={i18n.resolvedLanguage || i18n.language}
                       columnWarnings={columnWarnings}
                       onDismissColumnWarning={onDismissColumnWarning}
                       onClearFiltersForHiddenTask={onClearFiltersForHiddenTask}


### PR DESCRIPTION
## Summary
- Size the Kanban grid to visible columns so hidden Archive/statuses do not leave empty scroll space.
- Show all statuses in trash so the badge matches recoverable cards.
- Use live i18n for default task titles after a language switch.

## Test plan
- [ ] Hide Archive (default): no blank column-width gap at the end of the board.
- [ ] Hide another status: still no extra empty slots.
- [ ] Open trash with Archive hidden: Archive appears and counts match the tab badge.
- [ ] Switch FR → EN, create a task: first title is New Task.


Made with [Cursor](https://cursor.com)