### PR TITLE
Safer K8s rollouts: N-1 assets and fleet-stable reload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Deploy-state unit tests
+        run: npm run test:deploy-state
+
       - name: Help UI index (stale check)
         run: npm run help:ui-index:check
 

--- a/.gitignore
+++ b/.gitignore
@@ -145,5 +145,9 @@ QA_Test_Plan.csv
 # Generated version file (created at Docker build time)
 server/version.json
 
+# Previous-release Vite assets extracted before docker build (keep .gitkeep)
+docker-prev-assets/*
+!docker-prev-assets/.gitkeep
+
 # Workspace
 *.code-workspace

--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -22,6 +22,17 @@ RUN npm ci --include=dev || npm install --include=dev
 # Copy source code
 COPY . .
 
+# Same git/build args as the production stage so the baked JS version matches
+# server/version.json (page baseline vs X-App-Version).
+ARG GIT_COMMIT=unknown
+ARG GIT_BRANCH=unknown
+ARG BUILD_TIME
+ARG BUILD_NUMBER
+ENV GIT_COMMIT=${GIT_COMMIT}
+ENV GIT_BRANCH=${GIT_BRANCH}
+ENV BUILD_TIME=${BUILD_TIME}
+ENV BUILD_NUMBER=${BUILD_NUMBER}
+
 # Build the frontend (MULTI_TENANT env var will be available to vite.config.ts)
 RUN npm run build
 
@@ -59,6 +70,13 @@ RUN ls -la node_modules/.bin/vite && node_modules/.bin/vite --version
 
 # Copy built frontend from builder stage
 COPY --from=frontend-builder /app/dist ./dist
+
+# Previous release hashed JS/CSS (optional). CI runs scripts/prepare-prev-assets.sh
+# so new pods can serve last generation's /assets during a rolling update.
+COPY docker-prev-assets/ /tmp/docker-prev-assets/
+RUN mkdir -p /app/dist/assets && \
+    find /tmp/docker-prev-assets -type f ! -name '.gitkeep' -exec cp -n {} /app/dist/assets/ \; && \
+    rm -rf /tmp/docker-prev-assets
 
 # Version tracking build args. Declared here (not at the top of the stage) so a new
 # commit hash does not invalidate the npm install layers above. `.git` is dockerignored,

--- a/k8s/app-deployment-pg.yaml
+++ b/k8s/app-deployment-pg.yaml
@@ -113,6 +113,10 @@ spec:
         - configMapRef:
             name: easy-kanban-config-pg
         env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         - name: POSTGRES_PASSWORD
           valueFrom:
             secretKeyRef:

--- a/k8s/build-and-push-to-registry-app.sh
+++ b/k8s/build-and-push-to-registry-app.sh
@@ -75,6 +75,11 @@ echo -e "${CYAN}   Build Time: ${BUILD_TIME}${NC}"
 echo -e "${CYAN}   Multi-Tenant: ${MULTI_TENANT}${NC}"
 echo ""
 
+# Keep last image's hashed /assets so new pods can serve the previous HTML shell
+echo -e "${YELLOW}📦 Preparing previous hashed assets (N-1)...${NC}"
+"${PROJECT_ROOT}/scripts/prepare-prev-assets.sh" easy-kanban:latest || true
+echo ""
+
 # Build the image
 echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo -e "${BLUE}🔨 Building Docker image...${NC}"

--- a/k8s/old/build-and-import-new-image.sh
+++ b/k8s/old/build-and-import-new-image.sh
@@ -59,6 +59,8 @@ echo -e "${BLUE}🔨 Building Docker image...${NC}"
 echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo ""
 
+"${PROJECT_ROOT}/scripts/prepare-prev-assets.sh" easy-kanban:latest || true
+
 docker build -f Dockerfile.prod -t easy-kanban:latest \
   --build-arg GIT_COMMIT="${GIT_COMMIT}" \
   --build-arg GIT_BRANCH="${GIT_BRANCH}" \

--- a/k8s/setup-system.sh
+++ b/k8s/setup-system.sh
@@ -177,6 +177,7 @@ fi
 if [ "$SKIP_IMAGE" = false ]; then
     echo "🐳 Building Docker image..."
     cd "${SCRIPT_DIR}/.."
+    "${SCRIPT_DIR}/../scripts/prepare-prev-assets.sh" easy-kanban:latest || true
     docker build -f Dockerfile.prod -t easy-kanban:latest .
     echo "✅ Docker image built"
     

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "audit:schema": "npm run audit:sql && npm run audit:js",
     "help:ui-index": "node scripts/harvest-help-ui-index.js",
     "help:ui-index:check": "node scripts/harvest-help-ui-index.js --check",
+    "test:deploy-state": "node --test server/services/deployStateService.test.js",
     "preview": "vite preview",
     "security:check": "node scripts/security-check.js",
     "security:offline": "node scripts/offline-security.js",

--- a/scripts/prepare-prev-assets.sh
+++ b/scripts/prepare-prev-assets.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Copy hashed /assets from a previous app image into docker-prev-assets/
+# so Dockerfile.prod can merge them (N-1 files, no overwrite of new hashes).
+#
+# Usage: scripts/prepare-prev-assets.sh [image]
+# Default image: easy-kanban:latest (local tag used by k8s/build-and-push-to-registry-app.sh)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEST="${PROJECT_ROOT}/docker-prev-assets"
+IMAGE="${1:-easy-kanban:latest}"
+
+mkdir -p "$DEST"
+# Keep the directory valid for Docker COPY even when empty
+find "$DEST" -type f ! -name '.gitkeep' -delete 2>/dev/null || true
+
+if ! docker image inspect "$IMAGE" >/dev/null 2>&1; then
+  echo "ℹ️  No previous image ${IMAGE} — new pods will only have this build's assets"
+  exit 0
+fi
+
+cid="$(docker create "$IMAGE")"
+cleanup() { docker rm -f "$cid" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+if docker cp "${cid}:/app/dist/assets/." "$DEST/" 2>/dev/null; then
+  count="$(find "$DEST" -type f ! -name '.gitkeep' | wc -l | tr -d ' ')"
+  echo "✅ Copied ${count} previous hashed asset(s) from ${IMAGE}"
+else
+  echo "ℹ️  ${IMAGE} has no /app/dist/assets — skipping N-1 merge"
+fi

--- a/server/config/database.js
+++ b/server/config/database.js
@@ -1484,6 +1484,8 @@ const initializeDefaultData = async (db, tenantId = null) => {
 
   // Update APP_VERSION on every startup (from version.json or environment variable)
   // Priority: 1) version.json (build-time), 2) ENV variable (runtime)
+  // Admin → Licensing display only. Browser reload / banners use Redis fleet
+  // deploy state + version.json (see deployStateService.js), not this row.
   let appVersion = null;
   let versionChanged = false;
   

--- a/server/index.js
+++ b/server/index.js
@@ -18,6 +18,10 @@ import { checkInstanceStatus, initializeInstanceStatus } from './middleware/inst
 import { loginLimiter, passwordResetLimiter, registrationLimiter, activationLimiter } from './middleware/rateLimiters.js';
 import { getAppVersion } from './utils/appVersion.js';
 import { getTenantDomain } from './utils/tenantDomain.js';
+import {
+  getCachedFleetState,
+  startDeployStateHeartbeats,
+} from './services/deployStateService.js';
 
 // Import generateRandomPassword function
 const generateRandomPassword = (length = 12) => {
@@ -81,7 +85,6 @@ import { cspIngestRouter, cspAdminRouter } from './routes/cspReport.js';
 // Import real-time services
 import redisService from './services/redisService.js';
 import postgresNotificationService from './services/postgresNotificationService.js';
-import notificationService from './services/notificationService.js';
 import websocketService from './services/websocketService.js';
 
 // Import storage utilities
@@ -235,6 +238,22 @@ app.use(async (req, res, next) => {
   }
   
   res.setHeader('X-App-Version', version);
+  const fleet = getCachedFleetState();
+  if (fleet.deployState) {
+    res.setHeader('X-Deploy-State', fleet.deployState);
+  }
+  if (fleet.podCount != null) {
+    res.setHeader('X-Deploy-Pod-Count', String(fleet.podCount));
+  }
+  if (fleet.fleetVersion) {
+    res.setHeader('X-Deploy-Fleet-Version', fleet.fleetVersion);
+  }
+  const expose = res.getHeader('Access-Control-Expose-Headers');
+  const extra = 'X-App-Version, X-Deploy-State, X-Deploy-Pod-Count, X-Deploy-Fleet-Version';
+  res.setHeader(
+    'Access-Control-Expose-Headers',
+    expose ? `${expose}, ${extra}` : extra
+  );
   next();
 });
 
@@ -503,14 +522,24 @@ app.get('/api/version', async (req, res) => {
     // Try to read full version info from version.json
     const versionPath = new URL('./version.json', import.meta.url);
     const versionData = JSON.parse(fs.readFileSync(versionPath, 'utf8'));
-    res.json(versionData);
+    const fleet = getCachedFleetState();
+    res.json({
+      ...versionData,
+      deployState: fleet.deployState,
+      fleetVersion: fleet.fleetVersion,
+      podCount: fleet.podCount,
+    });
   } catch (error) {
     // Fallback to basic version info
     const version = await getAppVersion(defaultDb);
+    const fleet = getCachedFleetState();
     res.json({
       version,
       source: 'environment',
-      environment: process.env.NODE_ENV || 'production'
+      environment: process.env.NODE_ENV || 'production',
+      deployState: fleet.deployState,
+      fleetVersion: fleet.fleetVersion,
+      podCount: fleet.podCount,
     });
   }
 });
@@ -608,27 +637,11 @@ async function initializeServices() {
     startAdminPortalInspectNotify();
     
     console.log('✅ Real-time services initialized');
-    
-    // Broadcast app version to all connected clients
-    // If version changed, broadcast immediately; otherwise wait briefly for WebSocket connections
-    const broadcastVersion = async () => {
-      // In single-tenant mode, broadcast version from default database
-      if (defaultDb) {
-        const appVersion = await getAppVersion(defaultDb);
-        notificationService.publish('version-updated', { version: appVersion }, null);
-        console.log(`📦 Broadcasting app version: ${appVersion}${versionInfo.versionChanged ? ' (version changed - notifying users)' : ''}`);
-      }
-      // In multi-tenant mode, version updates are broadcast per-tenant when databases are initialized
-      // (handled in tenantRouting middleware)
-    };
-    
-    if (versionInfo.versionChanged && versionInfo.appVersion) {
-      // Version changed - broadcast immediately to notify users
-      await broadcastVersion();
-    } else {
-      // Normal startup - wait briefly for WebSocket connections
-      setTimeout(broadcastVersion, 1000);
-    }
+
+    // Fleet version / rolling-update state (Redis heartbeats). DB APP_VERSION
+    // is still upserted on tenant init for Admin → Licensing; clients do not
+    // use that row for reload / banner.
+    startDeployStateHeartbeats();
   } catch (error) {
     console.error('❌ Failed to initialize real-time services:', error);
     // Continue without real-time features

--- a/server/services/deployStateService.js
+++ b/server/services/deployStateService.js
@@ -1,0 +1,235 @@
+/**
+ * Fleet deploy state (multi-pod rolling updates).
+ *
+ * Each replica heartbeats its baked version.json into Redis. Any pod can then
+ * derive deploying (mixed versions) vs stable (all live heartbeats agree).
+ * Redis down / single process: treat as unknown/stable locally — never invent
+ * a cluster-wide "done" from one pod's opinion of the others.
+ */
+
+import fs from 'fs';
+import os from 'os';
+import redisService from './redisService.js';
+import notificationService from './notificationService.js';
+
+const HASH_KEY = 'agila:deploy:pods';
+const HEARTBEAT_MS = 10_000;
+const STALE_MS = 30_000;
+
+/** @typedef {'deploying' | 'stable' | 'unknown'} DeployState */
+
+let heartbeatTimer = null;
+let localVersion = null;
+let lastPublishedKey = null;
+let cachedFleet = {
+  deployState: 'unknown',
+  fleetVersion: null,
+  podCount: 0,
+  versions: [],
+};
+
+export function getPodId() {
+  return process.env.POD_NAME || process.env.HOSTNAME || os.hostname() || `pid-${process.pid}`;
+}
+
+export function readLocalAppVersion() {
+  try {
+    const versionPath = new URL('../version.json', import.meta.url);
+    const versionData = JSON.parse(fs.readFileSync(versionPath, 'utf8'));
+    return versionData.version || process.env.APP_VERSION || '0';
+  } catch {
+    return process.env.APP_VERSION || '0';
+  }
+}
+
+/**
+ * Pure derive — unit-tested. `entries` are live (non-stale) heartbeats.
+ * @param {{ version: string }[]} entries
+ * @param {string} thisPodVersion
+ */
+export function deriveFleetState(entries, thisPodVersion) {
+  const versions = [
+    ...new Set(entries.map((e) => e.version).filter((v) => typeof v === 'string' && v.length > 0)),
+  ];
+
+  if (versions.length === 0) {
+    return {
+      deployState: 'unknown',
+      fleetVersion: thisPodVersion || null,
+      podCount: 0,
+      versions: thisPodVersion ? [thisPodVersion] : [],
+    };
+  }
+
+  if (versions.length === 1) {
+    return {
+      deployState: 'stable',
+      fleetVersion: versions[0],
+      podCount: entries.length,
+      versions,
+    };
+  }
+
+  return {
+    deployState: 'deploying',
+    fleetVersion: thisPodVersion || versions[0],
+    podCount: entries.length,
+    versions,
+  };
+}
+
+function parseHeartbeat(raw) {
+  if (!raw) return null;
+  try {
+    const parsed = typeof raw === 'string' ? JSON.parse(raw) : raw;
+    if (!parsed || typeof parsed.version !== 'string') return null;
+    const ts = Number(parsed.ts);
+    return { version: parsed.version, ts: Number.isFinite(ts) ? ts : 0 };
+  } catch {
+    return null;
+  }
+}
+
+export function getCachedFleetState() {
+  return { ...cachedFleet };
+}
+
+function setCachedFleet(next) {
+  cachedFleet = {
+    deployState: next.deployState,
+    fleetVersion: next.fleetVersion,
+    podCount: next.podCount,
+    versions: [...(next.versions || [])],
+  };
+}
+
+async function readLiveEntries(client) {
+  const now = Date.now();
+  const all = await client.hGetAll(HASH_KEY);
+  const live = [];
+  const staleFields = [];
+
+  for (const [podId, raw] of Object.entries(all || {})) {
+    const entry = parseHeartbeat(raw);
+    if (!entry || now - entry.ts > STALE_MS) {
+      staleFields.push(podId);
+      continue;
+    }
+    live.push({ podId, ...entry });
+  }
+
+  if (staleFields.length > 0) {
+    await client.hDel(HASH_KEY, staleFields);
+  }
+
+  return live;
+}
+
+async function writeHeartbeat(client, version) {
+  const podId = getPodId();
+  await client.hSet(
+    HASH_KEY,
+    podId,
+    JSON.stringify({ version, ts: Date.now() })
+  );
+}
+
+function publishKey(state) {
+  return `${state.deployState}|${state.fleetVersion || ''}|${state.podCount}|${(state.versions || []).slice().sort().join(',')}`;
+}
+
+async function maybePublishTransition(state) {
+  const key = publishKey(state);
+  if (key === lastPublishedKey) return;
+  const prev = lastPublishedKey;
+  lastPublishedKey = key;
+
+  if (!prev && state.deployState === 'stable') {
+    // First observation after boot on an already-stable fleet — do not spam tabs.
+    return;
+  }
+
+  try {
+    await notificationService.publish(
+      'deploy-state-updated',
+      {
+        deployState: state.deployState,
+        version: state.fleetVersion,
+        fleetVersion: state.fleetVersion,
+        podCount: state.podCount,
+        versions: state.versions,
+      },
+      null
+    );
+    console.log(
+      `📦 Fleet deploy state: ${state.deployState} version=${state.fleetVersion || '?'} pods=${state.podCount}`
+    );
+  } catch (err) {
+    console.warn('⚠️ Failed to publish deploy-state-updated:', err?.message || err);
+  }
+}
+
+export async function refreshFleetState() {
+  const version = localVersion || readLocalAppVersion();
+  localVersion = version;
+
+  const client = redisService.getPublisherClient();
+  if (!client) {
+    const local = {
+      deployState: 'unknown',
+      fleetVersion: version,
+      podCount: 0,
+      versions: version ? [version] : [],
+    };
+    setCachedFleet(local);
+    return local;
+  }
+
+  try {
+    await writeHeartbeat(client, version);
+    const live = await readLiveEntries(client);
+    const state = deriveFleetState(live, version);
+    setCachedFleet(state);
+    await maybePublishTransition(state);
+    return state;
+  } catch (err) {
+    console.warn('⚠️ Deploy-state Redis heartbeat failed:', err?.message || err);
+    const local = {
+      deployState: 'unknown',
+      fleetVersion: version,
+      podCount: 0,
+      versions: version ? [version] : [],
+    };
+    setCachedFleet(local);
+    return local;
+  }
+}
+
+export function startDeployStateHeartbeats() {
+  localVersion = readLocalAppVersion();
+  cachedFleet = {
+    deployState: 'unknown',
+    fleetVersion: localVersion,
+    podCount: 0,
+    versions: localVersion ? [localVersion] : [],
+  };
+
+  void refreshFleetState();
+  if (heartbeatTimer) {
+    clearInterval(heartbeatTimer);
+  }
+  heartbeatTimer = setInterval(() => {
+    void refreshFleetState();
+  }, HEARTBEAT_MS);
+  if (typeof heartbeatTimer.unref === 'function') {
+    heartbeatTimer.unref();
+  }
+  console.log(`📦 Deploy-state heartbeat started (pod=${getPodId()} version=${localVersion})`);
+}
+
+export function stopDeployStateHeartbeats() {
+  if (heartbeatTimer) {
+    clearInterval(heartbeatTimer);
+    heartbeatTimer = null;
+  }
+}

--- a/server/services/deployStateService.test.js
+++ b/server/services/deployStateService.test.js
@@ -1,0 +1,41 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { deriveFleetState } from './deployStateService.js';
+
+describe('deriveFleetState', () => {
+  it('is unknown when no live heartbeats', () => {
+    const s = deriveFleetState([], 'v2');
+    assert.equal(s.deployState, 'unknown');
+    assert.equal(s.fleetVersion, 'v2');
+    assert.equal(s.podCount, 0);
+  });
+
+  it('is stable when every live pod reports the same version', () => {
+    const s = deriveFleetState(
+      [
+        { version: 'v2' },
+        { version: 'v2' },
+        { version: 'v2' },
+      ],
+      'v2'
+    );
+    assert.equal(s.deployState, 'stable');
+    assert.equal(s.fleetVersion, 'v2');
+    assert.equal(s.podCount, 3);
+  });
+
+  it('is deploying when live pods disagree', () => {
+    const s = deriveFleetState(
+      [
+        { version: 'v1' },
+        { version: 'v1' },
+        { version: 'v2' },
+      ],
+      'v2'
+    );
+    assert.equal(s.deployState, 'deploying');
+    assert.equal(s.fleetVersion, 'v2');
+    assert.equal(s.podCount, 3);
+    assert.deepEqual(s.versions.slice().sort(), ['v1', 'v2']);
+  });
+});

--- a/server/services/postgresNotificationService.js
+++ b/server/services/postgresNotificationService.js
@@ -377,6 +377,10 @@ class PostgresNotificationService {
         this.allTenantsCallbacks.set(channel, new Set());
       }
       this.allTenantsCallbacks.get(channel).add(callback);
+
+      // Also LISTEN on the unprefixed channel so instance-wide publishes
+      // (tenantId null — e.g. fleet deploy-state) reach every pod.
+      await this.subscribe(channel, callback);
       
       console.log(`📡 Registered callback for all-tenant channel: ${channel} (will subscribe dynamically to tenant-specific channels)`);
     } else {

--- a/server/services/websocketService.js
+++ b/server/services/websocketService.js
@@ -900,6 +900,15 @@ class WebSocketService {
         this.io?.emit('version-updated', data);
       }
     });
+
+    // Fleet deploy state (instance-wide — all tenants / all sockets)
+    postgresNotificationService.subscribeToAllTenants('deploy-state-updated', (data, tenantId) => {
+      if (tenantId) {
+        this.io?.to(`tenant-${tenantId}`).emit('deploy-state-updated', data);
+      } else {
+        this.io?.emit('deploy-state-updated', data);
+      }
+    });
   }
 
   /**

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -109,7 +109,6 @@ import { resolveActivityFeedPosition } from './utils/activityFeedPosition';
 import { isMobileViewport } from './utils/mobileViewport';
 import { loadUserPreferences, loadUserPreferencesAsync, mergeClearedKanbanVisibilityFilters, saveUserPreferences, updateUserPreference, updateActivityFeedPreference, loadAdminDefaults, TaskViewMode, ViewMode, isGloballySavingPreferences, registerSavingStateCallback, UserPreferences, clearAllUserPreferenceCookies } from './utils/userPreferences';
 import { resolveGuestLanguage, normalizeAppLanguage, getExplicitGuestLanguage, setExplicitGuestLanguage, consumeLanguageQueryParam } from './utils/guestLanguage';
-import { versionDetection } from './utils/versionDetection';
 import { getAllPriorities, getAllTags, getTags, getPriorities, getSettings, getTaskWatchers, getTaskCollaborators, addTagToTask, removeTagFromTask, getBoardTaskRelationships, getTaskRelationships, getAllSprints, getUserSettings, removeTaskRelationship } from './api';
 import { 
   DEFAULT_COLUMNS, 
@@ -1816,6 +1815,7 @@ function AppContent() {
     websocketClient.onTaskTagRemoved(taskWebSocket.handleTaskTagRemoved);
     websocketClient.onInstanceStatusUpdated(settingsWebSocket.handleInstanceStatusUpdated);
     websocketClient.onVersionUpdated(settingsWebSocket.handleVersionUpdated);
+    websocketClient.onDeployStateUpdated(settingsWebSocket.handleDeployStateUpdated);
     websocketClient.onCommentCreated(commentWebSocket.handleCommentCreated);
     websocketClient.onCommentUpdated(commentWebSocket.handleCommentUpdated);
     websocketClient.onCommentDeleted(commentWebSocket.handleCommentDeleted);
@@ -1871,6 +1871,7 @@ function AppContent() {
       websocketClient.offTaskTagRemoved(taskWebSocket.handleTaskTagRemoved);
       websocketClient.offInstanceStatusUpdated(settingsWebSocket.handleInstanceStatusUpdated);
       websocketClient.offVersionUpdated(settingsWebSocket.handleVersionUpdated);
+      websocketClient.offDeployStateUpdated(settingsWebSocket.handleDeployStateUpdated);
       websocketClient.offCommentCreated(commentWebSocket.handleCommentCreated);
       websocketClient.offCommentUpdated(commentWebSocket.handleCommentUpdated);
       websocketClient.offCommentDeleted(commentWebSocket.handleCommentDeleted);
@@ -6532,6 +6533,7 @@ function AppContent() {
         <VersionUpdateBanner
           currentVersion={versionStatus.versionInfo.currentVersion}
           newVersion={versionStatus.versionInfo.newVersion}
+          mode={versionStatus.versionBannerMode}
           onRefresh={versionStatus.handleRefreshVersion}
           onDismiss={versionStatus.handleDismissVersionBanner}
         />

--- a/src/api.ts
+++ b/src/api.ts
@@ -224,10 +224,19 @@ api.interceptors.response.use(
         summarizeApiPayload(response.data, 500)
       );
     }
-    // Check for version updates via X-App-Version header
+    // Fleet deploy state + this-pod version (version.json), not DB APP_VERSION
     const appVersion = response.headers['x-app-version'];
-    if (appVersion) {
-      versionDetection.checkVersion(appVersion);
+    const deployState = response.headers['x-deploy-state'];
+    const fleetVersion = response.headers['x-deploy-fleet-version'];
+    const podCountRaw = response.headers['x-deploy-pod-count'];
+    if (appVersion || deployState) {
+      const podCount = podCountRaw != null ? parseInt(String(podCountRaw), 10) : undefined;
+      versionDetection.applyFleetSignal({
+        version: appVersion || fleetVersion || undefined,
+        fleetVersion: fleetVersion || appVersion || undefined,
+        deployState: deployState || undefined,
+        podCount: Number.isFinite(podCount) ? podCount : undefined,
+      });
     }
     return response;
   },

--- a/src/components/VersionUpdateBanner.tsx
+++ b/src/components/VersionUpdateBanner.tsx
@@ -1,9 +1,11 @@
 import { AlertCircle, RefreshCw, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import type { VersionBannerMode } from '../hooks/useVersionStatus';
 
 interface VersionUpdateBannerProps {
   currentVersion: string;
   newVersion: string;
+  mode?: VersionBannerMode;
   onRefresh: () => void;
   onDismiss: () => void;
 }
@@ -11,10 +13,13 @@ interface VersionUpdateBannerProps {
 const VersionUpdateBanner: React.FC<VersionUpdateBannerProps> = ({
   currentVersion,
   newVersion,
+  mode = 'ready',
   onRefresh,
   onDismiss,
 }) => {
   const { t } = useTranslation('common');
+  const deploying = mode === 'deploying';
+
   return (
     <div className="fixed top-0 left-0 right-0 z-[10000] bg-blue-600 text-white shadow-lg">
       <div className="max-w-7xl mx-auto px-4 py-3">
@@ -23,7 +28,9 @@ const VersionUpdateBanner: React.FC<VersionUpdateBannerProps> = ({
             <AlertCircle className="h-5 w-5 flex-shrink-0" />
             <div className="flex-1">
               <p className="text-sm font-medium">
-                {t('versionUpdateBanner.title')}
+                {deploying
+                  ? t('versionUpdateBanner.deployingTitle')
+                  : t('versionUpdateBanner.title')}
                 {currentVersion && newVersion && currentVersion !== newVersion && (
                   <span className="ml-2 text-blue-200">
                     (v{currentVersion} → v{newVersion})
@@ -31,19 +38,25 @@ const VersionUpdateBanner: React.FC<VersionUpdateBannerProps> = ({
                 )}
               </p>
               <p className="text-xs text-blue-100 mt-1">
-                {t('versionUpdateBanner.description')}
+                {deploying
+                  ? t('versionUpdateBanner.deployingDescription')
+                  : t('versionUpdateBanner.description')}
               </p>
             </div>
           </div>
           <div className="flex items-center space-x-2 ml-4">
+            {!deploying && (
+              <button
+                type="button"
+                onClick={onRefresh}
+                className="inline-flex items-center px-4 py-2 bg-white text-blue-600 rounded-md hover:bg-blue-50 transition-colors font-medium text-sm"
+              >
+                <RefreshCw className="h-4 w-4 mr-2" />
+                {t('versionUpdateBanner.refreshNow')}
+              </button>
+            )}
             <button
-              onClick={onRefresh}
-              className="inline-flex items-center px-4 py-2 bg-white text-blue-600 rounded-md hover:bg-blue-50 transition-colors font-medium text-sm"
-            >
-              <RefreshCw className="h-4 w-4 mr-2" />
-              {t('versionUpdateBanner.refreshNow')}
-            </button>
-            <button
+              type="button"
               onClick={onDismiss}
               className="p-2 hover:bg-blue-700 rounded-md transition-colors"
               title={t('versionUpdateBanner.dismissTooltip')}
@@ -58,4 +71,3 @@ const VersionUpdateBanner: React.FC<VersionUpdateBannerProps> = ({
 };
 
 export default VersionUpdateBanner;
-

--- a/src/hooks/useSettingsWebSocket.ts
+++ b/src/hooks/useSettingsWebSocket.ts
@@ -183,12 +183,18 @@ export const useSettingsWebSocket = ({
     }
   }, [versionStatus.setInstanceStatus]);
 
-  const handleVersionUpdated = useCallback((data: any) => {
-    console.log('📦 Version updated via WebSocket:', data);
-    if (data.version) {
-      // Pass isFromWebSocket=true so new sessions can detect new versions
-      versionDetection.checkVersion(data.version, true);
-    }
+  const handleVersionUpdated = useCallback((_data: any) => {
+    // DB APP_VERSION / legacy version-updated is not used for reload or banner.
+  }, []);
+
+  const handleDeployStateUpdated = useCallback((data: any) => {
+    console.log('📦 Fleet deploy state via WebSocket:', data);
+    versionDetection.applyFleetSignal({
+      version: data?.fleetVersion || data?.version,
+      fleetVersion: data?.fleetVersion || data?.version,
+      deployState: data?.deployState,
+      podCount: typeof data?.podCount === 'number' ? data.podCount : undefined,
+    });
   }, []);
 
   return {
@@ -205,6 +211,7 @@ export const useSettingsWebSocket = ({
     handleSettingsUpdated,
     handleInstanceStatusUpdated,
     handleVersionUpdated,
+    handleDeployStateUpdated,
   };
 };
 

--- a/src/hooks/useVersionStatus.tsx
+++ b/src/hooks/useVersionStatus.tsx
@@ -2,7 +2,7 @@
  * Hook for managing version and instance status state
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { versionDetection } from '../utils/versionDetection';
 import InstanceStatusBannerView from '../components/layout/InstanceStatusBanner';
 
@@ -17,112 +17,82 @@ export interface VersionInfo {
   newVersion: string;
 }
 
+export type VersionBannerMode = 'hidden' | 'deploying' | 'ready';
+
 export interface UseVersionStatusReturn {
-  // Instance Status
   instanceStatus: InstanceStatus;
   setInstanceStatus: (status: InstanceStatus | ((prev: InstanceStatus) => InstanceStatus)) => void;
-  
-  // Version Banner
+
+  versionBannerMode: VersionBannerMode;
   showVersionBanner: boolean;
   setShowVersionBanner: (show: boolean) => void;
   versionInfo: VersionInfo;
   setVersionInfo: (info: VersionInfo) => void;
-  
-  // Handlers
+
   handleRefreshVersion: () => void;
   handleDismissVersionBanner: () => void;
-  
-  // Component
+
   InstanceStatusBanner: () => JSX.Element | null;
 }
 
 export const useVersionStatus = (): UseVersionStatusReturn => {
-  // Instance Status Banner State
   const [instanceStatus, setInstanceStatus] = useState<InstanceStatus>({
     status: 'active',
     message: '',
-    isDismissed: false
+    isDismissed: false,
   });
 
-  // Version Update Banner State
-  const [showVersionBanner, setShowVersionBanner] = useState<boolean>(false);
+  const [versionBannerMode, setVersionBannerMode] = useState<VersionBannerMode>('hidden');
   const [versionInfo, setVersionInfo] = useState<VersionInfo>({
     currentVersion: '',
-    newVersion: ''
+    newVersion: '',
   });
+  const autoReloadStarted = useRef(false);
 
-  // Version detection setup
-  useEffect(() => {
-    const handleVersionChange = (oldVersion: string, newVersion: string) => {
-      console.log(`🔔 Version change detected: ${oldVersion} → ${newVersion}`);
+  const navigateWithCacheBust = (targetVersion?: string) => {
+    if (targetVersion) {
+      localStorage.setItem('dismissedVersion', targetVersion);
+    }
+    sessionStorage.setItem('pendingVersionRefresh', 'true');
+    const u = new URL(window.location.href);
+    u.searchParams.set('_v', String(Date.now()));
+    window.location.href = u.toString();
+  };
 
-      const dismissedVersion = localStorage.getItem('dismissedVersion');
-
-      // Only clear dismissal when a *different* version is a genuine upgrade path.
-      // Do NOT clear when an older pod answers mid-rollout (that caused 2nd/3rd banners).
-      if (dismissedVersion === newVersion) {
-        console.log(`🔕 Version ${newVersion} was already dismissed, not showing banner`);
-        setVersionInfo({
-          currentVersion: oldVersion === 'unknown' ? newVersion : oldVersion,
-          newVersion,
-        });
-        return;
-      }
-
-      let displayCurrentVersion = oldVersion;
-      if (oldVersion === 'unknown') {
-        const initialVersion = versionDetection.getInitialVersion();
-        if (initialVersion && initialVersion !== newVersion) {
-          displayCurrentVersion = initialVersion;
-          console.log(`📝 Using initial version from API headers: ${initialVersion}`);
-        } else {
-          displayCurrentVersion = newVersion;
-        }
-      }
-
-      setVersionInfo({
-        currentVersion: displayCurrentVersion,
-        newVersion,
-      });
-      setShowVersionBanner(true);
-    };
-
-    versionDetection.onVersionChange(handleVersionChange);
-    return () => {
-      versionDetection.offVersionChange(handleVersionChange);
-    };
-  }, []);
-
-  // Handlers for version banner
   const handleRefreshVersion = () => {
     const targetVersion = versionInfo.newVersion;
     if (targetVersion) {
       localStorage.setItem('dismissedVersion', targetVersion);
     }
     sessionStorage.setItem('pendingVersionRefresh', 'true');
-    setShowVersionBanner(false);
+    setVersionBannerMode('hidden');
 
-    const navigateWithCacheBust = () => {
-      const u = new URL(window.location.href);
-      u.searchParams.set('_v', String(Date.now()));
-      window.location.href = u.toString();
-    };
-
-    // Wait until we hit a pod that already serves the target build (avoids reload onto old replica).
     void (async () => {
       const maxAttempts = 12;
       for (let attempt = 0; attempt < maxAttempts; attempt++) {
         try {
           const res = await fetch('/api/version', { cache: 'no-store' });
           if (res.ok) {
-            const data = (await res.json().catch(() => null)) as { version?: string } | null;
-            const served = data?.version || res.headers.get('x-app-version') || '';
-            if (!targetVersion || served === targetVersion) {
-              navigateWithCacheBust();
+            const data = (await res.json().catch(() => null)) as {
+              version?: string;
+              fleetVersion?: string;
+              deployState?: string;
+            } | null;
+            const served =
+              data?.fleetVersion ||
+              data?.version ||
+              res.headers.get('x-deploy-fleet-version') ||
+              res.headers.get('x-app-version') ||
+              '';
+            const deployState =
+              data?.deployState || res.headers.get('x-deploy-state') || '';
+            const fleetReady = deployState !== 'deploying';
+            if (fleetReady && (!targetVersion || served === targetVersion)) {
+              navigateWithCacheBust(targetVersion);
               return;
             }
             console.log(
-              `⏳ Waiting for rollout: /api/version is ${served || 'unknown'}, want ${targetVersion} (try ${attempt + 1}/${maxAttempts})`
+              `⏳ Waiting for fleet: deployState=${deployState || 'unknown'} version=${served || 'unknown'} want ${targetVersion} (try ${attempt + 1}/${maxAttempts})`
             );
           }
         } catch {
@@ -130,23 +100,95 @@ export const useVersionStatus = (): UseVersionStatusReturn => {
         }
         await new Promise((r) => setTimeout(r, 400 + attempt * 200));
       }
-      navigateWithCacheBust();
+      navigateWithCacheBust(targetVersion);
     })();
   };
 
+  useEffect(() => {
+    const handleVersionChange = (oldVersion: string, newVersion: string) => {
+      console.log(`🔔 Fleet stable on newer build: ${oldVersion} → ${newVersion}`);
+
+      const dismissedVersion = localStorage.getItem('dismissedVersion');
+      if (dismissedVersion === newVersion) {
+        return;
+      }
+
+      setVersionInfo({
+        currentVersion: oldVersion === 'unknown' ? newVersion : oldVersion,
+        newVersion,
+      });
+
+      if (versionDetection.shouldAutoReload(newVersion) && !autoReloadStarted.current) {
+        autoReloadStarted.current = true;
+        setVersionBannerMode('ready');
+        // Defer so versionInfo is set for handleRefreshVersion's closure —
+        // navigate uses newVersion directly below.
+        localStorage.setItem('dismissedVersion', newVersion);
+        sessionStorage.setItem('pendingVersionRefresh', 'true');
+        void (async () => {
+          const maxAttempts = 12;
+          for (let attempt = 0; attempt < maxAttempts; attempt++) {
+            try {
+              const res = await fetch('/api/version', { cache: 'no-store' });
+              if (res.ok) {
+                const data = (await res.json().catch(() => null)) as {
+                  version?: string;
+                  fleetVersion?: string;
+                  deployState?: string;
+                } | null;
+                const served = data?.fleetVersion || data?.version || '';
+                const deployState = data?.deployState || '';
+                if (deployState !== 'deploying' && served === newVersion) {
+                  const u = new URL(window.location.href);
+                  u.searchParams.set('_v', String(Date.now()));
+                  window.location.href = u.toString();
+                  return;
+                }
+              }
+            } catch {
+              /* retry */
+            }
+            await new Promise((r) => setTimeout(r, 400 + attempt * 200));
+          }
+          const u = new URL(window.location.href);
+          u.searchParams.set('_v', String(Date.now()));
+          window.location.href = u.toString();
+        })();
+        return;
+      }
+
+      setVersionBannerMode('ready');
+    };
+
+    const handleDeploying = (deploying: boolean, fleetVersion: string | null) => {
+      if (deploying) {
+        setVersionInfo((prev) => ({
+          currentVersion: versionDetection.getInitialVersion() || prev.currentVersion,
+          newVersion: fleetVersion || prev.newVersion,
+        }));
+        setVersionBannerMode('deploying');
+        return;
+      }
+      setVersionBannerMode((mode) => (mode === 'deploying' ? 'hidden' : mode));
+    };
+
+    versionDetection.onVersionChange(handleVersionChange);
+    versionDetection.onDeployingChange(handleDeploying);
+    return () => {
+      versionDetection.offVersionChange(handleVersionChange);
+      versionDetection.offDeployingChange(handleDeploying);
+    };
+  }, []);
+
   const handleDismissVersionBanner = () => {
-    setShowVersionBanner(false);
-    // When dismissing, we want to:
-    // 1. Remember this specific version was dismissed (localStorage)
-    // 2. NOT update initialVersion because we want to detect NEWER versions later
-    //    (e.g., if user dismisses v2, we still want to detect v3, v4, etc.)
-    // The lastNotifiedVersion tracking prevents duplicate notifications for the same version
-    if (versionInfo.newVersion) {
+    setVersionBannerMode('hidden');
+    // Only remember a skip for the *ready* (reload) banner. Dismissing
+    // "update in progress" must not block the post-rollout refresh.
+    if (versionBannerMode === 'ready' && versionInfo.newVersion) {
       localStorage.setItem('dismissedVersion', versionInfo.newVersion);
     }
   };
-  
-  // Instance Status Banner Component
+
   const InstanceStatusBanner = () => (
     <InstanceStatusBannerView
       status={instanceStatus.status}
@@ -160,8 +202,9 @@ export const useVersionStatus = (): UseVersionStatusReturn => {
   return {
     instanceStatus,
     setInstanceStatus,
-    showVersionBanner,
-    setShowVersionBanner,
+    versionBannerMode,
+    showVersionBanner: versionBannerMode !== 'hidden',
+    setShowVersionBanner: (show: boolean) => setVersionBannerMode(show ? 'ready' : 'hidden'),
     versionInfo,
     setVersionInfo,
     handleRefreshVersion,
@@ -169,4 +212,3 @@ export const useVersionStatus = (): UseVersionStatusReturn => {
     InstanceStatusBanner,
   };
 };
-

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -1477,6 +1477,8 @@
   "versionUpdateBanner": {
     "title": "New version available",
     "description": "A new version of the application has been deployed. Please refresh to get the latest updates.",
+    "deployingTitle": "Update in progress",
+    "deployingDescription": "A new version is rolling out. This page will refresh when every server is ready.",
     "refreshNow": "Refresh Now",
     "dismissTooltip": "Dismiss (will refresh on next page load)"
   },

--- a/src/i18n/locales/fr/common.json
+++ b/src/i18n/locales/fr/common.json
@@ -1478,6 +1478,8 @@
   "versionUpdateBanner": {
     "title": "Nouvelle version disponible",
     "description": "Une nouvelle version de l'application a été déployée. Veuillez actualiser pour obtenir les dernières mises à jour.",
+    "deployingTitle": "Mise à jour en cours",
+    "deployingDescription": "Une nouvelle version est en cours de déploiement. Cette page s'actualisera lorsque tous les serveurs seront prêts.",
     "refreshNow": "Actualiser maintenant",
     "dismissTooltip": "Ignorer (s'actualisera au prochain chargement de page)"
   },

--- a/src/services/websocketClient.ts
+++ b/src/services/websocketClient.ts
@@ -688,6 +688,14 @@ class WebSocketClient {
     this.removeEventListener('version-updated', callback);
   }
 
+  onDeployStateUpdated(callback: (data: any) => void) {
+    this.addEventListener('deploy-state-updated', callback);
+  }
+
+  offDeployStateUpdated(callback?: (data: any) => void) {
+    this.removeEventListener('deploy-state-updated', callback);
+  }
+
   offWebSocketReady(callback?: () => void) {
     if (callback) {
       const index = this.readyCallbacks.indexOf(callback);

--- a/src/utils/buildVersion.ts
+++ b/src/utils/buildVersion.ts
@@ -1,0 +1,5 @@
+/** Version of the JS bundle that is running (not the pod that answered an API call). */
+export const BUILD_VERSION =
+  typeof __AGILA_BUILD_VERSION__ !== 'undefined' && __AGILA_BUILD_VERSION__
+    ? __AGILA_BUILD_VERSION__
+    : 'dev';

--- a/src/utils/versionDetection.ts
+++ b/src/utils/versionDetection.ts
@@ -1,16 +1,26 @@
+import { BUILD_VERSION } from './buildVersion';
+
 /**
- * Version Detection Utility
+ * Version / fleet-deploy detection.
  *
- * Tracks app version changes and notifies listeners when a new version is detected.
- * The initial version is stored in-memory when the app first loads, and subsequent
- * API responses are checked for version changes via the X-App-Version header.
+ * Reload and banner logic use the pod's version.json (X-App-Version /
+ * X-Deploy-Fleet-Version) plus Redis-derived X-Deploy-State — not DB APP_VERSION.
  *
- * During K8s rolling updates, clients may briefly hit old + new pods. We must not
- * treat a temporary "downgrade" (seeing an older X-App-Version) as a new update,
- * or clear a dismissed target version when an old pod answers.
+ * During a rolling update, pods disagree → deploying → never reload.
+ * When every live heartbeat agrees and this tab is behind → reload (or banner).
  */
 
 type VersionChangeCallback = (oldVersion: string, newVersion: string) => void;
+type DeployingCallback = (deploying: boolean, fleetVersion: string | null) => void;
+
+export type DeployState = 'deploying' | 'stable' | 'unknown';
+
+export type FleetSignal = {
+  version?: string | null;
+  deployState?: string | null;
+  podCount?: number | null;
+  fleetVersion?: string | null;
+};
 
 const DISMISSED_KEY = 'dismissedVersion';
 
@@ -22,21 +32,39 @@ function readDismissedVersion(): string | null {
   }
 }
 
+function normalizeDeployState(raw?: string | null): DeployState {
+  if (raw === 'deploying' || raw === 'stable') return raw;
+  return 'unknown';
+}
+
+export function shouldAutoReloadForFleet(opts: {
+  deployState: DeployState;
+  pageVersion: string | null;
+  fleetVersion: string | null;
+  sawDeploying: boolean;
+  podCount: number;
+}): boolean {
+  if (opts.deployState !== 'stable') return false;
+  if (!opts.fleetVersion || !opts.pageVersion) return false;
+  if (opts.fleetVersion === opts.pageVersion) return false;
+  if (readDismissedVersion() === opts.fleetVersion) return false;
+  return opts.sawDeploying || opts.podCount >= 2;
+}
+
 class VersionDetectionService {
   private initialVersion: string | null = null;
   private listeners: VersionChangeCallback[] = [];
+  private deployingListeners: DeployingCallback[] = [];
   private isInitialized = false;
   private lastNotifiedVersion: string | null = null;
+  private sawDeploying = false;
+  private lastPodCount = 0;
+  private lastDeployState: DeployState = 'unknown';
 
-  /**
-   * Set the initial app version (called on first API response)
-   * Can also be called to update the version after a refresh
-   */
   setInitialVersion(version: string) {
     const wasInitialized = this.isInitialized;
     this.initialVersion = version;
     this.isInitialized = true;
-    // Reset notification tracking when version is explicitly set (e.g., after refresh)
     this.lastNotifiedVersion = null;
     if (!wasInitialized) {
       console.log(`📦 Initial app version: ${version}`);
@@ -46,66 +74,57 @@ class VersionDetectionService {
   }
 
   /**
-   * Check if a new version has been detected
-   * @param newVersion - The new version to check
-   * @param isFromWebSocket - Whether this version came from WebSocket (vs API header)
+   * Apply fleet + this-pod version from headers, /api/version, or WebSocket.
+   */
+  applyFleetSignal(signal: FleetSignal): void {
+    const deployState = normalizeDeployState(signal.deployState);
+    const fleetVersion = signal.fleetVersion || signal.version || null;
+    const thisPodVersion = signal.version || fleetVersion;
+    const podCount = typeof signal.podCount === 'number' && Number.isFinite(signal.podCount)
+      ? signal.podCount
+      : 0;
+
+    this.lastDeployState = deployState;
+    this.lastPodCount = podCount;
+
+    if (!this.isInitialized || !this.initialVersion) {
+      if (thisPodVersion) {
+        this.setInitialVersion(thisPodVersion);
+      }
+      if (deployState === 'deploying') {
+        this.sawDeploying = true;
+        this.notifyDeploying(true, fleetVersion);
+      }
+      return;
+    }
+
+    if (deployState === 'deploying') {
+      this.sawDeploying = true;
+      this.notifyDeploying(true, fleetVersion);
+      return;
+    }
+
+    this.notifyDeploying(false, fleetVersion);
+
+    if (deployState !== 'stable' || !fleetVersion) {
+      return;
+    }
+
+    this.maybeNotifyStableUpgrade(fleetVersion);
+  }
+
+  /**
+   * @deprecated Prefer applyFleetSignal. Kept so older call sites still compile.
+   * Without deployState this never triggers a reload (avoids mid-rollout flips).
    */
   checkVersion(newVersion: string, isFromWebSocket: boolean = false): boolean {
     if (!newVersion) return false;
-
-    const dismissedVersion = readDismissedVersion();
-
-    // Already adopted / dismissed this build — ignore, including mid-rollout flip-flops
-    if (dismissedVersion === newVersion) {
-      if (!this.isInitialized) {
-        this.setInitialVersion(newVersion);
-      } else if (this.initialVersion !== newVersion) {
-        // Sticky: once user refreshed for V, don't let an old pod reset baseline to V-1
-        this.initialVersion = newVersion;
-      }
-      return false;
-    }
-
     if (!this.isInitialized || !this.initialVersion) {
-      if (isFromWebSocket) {
-        console.log(`🔄 New version detected on fresh session: ${newVersion} (not dismissed)`);
+      if (!isFromWebSocket) {
         this.setInitialVersion(newVersion);
-        this.notifyListeners('unknown', newVersion);
-        this.lastNotifiedVersion = newVersion;
-        return true;
       }
-      this.setInitialVersion(newVersion);
-      this.lastNotifiedVersion = null;
       return false;
     }
-
-    if (newVersion === this.initialVersion) {
-      return false;
-    }
-
-    // Once we're already prompting for a target build, ignore other builds (old pods mid-rollout)
-    if (this.lastNotifiedVersion && newVersion !== this.lastNotifiedVersion) {
-      console.log(
-        `⏭️ Ignoring version ${newVersion}; already notifying for ${this.lastNotifiedVersion}`
-      );
-      return false;
-    }
-
-    // Mid-rollout: old pod after we already saw / dismissed the new build — do not "update" to older
-    if (dismissedVersion && newVersion !== dismissedVersion) {
-      console.log(
-        `⏭️ Ignoring version ${newVersion} during rollout (target/dismissed: ${dismissedVersion}, baseline: ${this.initialVersion})`
-      );
-      return false;
-    }
-
-    if (newVersion !== this.lastNotifiedVersion) {
-      console.log(`🔄 Version change detected: ${this.initialVersion} → ${newVersion}`);
-      this.notifyListeners(this.initialVersion, newVersion);
-      this.lastNotifiedVersion = newVersion;
-      return true;
-    }
-
     return false;
   }
 
@@ -115,6 +134,56 @@ class VersionDetectionService {
 
   offVersionChange(callback: VersionChangeCallback) {
     this.listeners = this.listeners.filter((cb) => cb !== callback);
+  }
+
+  onDeployingChange(callback: DeployingCallback) {
+    this.deployingListeners.push(callback);
+  }
+
+  offDeployingChange(callback: DeployingCallback) {
+    this.deployingListeners = this.deployingListeners.filter((cb) => cb !== callback);
+  }
+
+  private notifyDeploying(deploying: boolean, fleetVersion: string | null) {
+    this.deployingListeners.forEach((callback) => {
+      try {
+        callback(deploying, fleetVersion);
+      } catch (error) {
+        console.error('Error in deploy-state callback:', error);
+      }
+    });
+  }
+
+  private maybeNotifyStableUpgrade(fleetVersion: string) {
+    const dismissedVersion = readDismissedVersion();
+    if (dismissedVersion === fleetVersion) {
+      if (this.initialVersion !== fleetVersion) {
+        this.initialVersion = fleetVersion;
+      }
+      return;
+    }
+
+    if (!this.initialVersion || fleetVersion === this.initialVersion) {
+      return;
+    }
+
+    if (this.lastNotifiedVersion === fleetVersion) {
+      return;
+    }
+
+    console.log(`🔄 Fleet stable on newer build: ${this.initialVersion} → ${fleetVersion}`);
+    this.notifyListeners(this.initialVersion, fleetVersion);
+    this.lastNotifiedVersion = fleetVersion;
+  }
+
+  shouldAutoReload(fleetVersion: string | null): boolean {
+    return shouldAutoReloadForFleet({
+      deployState: this.lastDeployState,
+      pageVersion: this.initialVersion,
+      fleetVersion,
+      sawDeploying: this.sawDeploying,
+      podCount: this.lastPodCount,
+    });
   }
 
   private notifyListeners(oldVersion: string, newVersion: string) {
@@ -131,12 +200,24 @@ class VersionDetectionService {
     return this.initialVersion;
   }
 
+  getSawDeploying(): boolean {
+    return this.sawDeploying;
+  }
+
   reset() {
     this.initialVersion = null;
     this.isInitialized = false;
     this.lastNotifiedVersion = null;
+    this.sawDeploying = false;
+    this.lastPodCount = 0;
+    this.lastDeployState = 'unknown';
     this.listeners = [];
+    this.deployingListeners = [];
   }
 }
 
 export const versionDetection = new VersionDetectionService();
+
+if (BUILD_VERSION && BUILD_VERSION !== 'dev') {
+  versionDetection.setInitialVersion(BUILD_VERSION);
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,4 @@
 /// <reference types="vite/client" />
+
+/** Baked at Vite build from server/version.json — this tab's HTML/JS generation. */
+declare const __AGILA_BUILD_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -231,6 +231,18 @@ export default defineConfig({
     // Always emit string literals (undefined would skip replacement and break demo UI)
     'process.env.DEMO_ENABLED': JSON.stringify(process.env.DEMO_ENABLED === 'true' ? 'true' : 'false'),
     'process.env.MULTI_TENANT': JSON.stringify(process.env.MULTI_TENANT === 'true' ? 'true' : 'false'),
+    // Same string as server/version.json (scripts/generate-version.js runs before vite build)
+    '__AGILA_BUILD_VERSION__': JSON.stringify(
+      (() => {
+        try {
+          const raw = fs.readFileSync(path.join(process.cwd(), 'server/version.json'), 'utf8');
+          const parsed = JSON.parse(raw) as { version?: string };
+          return parsed.version || 'dev';
+        } catch {
+          return 'dev';
+        }
+      })()
+    ),
   },
   build: {
     // Ensure proper code splitting and asset handling


### PR DESCRIPTION
## Summary
- Keep previous hashed `/assets` in the next image so old HTML does not 404 mid-rollout.
- Pods heartbeat `version.json` in Redis; clients show “update in progress” while the fleet is mixed and reload only when every live replica agrees.
- Also includes the prior `dev` commit that blocks sign-in when a workspace is not active.

## Test plan
- [ ] Rolling update on 3 replicas: old tab stays usable (no white screen) while `X-Deploy-State: deploying`
- [ ] After all pods share one version, open tabs refresh (or show the ready banner if they never saw `deploying` and `podCount < 2`)
- [ ] `/api/version` includes `deployState`, `fleetVersion`, `podCount`
- [ ] Admin → Licensing still shows DB `APP_VERSION` (unchanged source)
- [ ] Next image build copies N-1 assets from the previous `easy-kanban:latest` (or ECR tag)


Made with [Cursor](https://cursor.com)