### PR TITLE
Let Escape clear card multi-select while a checkbox is focused

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -160,7 +160,7 @@ import { renumberColumns, isArchivedColumnFlag, reconcileVisibleColumnIds, sameC
 import { handleSameColumnReorder, handleCrossColumnMove, handleBulkMoveTasks, moveTaskToPosition, calculatePositionForIndex, renumberColumnAfterCopy, resolveKanbanDropIndex, snapshotColumnTaskOrder, restoreColumnTaskOrders, TaskDropPlacement } from './utils/taskReorderingUtils';
 import { getTaskColumnId, orderedCheckedTasksInColumn, snapshotTaskBoardLocation } from './utils/kanbanMultiSelect';
 import { useKanbanMultiSelect } from './hooks/useKanbanMultiSelect';
-import { hasEscapeConsumingOverlay, isEditableEscapeTarget } from './utils/escapeKeyUtils';
+import { blurEditableEscapeTarget, hasEscapeConsumingOverlay } from './utils/escapeKeyUtils';
 import { focusHeaderTaskSearch } from './utils/keyboardShortcutUtils';
 import { handleInviteUser as handleInviteUserUtil } from './utils/userInvitationUtils';
 import { notifyBoardTrashChanged, notifyLifecycleDataChanged } from './utils/boardTrashEvents';
@@ -326,7 +326,7 @@ function AppContent() {
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return;
       if (e.defaultPrevented) return;
-      if (isEditableEscapeTarget(e.target)) return;
+      if (blurEditableEscapeTarget(e)) return;
       if (hasEscapeConsumingOverlay()) return;
       e.preventDefault();
       handleSelectTask(null);

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -2141,7 +2141,10 @@ const TaskCard = React.memo(function TaskCard({
                 toggleChecked({ range: true });
               }
             }}
-            onKeyDown={(e) => e.stopPropagation()}
+            onKeyDown={(e) => {
+              // Let Escape bubble so multi-select can clear while a checkbox is focused.
+              if (e.key !== 'Escape') e.stopPropagation();
+            }}
             onPointerDown={(e) => e.stopPropagation()}
           >
             <ModernCheckbox

--- a/src/hooks/useKanbanMultiSelect.ts
+++ b/src/hooks/useKanbanMultiSelect.ts
@@ -22,7 +22,7 @@ import {
   writeKanbanMultiSelectSession,
   type ToggleTaskCheckedOptions,
 } from '../utils/kanbanMultiSelect';
-import { hasEscapeConsumingOverlay, isEditableEscapeTarget } from '../utils/escapeKeyUtils';
+import { blurEditableEscapeTarget, hasEscapeConsumingOverlay } from '../utils/escapeKeyUtils';
 
 type EditTaskOptions = { skipActivity?: boolean };
 
@@ -239,11 +239,17 @@ export function useKanbanMultiSelect({
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== 'Escape') return;
       if (e.defaultPrevented) return;
-      if (isEditableEscapeTarget(e.target)) return;
+      if (blurEditableEscapeTarget(e)) return;
       if (hasEscapeConsumingOverlay()) return;
       e.preventDefault();
       lastAnchorIdRef.current = null;
       setCheckedTaskIds(new Set());
+      if (
+        document.activeElement instanceof HTMLInputElement &&
+        document.activeElement.type === 'checkbox'
+      ) {
+        document.activeElement.blur();
+      }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);

--- a/src/utils/escapeKeyUtils.ts
+++ b/src/utils/escapeKeyUtils.ts
@@ -2,16 +2,46 @@
  * Shared Escape-key helpers for layered dismiss (menus → TaskDetails → multi-check).
  */
 
+/** Inputs that are not text fields — Escape should not be treated as “still typing”. */
+const NON_TEXT_INPUT_TYPES = new Set([
+  'checkbox',
+  'radio',
+  'button',
+  'submit',
+  'reset',
+  'hidden',
+  'range',
+  'file',
+  'image',
+]);
+
 export function isEditableEscapeTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
-  const tag = target.tagName;
-  if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return true;
+  if (target instanceof HTMLTextAreaElement || target instanceof HTMLSelectElement) {
+    return true;
+  }
+  if (target instanceof HTMLInputElement) {
+    return !NON_TEXT_INPUT_TYPES.has((target.type || 'text').toLowerCase());
+  }
   if (target.isContentEditable) return true;
   return !!(
     target.closest('[contenteditable="true"]') ||
     target.closest('.ProseMirror') ||
     target.closest('.tiptap')
   );
+}
+
+/**
+ * First Escape leaves a text field (blur). Callers then return so a second Escape
+ * can close details or clear multi-select.
+ */
+export function blurEditableEscapeTarget(event: KeyboardEvent): boolean {
+  if (event.defaultPrevented) return false;
+  if (!isEditableEscapeTarget(event.target)) return false;
+  if (!(event.target instanceof HTMLElement)) return false;
+  event.target.blur();
+  event.preventDefault();
+  return true;
 }
 
 /** True when a modal/menu/confirm should consume Escape before board-level handlers. */


### PR DESCRIPTION
## Summary
- Escape on a focused card checkbox now clears the multi-select instead of being treated as typing.
- Escape in a text field still leaves the field first; a second Escape clears checks or closes Task Details.

## Test plan
- [ ] Check one or more cards, leave focus on a checkbox, press Escape — selection clears
- [ ] Start inline title edit, press Escape — edit cancels; press Escape again — checks clear if any
- [ ] Open Task Details, press Escape — panel closes before checks clear


Made with [Cursor](https://cursor.com)