### PR TITLE
Fetch on-prem and corp checkouts over HTTPS

### DIFF
--- a/scripts/deploy-eks-via-ssh.sh
+++ b/scripts/deploy-eks-via-ssh.sh
@@ -12,7 +12,9 @@ echo "EKS deploy ${SHA} → ${REMOTE}:${DEST}"
 ssh -o BatchMode=yes "$REMOTE" bash -s <<EOF
 set -euo pipefail
 cd ${DEST}
-git fetch origin
+# Non-interactive: no GitHub SSH key on this hop (same as scripts/deploy-demo.sh)
+git remote set-url origin https://github.com/drenlia-inc/agila.git
+git fetch origin ${SHA}
 git reset --hard ${SHA}
 export GITHUB_SHA=${SHA}
 export IMAGE_SHA=${SHA}

--- a/scripts/deploy-k8s-onprem-via-ssh.sh
+++ b/scripts/deploy-k8s-onprem-via-ssh.sh
@@ -12,7 +12,9 @@ echo "On-prem deploy ${SHA} → ${REMOTE}:${DEST}"
 ssh -o BatchMode=yes "$REMOTE" bash -s <<EOF
 set -euo pipefail
 cd ${DEST}
-git fetch origin
+# Non-interactive: no GitHub SSH key on this hop (same as scripts/deploy-demo.sh)
+git remote set-url origin https://github.com/drenlia-inc/agila.git
+git fetch origin ${SHA}
 git reset --hard ${SHA}
 export GITHUB_SHA=${SHA}
 export IMAGE_SHA=${SHA}


### PR DESCRIPTION
## Summary
- First *Deploy k8s* failed on `git fetch` (`Permission denied (publickey)`).
- The hop is drenlia-runner → SSH as daniel; that session has no GitHub SSH key.
- Use HTTPS origin, same as `scripts/deploy-demo.sh`, and fetch the exact `GITHUB_SHA`.

## Test plan
- [ ] Merge and confirm *Deploy k8s* gets past `git fetch` on k8s.private


Made with [Cursor](https://cursor.com)