### PR TITLE
Lock unavailable workspaces and hide operator status from users

### DIFF
--- a/server/i18n/locales/en.json
+++ b/server/i18n/locales/en.json
@@ -445,11 +445,7 @@
     }
   },
   "instanceStatus": {
-    "suspended": "This instance has been temporarily suspended. Please contact support for assistance.",
-    "terminated": "This instance has been terminated. Please contact support for assistance.",
-    "failed": "This instance failed to deploy properly. Please contact support for assistance.",
-    "deploying": "This instance is currently being deployed. Please try again in a few minutes.",
-    "unavailable": "This instance is currently unavailable. Please contact support."
+    "unavailable": "This workspace is not available right now. Please contact support."
   },
   "system": {
     "achievementCheckCompleted": "Achievement check completed",

--- a/server/i18n/locales/fr.json
+++ b/server/i18n/locales/fr.json
@@ -445,11 +445,7 @@
     }
   },
   "instanceStatus": {
-    "suspended": "Cette instance a été temporairement suspendue. Veuillez contacter le support pour obtenir de l'aide.",
-    "terminated": "Cette instance a été terminée. Veuillez contacter le support pour obtenir de l'aide.",
-    "failed": "Cette instance n'a pas pu être déployée correctement. Veuillez contacter le support pour obtenir de l'aide.",
-    "deploying": "Cette instance est actuellement en cours de déploiement. Veuillez réessayer dans quelques minutes.",
-    "unavailable": "Cette instance n'est actuellement pas disponible. Veuillez contacter le support."
+    "unavailable": "Cet espace de travail n'est pas disponible pour le moment. Veuillez contacter le support."
   },
   "system": {
     "achievementCheckCompleted": "Vérification des réalisations terminée",

--- a/server/middleware/instanceStatus.js
+++ b/server/middleware/instanceStatus.js
@@ -2,104 +2,85 @@ import { wrapQuery } from '../utils/queryLogger.js';
 import { getTranslator } from '../utils/i18n.js';
 
 /**
- * Middleware to check instance status before processing requests
- * Blocks access if instance status is not 'active'
- * Valid statuses: 'deploying', 'active', 'suspended', 'terminated', 'failed'
+ * Blocks API/app access unless INSTANCE_STATUS is `active`.
+ * Admin portal (INSTANCE_TOKEN) and a few public probes stay reachable so
+ * operators can restore the workspace and the login page can explain why.
  */
+function isInstanceStatusExempt(req) {
+  const path = req.path || '';
+  if (
+    path === '/health' ||
+    path === '/ready' ||
+    path === '/api/health' ||
+    path === '/api/ready' ||
+    path === '/api/version'
+  ) {
+    return true;
+  }
+  if (path === '/api/auth/instance-status') return true;
+  if (path === '/api/auth/check-default-admin' && req.method === 'GET') return true;
+  if (path === '/api/settings' && req.method === 'GET') return true;
+  if (path === '/api/csp-report' && req.method === 'POST') return true;
+  if (path.startsWith('/api/admin-portal/')) return true;
+  return false;
+}
+
 export const checkInstanceStatus = (db) => {
   return async (req, res, next) => {
     try {
-      // Skip status check for essential endpoints that need to work even when suspended
-      const skipPaths = [
-        '/health',
-        '/ready',
-        '/api/health',
-        '/api/auth/instance-status',  // Allow status checking
-        '/api/user/status',           // Allow user status checking
-        '/api/settings',              // Allow loading site settings
-        '/api/auth/check-default-admin', // Allow admin check
-        '/api/auth/login',               // Allow login attempts
-
-        '/api/auth/google/url',          // Allow OAuth
-        '/api/auth/google/callback',     // Allow OAuth callback
-      ];
-      
-      const shouldSkip = skipPaths.some(path => 
-        req.path === path || req.path.startsWith('/api/admin-portal/')
-      );
-      
-      if (shouldSkip) {
+      if (isInstanceStatusExempt(req)) {
         return next();
       }
 
-      // Get instance status from settings
-      const statusSetting = await wrapQuery(db.prepare('SELECT value FROM settings WHERE key = ?'), 'SELECT').get('INSTANCE_STATUS');
+      const statusSetting = await wrapQuery(
+        db.prepare('SELECT value FROM settings WHERE key = ?'),
+        'SELECT'
+      ).get('INSTANCE_STATUS');
       const status = statusSetting ? statusSetting.value : 'active';
 
-      // Allow access only if status is active
       if (status !== 'active') {
-        const t = getTranslator(db);
+        const t = await getTranslator(db);
         const statusMessage = getStatusMessage(status, t);
-        
-        // Return JSON error for API requests
+
         if (req.path.startsWith('/api/')) {
           return res.status(503).json({
             error: 'Instance unavailable',
             status: status,
             message: statusMessage,
-            code: 'INSTANCE_SUSPENDED'
+            code: 'INSTANCE_UNAVAILABLE',
           });
         }
-        
-        // Return HTML page for web requests
-        return res.status(503).render('maintenance', {
-          status: status,
-          message: statusMessage,
-          title: 'Instance Unavailable'
-        });
+
+        // Let the SPA load so the login page can explain the lockout.
+        return next();
       }
 
       next();
     } catch (error) {
       console.error('Error checking instance status:', error);
-      // Fail open - allow access if status check fails
       next();
     }
   };
 };
 
-/**
- * Get user-friendly message for instance status
- * @param {string} status - Instance status
- * @param {Function} t - Translation function (optional, defaults to English)
- */
-const getStatusMessage = (status, t = (key) => key) => {
-  switch (status) {
-    case 'suspended':
-      return t('instanceStatus.suspended');
-    case 'terminated':
-      return t('instanceStatus.terminated');
-    case 'failed':
-      return t('instanceStatus.failed');
-    case 'deploying':
-      return t('instanceStatus.deploying');
-    default:
-      return t('instanceStatus.unavailable');
-  }
-};
+const getStatusMessage = (_status, t = (key) => key) => t('instanceStatus.unavailable');
 
 /**
- * Initialize instance status setting if it doesn't exist
- * Only sets to 'active' if the setting doesn't exist at all
- * Preserves existing status values (suspended/inactive) on restart
+ * Initialize instance status setting if it doesn't exist.
+ * Preserves existing status values on restart.
  */
 export const initializeInstanceStatus = async (db) => {
   try {
-    const existingSetting = await wrapQuery(db.prepare('SELECT value FROM settings WHERE key = ?'), 'SELECT').get('INSTANCE_STATUS');
-    
+    const existingSetting = await wrapQuery(
+      db.prepare('SELECT value FROM settings WHERE key = ?'),
+      'SELECT'
+    ).get('INSTANCE_STATUS');
+
     if (!existingSetting) {
-      await wrapQuery(db.prepare('INSERT INTO settings (key, value) VALUES (?, ?)'), 'INSERT')
-        .run('INSTANCE_STATUS', 'active');
+      await wrapQuery(
+        db.prepare('INSERT INTO settings (key, value) VALUES (?, ?)'),
+        'INSERT'
+      ).run('INSTANCE_STATUS', 'active');
       console.log('✅ Initialized INSTANCE_STATUS setting to active');
     } else {
       console.log(`ℹ️ Instance status preserved: ${existingSetting.value}`);

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -8,7 +8,6 @@ import { licenseLimitBody } from '../middleware/licenseCheck.js';
 import notificationService from '../services/notificationService.js';
 import { loginLimiter, activationLimiter, invitationVerifyLimiter, registrationLimiter, oauthUrlLimiter, oauthCallbackLimiter } from '../middleware/rateLimiters.js';
 import { createDefaultAvatar, getRandomColor } from '../utils/avatarGenerator.js';
-import { getTranslator } from '../utils/i18n.js';
 import { getTenantId, getRequestDatabase, getTenantDatabase, isMultiTenant } from '../middleware/tenantRouting.js';
 import {
   getAuthHubCallbackUrl,
@@ -1272,32 +1271,13 @@ router.get('/debug/oauth', authenticateToken, requireRole(['admin']), async (req
 router.get('/instance-status', async (req, res) => {
   try {
     const db = getRequestDatabase(req);
-    const t = await getTranslator(db);
     // MIGRATED: Get setting using sqlManager
     const statusSetting = await authQueries.getSetting(db, 'INSTANCE_STATUS');
     const status = statusSetting?.value || 'active';
     
-    const getStatusMessage = (status) => {
-      switch (status) {
-        case 'active':
-          return 'This instance is running normally.'; // Active status doesn't need translation as it's not shown
-        case 'suspended':
-          return t('instanceStatus.suspended');
-        case 'terminated':
-          return t('instanceStatus.terminated');
-        case 'failed':
-          return t('instanceStatus.failed');
-        case 'deploying':
-          return t('instanceStatus.deploying');
-        default:
-          return t('instanceStatus.unavailable');
-      }
-    };
-    
     res.json({
       status: status,
       isActive: status === 'active',
-      message: getStatusMessage(status),
       timestamp: new Date().toISOString()
     });
   } catch (error) {

--- a/server/services/websocketService.js
+++ b/server/services/websocketService.js
@@ -177,6 +177,16 @@ class WebSocketService {
             console.log(`❌ WebSocket auth failed: User ${userInDb.email} (${userInDb.id}) is ${reason}`);
             return next(new Error('Invalid token'));
           }
+
+          const statusSetting = await wrapQuery(
+            db.prepare('SELECT value FROM settings WHERE key = ?'),
+            'SELECT'
+          ).get('INSTANCE_STATUS');
+          const instanceStatus = statusSetting?.value || 'active';
+          if (instanceStatus !== 'active') {
+            console.log(`❌ WebSocket auth failed: workspace status is ${instanceStatus}`);
+            return next(new Error('Instance unavailable'));
+          }
         } catch (dbError) {
           console.error('❌ Error checking user in database for WebSocket:', dbError);
           return next(new Error('Authentication failed'));
@@ -877,6 +887,9 @@ class WebSocketService {
       } else {
         this.io?.emit('instance-status-updated', data);
       }
+      if (data?.status && data.status !== 'active') {
+        setTimeout(() => this.disconnectTenantSockets(tenantId), 50);
+      }
     });
 
     // Version update events - broadcast to tenant-specific clients
@@ -898,6 +911,17 @@ class WebSocketService {
     const room = userSocketRoom(tenantId, userId);
     console.log(`🔌 Disconnecting sockets for user ${userId}${tenantId ? ` (tenant: ${tenantId})` : ''}`);
     this.io.in(room).disconnectSockets(true);
+  }
+
+  disconnectTenantSockets(tenantId = null) {
+    if (!this.io) return;
+    if (tenantId) {
+      console.log(`🔌 Disconnecting sockets for tenant ${tenantId} (workspace not active)`);
+      this.io.in(`tenant-${tenantId}`).disconnectSockets(true);
+      return;
+    }
+    console.log('🔌 Disconnecting all sockets (workspace not active)');
+    this.io.disconnectSockets(true);
   }
 
   getConnectedClients() {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1579,9 +1579,10 @@ function AppContent() {
         if (!response.data.isActive) {
           versionStatus.setInstanceStatus({
             status: response.data.status,
-            message: response.data.message,
+            message: '',
             isDismissed: false
           });
+          handleLogout();
         }
       } catch (error) {
         // If we can't check status, assume it's active
@@ -1592,7 +1593,7 @@ function AppContent() {
     if (isAuthenticated) {
       checkInitialInstanceStatus();
     }
-  }, [isAuthenticated]);
+  }, [isAuthenticated, handleLogout]);
   // Track if we've had our first successful connection and if we were offline
   const hasConnectedOnceRef = useRef(false);
   const wasOfflineRef = useRef(false);

--- a/src/api.ts
+++ b/src/api.ts
@@ -288,8 +288,12 @@ api.interceptors.response.use(
       const currentToken = localStorage.getItem('authToken');
       console.warn(`⚠️ Request rejected - no token available for ${error.config?.url || 'unknown'}. Token in storage: ${!!currentToken}`);
     } else if (error.response?.status === 503) {
-      // Service unavailable - don't clear token, just log
-      console.warn(`⚠️ Service unavailable (503) for ${error.config?.url} - keeping token`);
+      const code = error.response?.data?.code;
+      if (code === 'INSTANCE_UNAVAILABLE' || code === 'INSTANCE_SUSPENDED') {
+        handleAuthError('Workspace unavailable');
+      } else {
+        console.warn(`⚠️ Service unavailable (503) for ${error.config?.url} - keeping token`);
+      }
     }
     return Promise.reject(error);
   }

--- a/src/components/Login.tsx
+++ b/src/components/Login.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { login } from '../api';
 import api from '../api';
-import InstanceStatusBanner from './layout/InstanceStatusBanner';
+import { instanceStatusIsBlocking } from './layout/InstanceStatusBanner';
 import { Github, MousePointerClick, RefreshCw, Sparkles } from 'lucide-react';
 import { SsoLoginButton } from './auth/SsoLoginButton';
 import { useSettings } from '../contexts/SettingsContext';
@@ -36,7 +36,7 @@ export default function Login({ onLogin, siteSettings, hasDefaultAdmin = true, i
     refreshSettings,
   } = useSettings();
   const [theme, setTheme] = useState<'light' | 'dark'>(readDocumentTheme);
-  const [instanceStatus, setInstanceStatus] = useState<{ status: string; message: string } | null>(null);
+  const [instanceStatus, setInstanceStatus] = useState<string | null>(null);
   const brandSettings = contextSiteSettings || siteSettings;
   const logoSrc = resolvePublicBrandLogoSrc(brandSettings, theme);
   const siteName = String(brandSettings?.SITE_NAME ?? '').trim();
@@ -71,10 +71,7 @@ export default function Login({ onLogin, siteSettings, hasDefaultAdmin = true, i
       .then((response) => {
         if (cancelled) return;
         if (response.data && response.data.isActive === false) {
-          setInstanceStatus({
-            status: response.data.status,
-            message: response.data.message || '',
-          });
+          setInstanceStatus(response.data.status || 'unavailable');
         }
       })
       .catch(() => {
@@ -353,6 +350,7 @@ export default function Login({ onLogin, siteSettings, hasDefaultAdmin = true, i
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (instanceStatusIsBlocking(instanceStatus || '')) return;
     clearError();
     setIsLoading(true);
 
@@ -404,6 +402,7 @@ export default function Login({ onLogin, siteSettings, hasDefaultAdmin = true, i
   };
 
   const handleSsoSignIn = async (provider: 'google' | 'github' | 'm365') => {
+    if (instanceStatusIsBlocking(instanceStatus || '')) return;
     if (isDemoMode || !ssoProviders[provider]) {
       setI18nError('login.oauthNotConfigured');
       return;
@@ -438,6 +437,14 @@ export default function Login({ onLogin, siteSettings, hasDefaultAdmin = true, i
     }
   };
 
+  const workspaceBlocked = instanceStatusIsBlocking(instanceStatus || '');
+  const workspaceTitle = workspaceBlocked
+    ? tCommon('instanceStatus.titles.unavailable')
+    : t('login.signInToAccount');
+  const workspaceBody = workspaceBlocked
+    ? tCommon('instanceStatus.messages.unavailable')
+    : t('login.welcome');
+
   const hideGithubLink =
     (contextSiteSettings?.HIDE_GITHUB_LINK ?? siteSettings?.HIDE_GITHUB_LINK) === 'true';
 
@@ -449,13 +456,6 @@ export default function Login({ onLogin, siteSettings, hasDefaultAdmin = true, i
   // dismisses. Top-align with padding keeps the focused input stable.
   return (
     <div className="min-h-[100dvh] bg-gray-100 dark:bg-gray-900 flex flex-col">
-      {instanceStatus && (
-        <InstanceStatusBanner
-          status={instanceStatus.status}
-          message={instanceStatus.message}
-          layout="page"
-        />
-      )}
     <div className="flex-1 flex items-start justify-center pt-16 pb-12 px-4 sm:px-6 lg:px-8 relative">
       {/* Utilities — top right (matches app header: GitHub + language) */}
       <div className="absolute top-4 right-4 flex items-center gap-2 z-10">
@@ -497,10 +497,10 @@ export default function Login({ onLogin, siteSettings, hasDefaultAdmin = true, i
             />
           ) : null}
           <h2 className={`${logoSrc ? 'mt-6' : ''} text-center text-3xl font-extrabold text-gray-900 dark:text-gray-100`}>
-            {t('login.signInToAccount')}
+            {workspaceTitle}
           </h2>
           <p className="mt-2 text-center text-sm text-gray-600 dark:text-gray-400">
-            {t('login.welcome')}
+            {workspaceBody}
           </p>
         </div>
         
@@ -562,7 +562,13 @@ export default function Login({ onLogin, siteSettings, hasDefaultAdmin = true, i
           </div>
         )}
         
-        {!checkingBackend && backendAvailable && (
+        {!checkingBackend && backendAvailable && workspaceBlocked && (
+          <div className="mt-4 rounded-xl border border-gray-200 bg-white px-6 py-5 text-center shadow-sm dark:border-gray-700 dark:bg-gray-800">
+            <p className="text-sm text-gray-600 dark:text-gray-300">{t('login.signInDisabled')}</p>
+          </div>
+        )}
+
+        {!checkingBackend && backendAvailable && !workspaceBlocked && (
         <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
           {!isDemoMode && (
             <div className="rounded-md shadow-sm -space-y-px bg-white dark:bg-gray-800 p-6 rounded-lg">

--- a/src/components/layout/InstanceStatusBanner.tsx
+++ b/src/components/layout/InstanceStatusBanner.tsx
@@ -16,23 +16,12 @@ export function instanceStatusIsBlocking(status: string): boolean {
   return Boolean(status) && status !== 'active';
 }
 
-function statusColorClass(status: string): string {
-  switch (status) {
-    case 'suspended':
-      return 'bg-amber-100 border-amber-500 text-amber-900 dark:bg-amber-950 dark:border-amber-600 dark:text-amber-100';
-    case 'terminated':
-    case 'failed':
-      return 'bg-red-100 border-red-500 text-red-800 dark:bg-red-950 dark:border-red-600 dark:text-red-100';
-    case 'deploying':
-      return 'bg-blue-100 border-blue-500 text-blue-800 dark:bg-blue-950 dark:border-blue-600 dark:text-blue-100';
-    default:
-      return 'bg-gray-100 border-gray-500 text-gray-800 dark:bg-gray-800 dark:border-gray-500 dark:text-gray-100';
-  }
+function statusColorClass(): string {
+  return 'bg-slate-50/95 text-slate-900 dark:bg-slate-900/70 dark:text-slate-100 border-slate-200 dark:border-slate-700';
 }
 
 export default function InstanceStatusBanner({
   status,
-  message,
   isDismissed = false,
   onDismiss,
   layout = 'header',
@@ -43,14 +32,8 @@ export default function InstanceStatusBanner({
     return null;
   }
 
-  const title = t(`instanceStatus.titles.${status}`, {
-    defaultValue: t('instanceStatus.titles.unavailable'),
-  });
-  const body =
-    message ||
-    t(`instanceStatus.messages.${status}`, {
-      defaultValue: t('instanceStatus.messages.unavailable'),
-    });
+  const title = t('instanceStatus.titles.unavailable');
+  const body = t('instanceStatus.messages.unavailable');
   const canDismiss = DISMISSABLE.has(status) && typeof onDismiss === 'function';
   const positionClass =
     layout === 'page'
@@ -60,13 +43,13 @@ export default function InstanceStatusBanner({
   return (
     <div
       role="status"
-      className={`${positionClass} border-b-2 border-l-4 px-4 py-3 shadow-sm ${statusColorClass(status)}`}
+      className={`${positionClass} border-b px-4 py-2.5 ${statusColorClass()}`}
       data-instance-status-banner={status}
     >
-      <div className="flex items-start justify-between gap-3 max-w-7xl mx-auto">
+      <div className="flex items-start justify-between gap-3 max-w-3xl mx-auto">
         <div className="min-w-0">
-          <p className="text-sm font-semibold">{title}</p>
-          <p className="text-sm mt-0.5">{body}</p>
+          <p className="text-sm font-medium tracking-tight">{title}</p>
+          <p className="text-sm mt-0.5 opacity-80">{body}</p>
         </div>
         {canDismiss && (
           <button

--- a/src/hooks/useSettingsWebSocket.ts
+++ b/src/hooks/useSettingsWebSocket.ts
@@ -1,7 +1,8 @@
 import { useCallback } from 'react';
-import { useTranslation } from 'react-i18next';
 import { getAllTags, getAllPriorities, getAllSprints, getSettings } from '../api';
 import { versionDetection } from '../utils/versionDetection';
+import { handleAuthError } from '../utils/authErrorHandler';
+import { instanceStatusIsBlocking } from '../components/layout/InstanceStatusBanner';
 
 interface UseSettingsWebSocketProps {
   // State setters
@@ -26,8 +27,6 @@ export const useSettingsWebSocket = ({
   refreshMembers,
   versionStatus,
 }: UseSettingsWebSocketProps) => {
-  const { t } = useTranslation('common');
-  
   const handleTagCreated = useCallback(async (data: any) => {
     console.log('📨 Tag created via WebSocket:', data);
     // Optimistic catalog update so cards can render the chip before getAllTags returns
@@ -176,12 +175,13 @@ export const useSettingsWebSocket = ({
     const status = data?.status || 'unavailable';
     versionStatus.setInstanceStatus({
       status,
-      message: t(`instanceStatus.messages.${status}`, {
-        defaultValue: t('instanceStatus.messages.unavailable'),
-      }),
+      message: '',
       isDismissed: false
     });
-  }, [t, versionStatus.setInstanceStatus]);
+    if (instanceStatusIsBlocking(status)) {
+      handleAuthError('Workspace unavailable');
+    }
+  }, [versionStatus.setInstanceStatus]);
 
   const handleVersionUpdated = useCallback((data: any) => {
     console.log('📦 Version updated via WebSocket:', data);

--- a/src/i18n/locales/en/auth.json
+++ b/src/i18n/locales/en/auth.json
@@ -23,6 +23,7 @@
     "systemUnavailableContact": "If the issue persists, please contact your system administrator.",
     "retryConnection": "Retry Connection",
     "clearSession": "Clear Session & Reload",
+    "signInDisabled": "Sign-in is disabled for this workspace.",
     "accountDeactivated": "Your account has been deactivated. Please contact an administrator.",
     "accessDenied": "Access denied. You must be invited to use this system.",
     "oauthFailed": "Authentication failed. Please try again.",

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1482,18 +1482,10 @@
   },
   "instanceStatus": {
     "titles": {
-      "suspended": "Workspace suspended",
-      "terminated": "Workspace terminated",
-      "failed": "Workspace unavailable",
-      "deploying": "Workspace deploying",
       "unavailable": "Workspace unavailable"
     },
     "messages": {
-      "suspended": "This workspace has been temporarily suspended. Please contact support.",
-      "terminated": "This workspace has been terminated. Please contact support.",
-      "failed": "This workspace is not available. Please contact support.",
-      "deploying": "This workspace is still being deployed. Please try again in a few minutes.",
-      "unavailable": "This workspace is currently unavailable. Please contact support."
+      "unavailable": "This workspace is not available right now. Contact support if you need access."
     }
   },
   "networkStatusIndicator": {

--- a/src/i18n/locales/fr/auth.json
+++ b/src/i18n/locales/fr/auth.json
@@ -23,6 +23,7 @@
     "systemUnavailableContact": "Si le problème persiste, veuillez contacter votre administrateur système.",
     "retryConnection": "Réessayer la connexion",
     "clearSession": "Effacer la session et recharger",
+    "signInDisabled": "La connexion est désactivée pour cet espace de travail.",
     "accountDeactivated": "Votre compte a été désactivé. Veuillez contacter un administrateur.",
     "accessDenied": "Accès refusé. Vous devez être invité pour utiliser ce système.",
     "oauthFailed": "Échec de l'authentification. Veuillez réessayer.",

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -1483,18 +1483,10 @@
   },
   "instanceStatus": {
     "titles": {
-      "suspended": "Espace suspendu",
-      "terminated": "Espace résilié",
-      "failed": "Espace indisponible",
-      "deploying": "Espace en cours de déploiement",
-      "unavailable": "Espace indisponible"
+      "unavailable": "Espace de travail indisponible"
     },
     "messages": {
-      "suspended": "Cet espace a été temporairement suspendu. Veuillez contacter le support.",
-      "terminated": "Cet espace a été résilié. Veuillez contacter le support.",
-      "failed": "Cet espace n'est pas disponible. Veuillez contacter le support.",
-      "deploying": "Cet espace est encore en cours de déploiement. Réessayez dans quelques minutes.",
-      "unavailable": "Cet espace est actuellement indisponible. Veuillez contacter le support."
+      "unavailable": "Cet espace de travail n’est pas disponible pour le moment. Contactez le support si vous avez besoin d’y accéder."
     }
   },
   "networkStatusIndicator": {

--- a/src/services/websocketClient.ts
+++ b/src/services/websocketClient.ts
@@ -218,11 +218,17 @@ class WebSocketClient {
       
       // Handle authentication errors - redirect to login for expired/invalid tokens
       // Check for various auth error messages
+      const isUnavailable = error.message === 'Instance unavailable'
+        || error.message?.toLowerCase().includes('unavailable');
       const isAuthError = error.message === 'Invalid token' || 
                          error.message === 'Authentication required' ||
                          error.message?.toLowerCase().includes('token') ||
                          error.message?.toLowerCase().includes('auth');
       
+      if (isUnavailable) {
+        handleAuthError('Workspace unavailable');
+        return;
+      }
       if (isAuthError) {
           if (feDebug('FE_DEBUG_AUTH')) console.log('🔑 WebSocket auth error - token expired or invalid');
         handleAuthError('WebSocket authentication failed');

--- a/src/utils/appHelpers.ts
+++ b/src/utils/appHelpers.ts
@@ -21,14 +21,17 @@ export const checkInstanceStatusOnError = async (
     isDismissed: boolean;
   }) => void
 ): Promise<boolean> => {
-  if (error?.response?.status === 503 && error?.response?.data?.code === 'INSTANCE_SUSPENDED') {
-    // Update instance status state
+  const instanceCode = error?.response?.data?.code;
+  if (
+    error?.response?.status === 503 &&
+    (instanceCode === 'INSTANCE_UNAVAILABLE' || instanceCode === 'INSTANCE_SUSPENDED')
+  ) {
     setInstanceStatus({
       status: error.response.data.status,
-      message: error.response.data.message,
+      message: '',
       isDismissed: false
     });
-    return true; // Indicates this was an instance status error
+    return true;
   }
   
   // For any other API error, check if instance is still active
@@ -38,15 +41,14 @@ export const checkInstanceStatusOnError = async (
       if (!response.data.isActive) {
         setInstanceStatus({
           status: response.data.status,
-          message: response.data.message,
+          message: '',
           isDismissed: false
         });
       }
     } catch (statusError) {
-      // If we can't check status, assume it's suspended
       setInstanceStatus({
-        status: 'suspended',
-        message: 'Unable to determine instance status',
+        status: 'unavailable',
+        message: '',
         isDismissed: false
       });
     }


### PR DESCRIPTION
## Summary
- Block login, SSO, and live sessions when tenant `INSTANCE_STATUS` is not `active`, and drop WebSockets instead of leaving a 503 board.
- Show generic “Workspace unavailable” copy in the user’s language; do not surface suspended/cancelled/terminated in the product UI.

## Test plan
- [ ] Set a tenant to suspended and confirm login form is replaced by the unavailable screen (EN/FR toggle).
- [ ] Confirm `POST /api/auth/login` returns 503.
- [ ] Confirm an already-signed-in tab is logged out and cannot keep working.
- [ ] Restore `active` via admin portal and confirm sign-in works again.


Made with [Cursor](https://cursor.com)