### PR TITLE
Tidy Docker leftovers on the build host before rollout

### DIFF
--- a/k8s/build-and-push-to-registry-app.sh
+++ b/k8s/build-and-push-to-registry-app.sh
@@ -82,6 +82,10 @@ echo -e "${YELLOW}📦 Preparing previous hashed assets (N-1)...${NC}"
 "${PROJECT_ROOT}/scripts/prepare-prev-assets.sh" easy-kanban:latest || true
 echo ""
 
+echo -e "${YELLOW}🧹 Tidying old easy-kanban SHA tags and dangling images...${NC}"
+"${PROJECT_ROOT}/scripts/docker-tidy-before-build.sh" || true
+echo ""
+
 # Build the image
 echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
 echo -e "${BLUE}🔨 Building Docker image...${NC}"

--- a/scripts/deploy-eks.sh
+++ b/scripts/deploy-eks.sh
@@ -29,6 +29,8 @@ if docker image inspect easy-kanban:latest >/dev/null 2>&1; then
   bash "${PROJECT_ROOT}/scripts/prepare-prev-assets.sh" easy-kanban:latest || true
 fi
 
+bash "${PROJECT_ROOT}/scripts/docker-tidy-before-build.sh" || true
+
 docker build -f Dockerfile.prod \
   -t "${IMAGE}:${IMAGE_SHA}" \
   -t "${IMAGE}:latest" \

--- a/scripts/docker-tidy-before-build.sh
+++ b/scripts/docker-tidy-before-build.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Free disk on the build host (k8s.private / corp) without dropping the
+# previous :latest (layer cache + N-1 extract already ran).
+#
+# Removes: stopped containers, dangling images, unused build cache,
+# and easy-kanban tags that are not :latest (old GITHUB_SHA pins).
+# Does not: prune volumes, or delete unrelated images (e.g. agila-admin on corp).
+set -euo pipefail
+
+echo "🧹 Docker tidy (keep easy-kanban:latest for cache)"
+
+docker container prune -f >/dev/null || true
+docker image prune -f >/dev/null || true
+
+# Untag old SHA pins. Layers stay if :latest still points at them.
+while IFS= read -r ref; do
+  [ -n "$ref" ] || continue
+  case "$ref" in
+    *:latest) continue ;;
+    *':<none>') continue ;;
+  esac
+  echo "   rmi $ref"
+  docker rmi "$ref" >/dev/null 2>&1 || true
+done < <(docker images --format '{{.Repository}}:{{.Tag}}' | grep -E '(^|/)easy-kanban:' || true)
+
+# Unused BuildKit cache only (not --all — that wipes cache for this build).
+docker builder prune -f >/dev/null 2>&1 || true
+
+echo "   $(docker system df 2>/dev/null | tail -n +1 || true)"
+echo "✅ Docker tidy done"


### PR DESCRIPTION
## Summary
- Before each on-prem / EKS image build, prune stopped containers, dangling images, unused BuildKit cache, and old `easy-kanban:<SHA>` tags.
- Runs after N-1 asset extract so `:latest` stays on disk for cache. Does not prune volumes or wipe unrelated images (e.g. admin on corp). Registry / ECR are unchanged.

## Test plan
- [ ] Merge to `staging` and confirm Deploy k8s logs show the tidy step, then a successful build/push/rollout.
- [ ] Confirm `easy-kanban:latest` is still present on k8s.private after tidy (needed for the next N-1 copy).

Made with [Cursor](https://cursor.com)