### PR TITLE
Promote staging image-rollout automation to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, master, dev]
+    branches: [main, master, dev, staging]
   pull_request:
 
 jobs:

--- a/.github/workflows/deploy-eks.yml
+++ b/.github/workflows/deploy-eks.yml
@@ -1,0 +1,47 @@
+# Production tenant platform (EKS ns agila). Runner has no AWS — corp does.
+# Image only — see agila-admin docs/DEPLOYMENT.md section 2.
+name: Deploy EKS
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "src/**"
+      - "server/**"
+      - "k8s/**"
+      - "scripts/**"
+      - "Dockerfile.prod"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/deploy-eks.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-eks-app
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build on corp, push ECR, rollout
+    runs-on: self-hosted
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install and audit (high+)
+        run: |
+          npm ci
+          node scripts/ci-npm-audit.js
+
+      - name: Roll out on EKS via corp
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+          CORP_SSH: daniel@corp.private.drenlia.com
+          CORP_REMOTE_DIR: /data/server-setup/terraform/easy-kanban
+        run: bash scripts/deploy-eks-via-ssh.sh

--- a/.github/workflows/deploy-k8s.yml
+++ b/.github/workflows/deploy-k8s.yml
@@ -1,0 +1,47 @@
+# On-prem tenant platform (k8s.private, ns easy-kanban-pg).
+# Image only — see agila-admin docs/DEPLOYMENT.md section 2.
+name: Deploy k8s
+
+on:
+  push:
+    branches: [staging]
+    paths:
+      - "src/**"
+      - "server/**"
+      - "k8s/**"
+      - "scripts/**"
+      - "Dockerfile.prod"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/deploy-k8s.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-k8s-onprem
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build, push registry, rollout
+    runs-on: self-hosted
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install and audit (high+)
+        run: |
+          npm ci
+          node scripts/ci-npm-audit.js
+
+      - name: Roll out on k8s.private
+        env:
+          GITHUB_SHA: ${{ github.sha }}
+          K8S_SSH: daniel@k8s.private.drenlia.com
+          K8S_REMOTE_DIR: /home/daniel/easy-kanban
+        run: bash scripts/deploy-k8s-onprem-via-ssh.sh

--- a/k8s/build-and-push-to-registry-app.sh
+++ b/k8s/build-and-push-to-registry-app.sh
@@ -17,6 +17,8 @@ NC='\033[0m' # No Color
 REGISTRY_HOST="internal-registry.kube-system.svc.cluster.local:5000"
 IMAGE_NAME="easy-kanban"
 IMAGE_TAG="latest"
+# Optional extra registry tag (full Git SHA) so rollouts can pin instead of :latest
+IMAGE_SHA="${IMAGE_SHA:-${GITHUB_SHA:-}}"
 FULL_IMAGE="${REGISTRY_HOST}/${IMAGE_NAME}:${IMAGE_TAG}"
 
 # Get the project root
@@ -162,6 +164,10 @@ echo -e "${YELLOW}📦 Tagging image for registry...${NC}"
 docker tag ${IMAGE_NAME}:${IMAGE_TAG} ${LOCAL_FULL_IMAGE}
 echo -e "${GREEN}✓ Tagged as ${LOCAL_FULL_IMAGE} (for push)${NC}"
 echo -e "${CYAN}   Will be available as ${FULL_IMAGE} in cluster${NC}"
+if [ -n "${IMAGE_SHA}" ]; then
+    docker tag ${IMAGE_NAME}:${IMAGE_TAG} "${LOCAL_REGISTRY}/${IMAGE_NAME}:${IMAGE_SHA}"
+    echo -e "${GREEN}✓ Tagged as ${LOCAL_REGISTRY}/${IMAGE_NAME}:${IMAGE_SHA}${NC}"
+fi
 echo ""
 
 # Push to registry
@@ -180,6 +186,11 @@ else
     echo -e "${RED}❌ Image push failed!${NC}"
     kill $PF_PID 2>/dev/null || true
     exit 1
+fi
+
+if [ -n "${IMAGE_SHA}" ]; then
+    docker push "${LOCAL_REGISTRY}/${IMAGE_NAME}:${IMAGE_SHA}"
+    echo -e "${GREEN}✅ Pushed ${LOCAL_REGISTRY}/${IMAGE_NAME}:${IMAGE_SHA}${NC}"
 fi
 
 # Stop port-forward

--- a/scripts/deploy-eks-via-ssh.sh
+++ b/scripts/deploy-eks-via-ssh.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# drenlia-runner: reset the corp checkout to GITHUB_SHA and run the EKS image rollout.
+# Runner has no AWS credentials; corp does.
+set -euo pipefail
+
+REMOTE="${CORP_SSH:-daniel@corp.private.drenlia.com}"
+DEST="${CORP_REMOTE_DIR:-/data/server-setup/terraform/easy-kanban}"
+SHA="${GITHUB_SHA:?GITHUB_SHA is required}"
+
+echo "EKS deploy ${SHA} → ${REMOTE}:${DEST}"
+
+ssh -o BatchMode=yes "$REMOTE" bash -s <<EOF
+set -euo pipefail
+cd ${DEST}
+git fetch origin
+git reset --hard ${SHA}
+export GITHUB_SHA=${SHA}
+export IMAGE_SHA=${SHA}
+bash scripts/deploy-eks.sh
+EOF
+
+echo "EKS deploy complete (${SHA})"

--- a/scripts/deploy-eks-via-ssh.sh
+++ b/scripts/deploy-eks-via-ssh.sh
@@ -12,7 +12,9 @@ echo "EKS deploy ${SHA} → ${REMOTE}:${DEST}"
 ssh -o BatchMode=yes "$REMOTE" bash -s <<EOF
 set -euo pipefail
 cd ${DEST}
-git fetch origin
+# Non-interactive: no GitHub SSH key on this hop (same as scripts/deploy-demo.sh)
+git remote set-url origin https://github.com/drenlia-inc/agila.git
+git fetch origin ${SHA}
 git reset --hard ${SHA}
 export GITHUB_SHA=${SHA}
 export IMAGE_SHA=${SHA}

--- a/scripts/deploy-eks.sh
+++ b/scripts/deploy-eks.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Image-only EKS rollout for the tenant platform (ns agila, deployment easy-kanban).
+# Run on corp.private (IAM + kubectl --context drenlia-eks). Does not apply ConfigMaps or Secrets.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+ECR_REGISTRY="${ECR_REGISTRY:-336644450495.dkr.ecr.ca-central-1.amazonaws.com}"
+IMAGE_NAME="${IMAGE_NAME:-easy-kanban}"
+IMAGE="${IMAGE:-${ECR_REGISTRY}/${IMAGE_NAME}}"
+IMAGE_SHA="${IMAGE_SHA:-${GITHUB_SHA:?GITHUB_SHA or IMAGE_SHA is required}}"
+AWS_REGION="${AWS_REGION:-ca-central-1}"
+KUBECTL_CONTEXT="${KUBECTL_CONTEXT:-drenlia-eks}"
+NAMESPACE="${NAMESPACE:-agila}"
+DEPLOYMENT="${DEPLOYMENT:-easy-kanban}"
+CONTAINER="${CONTAINER:-easy-kanban}"
+
+cd "$PROJECT_ROOT"
+GIT_COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo "${IMAGE_SHA:0:7}")"
+GIT_BRANCH="$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+BUILD_TIME="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+echo "EKS image rollout ${IMAGE}:${IMAGE_SHA} → ${NAMESPACE}/${DEPLOYMENT}"
+
+bash "${PROJECT_ROOT}/scripts/prepare-prev-assets.sh" "${IMAGE}:latest" || true
+# Also try the local latest tag used on corp
+if docker image inspect easy-kanban:latest >/dev/null 2>&1; then
+  bash "${PROJECT_ROOT}/scripts/prepare-prev-assets.sh" easy-kanban:latest || true
+fi
+
+docker build -f Dockerfile.prod \
+  -t "${IMAGE}:${IMAGE_SHA}" \
+  -t "${IMAGE}:latest" \
+  -t easy-kanban:latest \
+  --build-arg GIT_COMMIT="${GIT_COMMIT}" \
+  --build-arg GIT_BRANCH="${GIT_BRANCH}" \
+  --build-arg BUILD_TIME="${BUILD_TIME}" \
+  --build-arg MULTI_TENANT=true \
+  .
+
+aws ecr get-login-password --region "$AWS_REGION" \
+  | docker login --username AWS --password-stdin "$ECR_REGISTRY"
+docker push "${IMAGE}:${IMAGE_SHA}"
+docker push "${IMAGE}:latest"
+
+echo "Setting image ${IMAGE}:${IMAGE_SHA} (ConfigMaps/Secrets untouched)"
+kubectl --context "$KUBECTL_CONTEXT" -n "$NAMESPACE" set image "deployment/${DEPLOYMENT}" \
+  "${CONTAINER}=${IMAGE}:${IMAGE_SHA}"
+kubectl --context "$KUBECTL_CONTEXT" -n "$NAMESPACE" rollout status "deployment/${DEPLOYMENT}" \
+  --timeout=180s
+
+echo "EKS rollout complete: ${IMAGE}:${IMAGE_SHA}"

--- a/scripts/deploy-k8s-onprem-via-ssh.sh
+++ b/scripts/deploy-k8s-onprem-via-ssh.sh
@@ -12,7 +12,9 @@ echo "On-prem deploy ${SHA} → ${REMOTE}:${DEST}"
 ssh -o BatchMode=yes "$REMOTE" bash -s <<EOF
 set -euo pipefail
 cd ${DEST}
-git fetch origin
+# Non-interactive: no GitHub SSH key on this hop (same as scripts/deploy-demo.sh)
+git remote set-url origin https://github.com/drenlia-inc/agila.git
+git fetch origin ${SHA}
 git reset --hard ${SHA}
 export GITHUB_SHA=${SHA}
 export IMAGE_SHA=${SHA}

--- a/scripts/deploy-k8s-onprem-via-ssh.sh
+++ b/scripts/deploy-k8s-onprem-via-ssh.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# drenlia-runner: reset the k8s.private checkout to GITHUB_SHA and run the image rollout.
+# See docs/DEPLOYMENT.md in agila-admin (agila section).
+set -euo pipefail
+
+REMOTE="${K8S_SSH:-daniel@k8s.private.drenlia.com}"
+DEST="${K8S_REMOTE_DIR:-/home/daniel/easy-kanban}"
+SHA="${GITHUB_SHA:?GITHUB_SHA is required}"
+
+echo "On-prem deploy ${SHA} → ${REMOTE}:${DEST}"
+
+ssh -o BatchMode=yes "$REMOTE" bash -s <<EOF
+set -euo pipefail
+cd ${DEST}
+git fetch origin
+git reset --hard ${SHA}
+export GITHUB_SHA=${SHA}
+export IMAGE_SHA=${SHA}
+bash scripts/deploy-k8s-onprem.sh
+EOF
+
+echo "On-prem deploy complete (${SHA})"

--- a/scripts/deploy-k8s-onprem.sh
+++ b/scripts/deploy-k8s-onprem.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Image-only rollout for on-prem k8s (easy-kanban-pg).
+# Run on k8s.private after the checkout is reset to GITHUB_SHA.
+# Does not apply ConfigMaps or Secrets.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+NAMESPACE="${NAMESPACE:-easy-kanban-pg}"
+DEPLOYMENT="${DEPLOYMENT:-easy-kanban}"
+CONTAINER="${CONTAINER:-easy-kanban}"
+# Nodes pull this registry IP (see k8s/app-deployment-pg.yaml)
+PULL_REGISTRY="${PULL_REGISTRY:-10.110.240.233:5000}"
+IMAGE_NAME="${IMAGE_NAME:-easy-kanban}"
+IMAGE_SHA="${IMAGE_SHA:-${GITHUB_SHA:?GITHUB_SHA or IMAGE_SHA is required}}"
+PULL_IMAGE="${PULL_REGISTRY}/${IMAGE_NAME}:${IMAGE_SHA}"
+
+cd "$PROJECT_ROOT"
+echo "On-prem image rollout ${IMAGE_SHA} → ${NAMESPACE}/${DEPLOYMENT}"
+
+export IMAGE_SHA
+export GITHUB_SHA="${GITHUB_SHA:-$IMAGE_SHA}"
+bash "${PROJECT_ROOT}/k8s/build-and-push-to-registry-app.sh"
+
+echo "Setting image ${PULL_IMAGE} (ConfigMaps/Secrets untouched)"
+kubectl -n "$NAMESPACE" set image "deployment/${DEPLOYMENT}" \
+  "${CONTAINER}=${PULL_IMAGE}"
+kubectl -n "$NAMESPACE" rollout status "deployment/${DEPLOYMENT}" --timeout=180s
+
+echo "On-prem rollout complete: ${PULL_IMAGE}"


### PR DESCRIPTION
## Summary
- On-prem *Deploy k8s* succeeded on \`staging\` (HTTPS fetch fix included).
- Merge to \`main\` starts *Deploy EKS* (corp → ECR → ns \`agila\`) and the existing *Deploy demo* job.
- Image only; ConfigMaps and Secrets are not applied.

## Test plan
- [ ] *Deploy EKS* completes \`rollout status\` on \`drenlia-eks\` / \`agila\` / \`easy-kanban\`
- [ ] *Deploy demo* still succeeds on web01
- [ ] Tenant ConfigMaps/Secrets unchanged


Made with [Cursor](https://cursor.com)